### PR TITLE
Phase 1: Add execution foundation (TerminalOperator, EnvironmentBuilder, SkillRegistry)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,27 @@
 {
   "name": "devos",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "DevOS Autonomous AI Operating System — Local Only",
   "main": "dist/index.js",
   "type": "commonjs",
   "scripts": {
-    "dev":    "ts-node index.ts",
-    "run":    "ts-node index.ts run",
+    "dev": "ts-node index.ts",
+    "run": "ts-node index.ts run",
     "daemon": "ts-node index.ts daemon",
     "status": "ts-node index.ts status",
-    "build":  "tsc",
-    "start":  "node dist/index.js"
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "dependencies": {
-    "axios":   "^1.13.5",
-    "dotenv":  "^17.3.1",
-    "execa":   "^9.6.1",
-    "uuid":    "^9.0.0"
+    "axios": "^1.13.5",
+    "dotenv": "^17.3.1",
+    "execa": "^8.0.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.3.0",
     "@types/uuid": "^9.0.0",
-    "ts-node":     "^10.9.2",
-    "typescript":  "^5.9.3"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/skills/registry.ts
+++ b/skills/registry.ts
@@ -1,0 +1,69 @@
+import { EnvironmentBuilder } from "./system/environmentBuilder";
+import { TerminalOperator } from "./system/terminalOperator";
+
+export interface Skill {
+  name: string;
+  description: string;
+  category: string;
+  execute(input: any): Promise<any>;
+}
+
+export class SkillRegistry {
+  private readonly skills = new Map<string, Skill>();
+
+  constructor() {
+    this.registerDefaultSkills();
+  }
+
+  public register(skill: Skill): void {
+    this.skills.set(skill.name, skill);
+  }
+
+  public get(name: string): Skill | undefined {
+    return this.skills.get(name);
+  }
+
+  public list(): Skill[] {
+    return Array.from(this.skills.values());
+  }
+
+  public findByCategory(category: string): Skill[] {
+    return this.list().filter((skill) => skill.category === category);
+  }
+
+  private registerDefaultSkills(): void {
+    const terminalOperator = new TerminalOperator();
+    const environmentBuilder = new EnvironmentBuilder(terminalOperator);
+
+    this.register({
+      name: "terminalOperator",
+      description: "Safely executes shell commands with timeout support",
+      category: "system",
+      execute: async (input: { command: string; timeout?: number; cwd?: string } | string) => {
+        if (typeof input === "string") {
+          return terminalOperator.execute(input);
+        }
+
+        return terminalOperator.execute(input.command, {
+          timeout: input.timeout,
+          cwd: input.cwd
+        });
+      }
+    });
+
+    this.register({
+      name: "environmentBuilder",
+      description: "Detects and prepares development environments",
+      category: "system",
+      execute: async (input: { dir: string; mode?: "detect" | "prepare" }) => {
+        if (input.mode === "detect") {
+          return environmentBuilder.detect(input.dir);
+        }
+
+        return environmentBuilder.prepare(input.dir);
+      }
+    });
+  }
+}
+
+export const registry = new SkillRegistry();

--- a/skills/system/environmentBuilder.ts
+++ b/skills/system/environmentBuilder.ts
@@ -1,0 +1,77 @@
+import { access } from "fs/promises";
+import path from "path";
+import { TerminalOperator } from "./terminalOperator";
+
+export type EnvironmentType = "node" | "python" | "docker" | "unknown";
+
+export class EnvironmentBuilder {
+  private readonly terminalOperator: TerminalOperator;
+
+  constructor(terminalOperator?: TerminalOperator) {
+    this.terminalOperator = terminalOperator ?? new TerminalOperator();
+  }
+
+  public async detect(dir: string): Promise<EnvironmentType> {
+    if (await this.exists(path.join(dir, "package.json"))) {
+      return "node";
+    }
+
+    if (
+      (await this.exists(path.join(dir, "requirements.txt"))) ||
+      (await this.exists(path.join(dir, "pyproject.toml")))
+    ) {
+      return "python";
+    }
+
+    if (await this.exists(path.join(dir, "Dockerfile"))) {
+      return "docker";
+    }
+
+    return "unknown";
+  }
+
+  public async prepare(
+    dir: string
+  ): Promise<{ success: boolean; type: string; output: string }> {
+    const type = await this.detect(dir);
+
+    if (type === "unknown") {
+      return {
+        success: false,
+        type,
+        output: "No supported environment files found"
+      };
+    }
+
+    const command = this.getPrepareCommand(type);
+    const result = await this.terminalOperator.execute(command, { cwd: dir });
+
+    return {
+      success: result.success,
+      type,
+      output: [result.stdout, result.stderr].filter(Boolean).join("\n").trim()
+    };
+  }
+
+  private getPrepareCommand(type: Exclude<EnvironmentType, "unknown">): string {
+    switch (type) {
+      case "node":
+        return "npm install";
+      case "python":
+        return "pip install -r requirements.txt";
+      case "docker":
+        return "docker build -t devos-app .";
+      default:
+        return "";
+    }
+  }
+
+  private async exists(filePath: string): Promise<boolean> {
+    try {
+      await access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/skills/system/terminalOperator.ts
+++ b/skills/system/terminalOperator.ts
@@ -1,0 +1,71 @@
+import { execaCommand } from "execa";
+
+export interface TerminalResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  duration: number;
+  command: string;
+}
+
+export class TerminalOperator {
+  private static readonly DEFAULT_TIMEOUT_MS = 30_000;
+
+  public async execute(
+    command: string,
+    options: { timeout?: number; cwd?: string } = {}
+  ): Promise<TerminalResult> {
+    const timeout = options.timeout ?? TerminalOperator.DEFAULT_TIMEOUT_MS;
+    const start = Date.now();
+
+    try {
+      const result = await execaCommand(command, {
+        cwd: options.cwd,
+        timeout,
+        reject: true,
+        shell: true
+      });
+
+      const duration = Date.now() - start;
+      console.log(`[TerminalOperator] ${command} completed in ${duration}ms`);
+
+      return {
+        success: true,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+        exitCode: result.exitCode ?? 0,
+        duration,
+        command
+      };
+    } catch (error: unknown) {
+      const duration = Date.now() - start;
+      const execaError = error as {
+        timedOut?: boolean;
+        shortMessage?: string;
+        stderr?: string;
+        stdout?: string;
+        exitCode?: number;
+        message?: string;
+      };
+
+      const timedOut = execaError.timedOut === true;
+      const timeoutMessage = `Command timed out after ${timeout}ms`;
+
+      console.log(
+        `[TerminalOperator] ${command} ${timedOut ? "timed out" : "failed"} in ${duration}ms`
+      );
+
+      return {
+        success: false,
+        stdout: execaError.stdout ?? "",
+        stderr: timedOut
+          ? `${timeoutMessage}${execaError.stderr ? `\n${execaError.stderr}` : ""}`
+          : execaError.stderr ?? execaError.shortMessage ?? execaError.message ?? "Unknown error",
+        exitCode: execaError.exitCode ?? (timedOut ? 124 : 1),
+        duration,
+        command
+      };
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, reusable execution foundation for running shell commands and preparing project environments. 
- Centralize skill discovery and usage with a lightweight registry so system skills can be looked up and invoked uniformly. 
- Ensure runtime compatibility by pinning `execa` to a CommonJS-compatible version and bumping package version.

### Description
- Added `skills/system/terminalOperator.ts` which exports `TerminalOperator` and `TerminalResult`; it executes commands via `execaCommand`, enforces a default 30s timeout, handles timeouts/errors gracefully, and logs execution duration. 
- Added `skills/system/environmentBuilder.ts` which exports `EnvironmentBuilder` with `detect(dir)` returning `node | python | docker | unknown` and `prepare(dir)` that runs `npm install`, `pip install -r requirements.txt`, or `docker build -t devos-app .` using `TerminalOperator`. 
- Replaced the stub with `skills/registry.ts` that defines a `Skill` interface and `SkillRegistry` class with `register`, `get`, `list`, and `findByCategory`, auto-registers `terminalOperator` and `environmentBuilder`, and exports a singleton `registry`. 
- Updated `package.json` to set `"version": "3.0.0"` and change `"execa"` to `"^8.0.1"` for CommonJS compatibility.

### Testing
- Ran `npm install` to refresh dependencies but it failed with a `403 Forbidden` from the npm registry in this environment so packages were not installed. 
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors elsewhere in the repository and missing external modules, and not due to the newly added files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7f42b4a48325811a5ddf48480c14)