### PR TITLE
Implement Phase 2 — Autonomous Builder and Self-Repair Debug Modules

### DIFF
--- a/skills/builder/projectBuilder.ts
+++ b/skills/builder/projectBuilder.ts
@@ -1,0 +1,144 @@
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { EnvironmentBuilder } from "../system/environmentBuilder";
+import { SelfRepair } from "../debug/selfRepair";
+
+export interface BuildResult {
+  success: boolean;
+  projectDir: string;
+  files: string[];
+  installOutput: string;
+  errors: string[];
+}
+
+interface ProjectFileSpec {
+  path: string;
+  content: string;
+}
+
+interface ProjectArchitecture {
+  projectName?: string;
+  files: ProjectFileSpec[];
+}
+
+interface OllamaGenerateResponse {
+  response?: string;
+}
+
+export class ProjectBuilder {
+  private readonly baseUrl: string;
+  private readonly environmentBuilder: EnvironmentBuilder;
+  private readonly selfRepair: SelfRepair;
+
+  constructor(baseUrl = "http://localhost:11434") {
+    this.baseUrl = baseUrl;
+    this.environmentBuilder = new EnvironmentBuilder();
+    this.selfRepair = new SelfRepair();
+  }
+
+  public async build(goal: string, outputDir: string): Promise<BuildResult> {
+    const errors: string[] = [];
+    const writtenFiles: string[] = [];
+
+    try {
+      const architecture = await this.selfRepair.execute(
+        async () => this.generateArchitecture(goal),
+        {
+          onFailure: async (error, attempt) =>
+            `Architecture generation failed on attempt ${attempt}: ${error.message}`
+        }
+      );
+
+      const projectDir = path.resolve(outputDir, architecture.projectName || "generated-project");
+      await mkdir(projectDir, { recursive: true });
+
+      for (const fileSpec of architecture.files) {
+        const filePath = path.resolve(projectDir, fileSpec.path);
+        const parentDir = path.dirname(filePath);
+
+        await mkdir(parentDir, { recursive: true });
+        await writeFile(filePath, fileSpec.content, "utf-8");
+        writtenFiles.push(path.relative(projectDir, filePath));
+      }
+
+      const installResult = await this.environmentBuilder.prepare(projectDir);
+      if (!installResult.success) {
+        errors.push(installResult.output || "Dependency installation failed.");
+      }
+
+      return {
+        success: errors.length === 0,
+        projectDir,
+        files: writtenFiles,
+        installOutput: installResult.output,
+        errors
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+
+      return {
+        success: false,
+        projectDir: path.resolve(outputDir),
+        files: writtenFiles,
+        installOutput: "",
+        errors
+      };
+    }
+  }
+
+  private async generateArchitecture(goal: string): Promise<ProjectArchitecture> {
+    const prompt = [
+      "You are a software scaffolding assistant.",
+      "Given a project goal, return a JSON object with this exact shape:",
+      "{\"projectName\": string, \"files\": [{\"path\": string, \"content\": string}]}",
+      "Return valid JSON only and include complete file contents.",
+      `Goal: ${goal}`
+    ].join("\n");
+
+    const response = await fetch(`${this.baseUrl}/api/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model: "llama3.2",
+        stream: false,
+        prompt
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as OllamaGenerateResponse;
+
+    if (!data.response) {
+      throw new Error("Ollama returned an empty architecture response.");
+    }
+
+    const jsonBlockMatch = data.response.match(/\{[\s\S]*\}/);
+    const candidate = jsonBlockMatch ? jsonBlockMatch[0] : data.response;
+
+    const parsed = JSON.parse(candidate) as Partial<ProjectArchitecture>;
+
+    if (!Array.isArray(parsed.files) || parsed.files.length === 0) {
+      throw new Error("Generated architecture does not include any files.");
+    }
+
+    const files = parsed.files.filter(
+      (file): file is ProjectFileSpec =>
+        typeof file?.path === "string" && typeof file?.content === "string"
+    );
+
+    if (files.length === 0) {
+      throw new Error("Generated architecture files are invalid.");
+    }
+
+    return {
+      projectName: parsed.projectName,
+      files
+    };
+  }
+}

--- a/skills/debug/logAnalyzer.ts
+++ b/skills/debug/logAnalyzer.ts
@@ -1,0 +1,109 @@
+export interface LogAnalysis {
+  errorType: "syntax" | "runtime" | "type" | "import" | "unknown";
+  message: string;
+  file?: string;
+  line?: number;
+  suggestion: string;
+}
+
+export class LogAnalyzer {
+  public analyze(log: string): LogAnalysis {
+    const normalizedLog = log ?? "";
+
+    const syntaxMatch = normalizedLog.match(
+      /SyntaxError:\s*([^\n]+)(?:\n\s*at\s+.*\(([^:()\n]+):(\d+):(\d+)\))?/i
+    );
+    if (syntaxMatch) {
+      return {
+        errorType: "syntax",
+        message: syntaxMatch[1].trim(),
+        file: syntaxMatch[2],
+        line: this.safeParseInt(syntaxMatch[3]),
+        suggestion:
+          "Review the indicated file for missing brackets, commas, or malformed syntax near the reported line."
+      };
+    }
+
+    const typeAssignMatch = normalizedLog.match(
+      /([^\n]+)\s+is not assignable to type\s+([^\n]+)/i
+    );
+    if (typeAssignMatch) {
+      return {
+        errorType: "type",
+        message: `${typeAssignMatch[1].trim()} is not assignable to type ${typeAssignMatch[2].trim()}`,
+        file: this.extractTsFile(normalizedLog),
+        line: this.extractLine(normalizedLog),
+        suggestion:
+          "Align the value and expected TypeScript type by updating interfaces, generics, or function return types."
+      };
+    }
+
+    const cannotFindModuleMatch = normalizedLog.match(
+      /(?:Error:\s*)?Cannot find module\s+'([^']+)'/i
+    );
+    if (cannotFindModuleMatch) {
+      return {
+        errorType: "import",
+        message: `Cannot find module '${cannotFindModuleMatch[1]}'`,
+        file: this.extractTsFile(normalizedLog),
+        line: this.extractLine(normalizedLog),
+        suggestion:
+          "Verify module path spelling, package installation, and tsconfig path aliases."
+      };
+    }
+
+    const typeErrorMatch = normalizedLog.match(
+      /TypeError:\s*([^\n]+)(?:\n\s*at\s+.*\(([^:()\n]+):(\d+):(\d+)\))?/i
+    );
+    if (typeErrorMatch) {
+      return {
+        errorType: "runtime",
+        message: typeErrorMatch[1].trim(),
+        file: typeErrorMatch[2],
+        line: this.safeParseInt(typeErrorMatch[3]),
+        suggestion:
+          "Check null/undefined values and object shapes before property access or method invocation."
+      };
+    }
+
+    const uncaughtMatch = normalizedLog.match(/Uncaught\s+(?:Exception|Error):\s*([^\n]+)/i);
+    if (uncaughtMatch) {
+      return {
+        errorType: "runtime",
+        message: uncaughtMatch[1].trim(),
+        file: this.extractTsFile(normalizedLog),
+        line: this.extractLine(normalizedLog),
+        suggestion:
+          "Inspect the uncaught exception source and add defensive checks or error handling around failing operations."
+      };
+    }
+
+    return {
+      errorType: "unknown",
+      message: normalizedLog.split("\n").find((line) => line.trim().length > 0) ?? "Unknown error",
+      file: this.extractTsFile(normalizedLog),
+      line: this.extractLine(normalizedLog),
+      suggestion:
+        "Collect a full stack trace and isolate the failing code path to identify the underlying issue."
+    };
+  }
+
+  private extractTsFile(log: string): string | undefined {
+    const fileMatch = log.match(/([\w./\\-]+\.(?:ts|tsx|js|mjs|cjs))/);
+    return fileMatch?.[1];
+  }
+
+  private extractLine(log: string): number | undefined {
+    const lineMatch = log.match(/\.(?:ts|tsx|js|mjs|cjs):(\d+):\d+/);
+    return this.safeParseInt(lineMatch?.[1]);
+  }
+
+  private safeParseInt(value?: string): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+}

--- a/skills/debug/rootCauseAnalyzer.ts
+++ b/skills/debug/rootCauseAnalyzer.ts
@@ -1,0 +1,98 @@
+import { LogAnalysis } from "./logAnalyzer";
+
+export interface RootCauseResult {
+  rootCause: string;
+  fix: string;
+  confidence: "high" | "medium" | "low";
+  affectedFile?: string;
+}
+
+interface OllamaResponse {
+  response?: string;
+}
+
+export class RootCauseAnalyzer {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl = "http://localhost:11434") {
+    this.baseUrl = baseUrl;
+  }
+
+  public async analyze(
+    logAnalysis: LogAnalysis,
+    stackTrace: string
+  ): Promise<RootCauseResult> {
+    const prompt = this.createPrompt(logAnalysis, stackTrace);
+
+    const response = await fetch(`${this.baseUrl}/api/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model: "llama3.2",
+        stream: false,
+        prompt
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as OllamaResponse;
+    return this.parseResult(data.response);
+  }
+
+  private createPrompt(logAnalysis: LogAnalysis, stackTrace: string): string {
+    return [
+      "You are a senior debugging assistant.",
+      "Given an error analysis and stack trace, identify root cause and a concrete fix.",
+      "Respond ONLY in JSON with keys: rootCause, fix, confidence (high|medium|low), affectedFile.",
+      "Error Analysis:",
+      JSON.stringify(logAnalysis, null, 2),
+      "Stack Trace:",
+      stackTrace,
+      "Return strict JSON only."
+    ].join("\n");
+  }
+
+  private parseResult(raw?: string): RootCauseResult {
+    if (!raw) {
+      return {
+        rootCause: "Model returned no response.",
+        fix: "Re-run with additional stack trace context.",
+        confidence: "low"
+      };
+    }
+
+    const jsonBlockMatch = raw.match(/\{[\s\S]*\}/);
+    const candidate = jsonBlockMatch ? jsonBlockMatch[0] : raw;
+
+    try {
+      const parsed = JSON.parse(candidate) as Partial<RootCauseResult>;
+      return {
+        rootCause: parsed.rootCause?.trim() || "Unable to determine exact root cause.",
+        fix: parsed.fix?.trim() || "Inspect recent code changes near the reported stack frame.",
+        confidence: this.normalizeConfidence(parsed.confidence),
+        affectedFile: parsed.affectedFile?.trim() || undefined
+      };
+    } catch {
+      return {
+        rootCause: "Failed to parse model response.",
+        fix: raw.trim(),
+        confidence: "low"
+      };
+    }
+  }
+
+  private normalizeConfidence(
+    confidence?: RootCauseResult["confidence"] | string
+  ): RootCauseResult["confidence"] {
+    if (confidence === "high" || confidence === "medium" || confidence === "low") {
+      return confidence;
+    }
+
+    return "low";
+  }
+}

--- a/skills/debug/selfRepair.ts
+++ b/skills/debug/selfRepair.ts
@@ -1,0 +1,71 @@
+export interface RepairAttempt {
+  attempt: number;
+  error: string;
+  timestamp: Date;
+}
+
+export class SelfRepair {
+  public attemptHistory: RepairAttempt[] = [];
+
+  public async execute<T>(
+    task: () => Promise<T>,
+    options?: {
+      maxRetries?: number;
+      onFailure?: (error: Error, attempt: number) => Promise<string | void>;
+    }
+  ): Promise<T> {
+    const maxRetries = options?.maxRetries ?? 5;
+    this.attemptHistory = [];
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
+      try {
+        return await task();
+      } catch (error) {
+        const normalizedError =
+          error instanceof Error ? error : new Error(typeof error === "string" ? error : "Unknown error");
+
+        lastError = normalizedError;
+        this.attemptHistory.push({
+          attempt,
+          error: normalizedError.message,
+          timestamp: new Date()
+        });
+
+        console.error(`[SelfRepair] Attempt ${attempt} failed: ${normalizedError.message}`);
+
+        if (options?.onFailure) {
+          try {
+            const note = await options.onFailure(normalizedError, attempt);
+            if (note) {
+              console.log(`[SelfRepair] onFailure note (attempt ${attempt}): ${note}`);
+            }
+          } catch (callbackError) {
+            const callbackMessage =
+              callbackError instanceof Error ? callbackError.message : String(callbackError);
+            console.error(`[SelfRepair] onFailure handler failed: ${callbackMessage}`);
+          }
+        }
+
+        if (attempt < maxRetries) {
+          await this.delay(1000);
+        }
+      }
+    }
+
+    const history = this.attemptHistory
+      .map((item) => `#${item.attempt} @ ${item.timestamp.toISOString()} - ${item.error}`)
+      .join("; ");
+
+    throw new Error(
+      `Task failed after ${maxRetries} attempts. Last error: ${lastError?.message ?? "unknown"}. Attempt history: ${history}`
+    );
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+}

--- a/skills/debug/systematicDebugger.ts
+++ b/skills/debug/systematicDebugger.ts
@@ -1,0 +1,60 @@
+import { LogAnalyzer } from "./logAnalyzer";
+import { RootCauseAnalyzer } from "./rootCauseAnalyzer";
+
+export interface DebugResult {
+  success: boolean;
+  rootCause: string;
+  fixApplied: string;
+  attempts: number;
+}
+
+export class SystematicDebugger {
+  private readonly logAnalyzer: LogAnalyzer;
+  private readonly rootCauseAnalyzer: RootCauseAnalyzer;
+
+  constructor(rootCauseAnalyzer?: RootCauseAnalyzer, logAnalyzer?: LogAnalyzer) {
+    this.rootCauseAnalyzer = rootCauseAnalyzer ?? new RootCauseAnalyzer();
+    this.logAnalyzer = logAnalyzer ?? new LogAnalyzer();
+  }
+
+  public async debug(
+    errorLog: string,
+    stackTrace: string,
+    applyFix?: (fix: string) => Promise<void>
+  ): Promise<DebugResult> {
+    console.log("[SystematicDebugger] Step 1: Capturing error context...");
+
+    console.log("[SystematicDebugger] Step 2: Running log analysis...");
+    const analysis = this.logAnalyzer.analyze(errorLog);
+    console.log("[SystematicDebugger] Log analysis result:", analysis);
+
+    console.log("[SystematicDebugger] Step 3: Requesting root cause analysis...");
+    const rootCauseResult = await this.rootCauseAnalyzer.analyze(analysis, stackTrace);
+    console.log("[SystematicDebugger] Root cause result:", rootCauseResult);
+
+    let fixApplied = rootCauseResult.fix;
+    let success = true;
+
+    if (applyFix) {
+      console.log("[SystematicDebugger] Step 4: Applying suggested fix...");
+      try {
+        await applyFix(rootCauseResult.fix);
+        console.log("[SystematicDebugger] Fix applied successfully.");
+      } catch (error) {
+        success = false;
+        const message = error instanceof Error ? error.message : String(error);
+        fixApplied = `Failed to apply fix: ${message}`;
+        console.error("[SystematicDebugger] Failed to apply fix:", message);
+      }
+    } else {
+      console.log("[SystematicDebugger] Step 4: No applyFix callback provided; returning suggestion only.");
+    }
+
+    return {
+      success,
+      rootCause: rootCauseResult.rootCause,
+      fixApplied,
+      attempts: 1
+    };
+  }
+}


### PR DESCRIPTION
### Motivation
- Deliver Phase 2 capabilities for autonomous project scaffolding and robust self-repair to enable the system to generate projects and iteratively recover from failures. 
- Provide a structured debugging toolchain that analyzes logs, uses an LLM to diagnose root causes, and optionally applies fixes programmatically.

### Description
- Added `skills/debug/logAnalyzer.ts` exporting `LogAnalyzer` and `LogAnalysis` that detect common TypeScript/Node error patterns (e.g. `SyntaxError`, `TypeError`, `Cannot find module`, `is not assignable to type`, uncaught exceptions) via regex and return actionable suggestions. 
- Added `skills/debug/rootCauseAnalyzer.ts` exporting `RootCauseAnalyzer` and `RootCauseResult` which calls an Ollama endpoint (`model: "llama3.2"`) with a structured prompt and parses the model JSON response into a typed diagnostic. 
- Added `skills/debug/systematicDebugger.ts` exporting `SystematicDebugger` and `DebugResult` to orchestrate the debug loop (capture → `LogAnalyzer` → `RootCauseAnalyzer` → optional `applyFix`) with explicit console logging. 
- Added `skills/debug/selfRepair.ts` exporting `SelfRepair` that implements a retry loop with a default of `5` attempts, 1s backoff, an optional `onFailure` callback, and persistent `attemptHistory`. 
- Added `skills/builder/projectBuilder.ts` exporting `ProjectBuilder` and `BuildResult` which uses Ollama to generate a JSON architecture, writes files to disk, invokes `EnvironmentBuilder` for dependency preparation, and uses `SelfRepair` to make architecture generation resilient.

### Testing
- Ran `npx tsc --noEmit` across the repository which failed due to pre-existing unrelated TypeScript errors in other parts of the repo (these errors are not introduced by this PR). 
- Verified the new modules compile by running `npx tsc --noEmit --esModuleInterop true skills/debug/logAnalyzer.ts skills/debug/rootCauseAnalyzer.ts skills/debug/systematicDebugger.ts skills/debug/selfRepair.ts skills/builder/projectBuilder.ts`, which completed successfully. 
- No additional automated tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac80c73be08325be41f17ebe111b8a)