### PR TITLE
Phase 3: Add CLI Metrics Dashboard and wire CLI command

### DIFF
--- a/dashboard/metrics.ts
+++ b/dashboard/metrics.ts
@@ -1,0 +1,175 @@
+import fs from "fs";
+import path from "path";
+
+interface MetricTask {
+  status?: string;
+  durationMs?: number;
+  timestamp?: string;
+  skill?: string;
+  skillName?: string;
+  skillUsed?: string;
+  skills?: string[];
+  usedSkills?: string[];
+}
+
+interface MetricError {
+  message?: string;
+}
+
+interface MetricsStore {
+  tasks?: MetricTask[];
+  errors?: MetricError[];
+  updatedAt?: string;
+}
+
+export interface DashboardStats {
+  totalTasks: number;
+  successCount: number;
+  failureCount: number;
+  successRate: string;
+  avgDurationMs: number;
+  topSkills: Array<{ name: string; count: number }>;
+  commonErrors: Array<{ message: string; count: number }>;
+  lastUpdated: string;
+}
+
+const METRICS_FILE = path.join(process.cwd(), "workspace", "logs", "metrics.json");
+
+export class MetricsDashboard {
+  private readStore(): MetricsStore {
+    try {
+      if (!fs.existsSync(METRICS_FILE)) {
+        return {};
+      }
+
+      const raw = fs.readFileSync(METRICS_FILE, "utf-8");
+      const parsed = JSON.parse(raw) as MetricsStore;
+      return parsed ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  getStats(): DashboardStats {
+    const store = this.readStore();
+    const tasks = Array.isArray(store.tasks) ? store.tasks : [];
+    const errors = Array.isArray(store.errors) ? store.errors : [];
+
+    const totalTasks = tasks.length;
+    const successCount = tasks.filter((t) => t.status === "completed" || t.status === "success").length;
+    const failureCount = tasks.filter((t) => t.status === "failed" || t.status === "failure").length;
+
+    const successRate = totalTasks === 0 ? "0.0%" : `${((successCount / totalTasks) * 100).toFixed(1)}%`;
+
+    const durationValues = tasks
+      .map((t) => (typeof t.durationMs === "number" ? t.durationMs : 0))
+      .filter((d) => Number.isFinite(d) && d >= 0);
+
+    const avgDurationMs =
+      durationValues.length === 0
+        ? 0
+        : Math.round(durationValues.reduce((sum, d) => sum + d, 0) / durationValues.length);
+
+    const skillCounts = new Map<string, number>();
+    for (const task of tasks) {
+      const candidates: string[] = [];
+
+      if (typeof task.skill === "string") candidates.push(task.skill);
+      if (typeof task.skillName === "string") candidates.push(task.skillName);
+      if (typeof task.skillUsed === "string") candidates.push(task.skillUsed);
+      if (Array.isArray(task.skills)) candidates.push(...task.skills.filter((s): s is string => typeof s === "string"));
+      if (Array.isArray(task.usedSkills)) {
+        candidates.push(...task.usedSkills.filter((s): s is string => typeof s === "string"));
+      }
+
+      for (const name of candidates.map((s) => s.trim()).filter(Boolean)) {
+        skillCounts.set(name, (skillCounts.get(name) ?? 0) + 1);
+      }
+    }
+
+    const topSkills = [...skillCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, count]) => ({ name, count }));
+
+    const errorCounts = new Map<string, number>();
+    for (const err of errors) {
+      const message = (err.message ?? "Unknown error").trim() || "Unknown error";
+      errorCounts.set(message, (errorCounts.get(message) ?? 0) + 1);
+    }
+
+    const commonErrors = [...errorCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([message, count]) => ({ message, count }));
+
+    const taskTimestamps = tasks
+      .map((t) => t.timestamp)
+      .filter((t): t is string => typeof t === "string" && t.length > 0)
+      .sort((a, b) => b.localeCompare(a));
+
+    const lastUpdated = store.updatedAt ?? taskTimestamps[0] ?? new Date(0).toISOString();
+
+    return {
+      totalTasks,
+      successCount,
+      failureCount,
+      successRate,
+      avgDurationMs,
+      topSkills,
+      commonErrors,
+      lastUpdated,
+    };
+  }
+
+  display(): void {
+    const stats = this.getStats();
+
+    const width = 38;
+    const hr = `╠${"═".repeat(width)}╣`;
+    const top = `╔${"═".repeat(width)}╗`;
+    const bottom = `╚${"═".repeat(width)}╝`;
+
+    const line = (text = "") => {
+      const clipped = text.length > width ? text.slice(0, width - 1) + "…" : text;
+      return `║${clipped.padEnd(width)}║`;
+    };
+
+    console.log(top);
+    console.log(line("         DevOS Dashboard"));
+    console.log(hr);
+    console.log(line(` Tasks:     ${stats.totalTasks} total`));
+    console.log(line(` Success:   ${stats.successCount} (${stats.successRate})`));
+    console.log(line(` Failed:    ${stats.failureCount}`));
+    console.log(line(` Avg Time:  ${stats.avgDurationMs}ms`));
+    console.log(hr);
+    console.log(line(" Top Skills:"));
+
+    if (stats.topSkills.length === 0) {
+      console.log(line("   (none)"));
+    } else {
+      stats.topSkills.slice(0, 2).forEach((skill, index) => {
+        console.log(line(`   ${index + 1}. ${skill.name} (${skill.count})`));
+      });
+    }
+
+    console.log(hr);
+    console.log(line(" Common Errors:"));
+    if (stats.commonErrors.length === 0) {
+      console.log(line("   (none)"));
+    } else {
+      stats.commonErrors.slice(0, 2).forEach((err, index) => {
+        console.log(line(`   ${index + 1}. ${err.message} (${err.count}x)`));
+      });
+    }
+
+    console.log(hr);
+    const updated = stats.lastUpdated === new Date(0).toISOString()
+      ? "never"
+      : new Date(stats.lastUpdated).toLocaleString();
+    console.log(line(` Last Updated: ${updated}`));
+    console.log(bottom);
+  }
+}
+
+export const dashboard = new MetricsDashboard();

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import { SkillMemory }                         from "./skills/skillMemory";
 import { Observability }                       from "./core/observability";
 import { CapabilityGraph }                     from "./core/capabilityGraph";
 import { PromptEvolver }                       from "./core/promptEvolver";
+import { dashboard }                           from "./dashboard/metrics";
 
 // ── Bootstrap ─────────────────────────────────────────────────
 
@@ -411,11 +412,7 @@ async function handleCLI(): Promise<void> {
 
     // ── devos dashboard ───────────────────────────────────────
     case "dashboard": {
-      Observability.printDashboard();
-      console.log(SkillMemory.report());
-      console.log(TaskPatternMemory.report());
-      console.log(CapabilityGraph.report());
-      console.log(PromptEvolver.report());
+      dashboard.display();
       break;
     }
 


### PR DESCRIPTION
### Motivation
- Provide a readable CLI observability dashboard for Phase 3 that surfaces aggregated metrics from `workspace/logs/metrics.json` and never crashes if the file is missing or malformed.

### Description
- Added `dashboard/metrics.ts` which exports `MetricsDashboard` and `DashboardStats` and implements safe loading from `workspace/logs/metrics.json` with graceful defaults.
- Implemented `getStats()` to compute `totalTasks`, `successCount`, `failureCount`, `successRate`, `avgDurationMs`, `topSkills`, `commonErrors`, and `lastUpdated` from stored metrics.
- Implemented `display()` to render a boxed CLI view matching the requested layout and exported a singleton via `export const dashboard = new MetricsDashboard()`.
- Wired the CLI in `index.ts` to `import { dashboard } from './dashboard/metrics'` and call `dashboard.display()` in the `dashboard` command handler (replacing the previous dashboard printing call).

### Testing
- Ran `npx tsc --noEmit` to validate types; the TypeScript run failed due to pre-existing unrelated type errors and missing external dependencies elsewhere in the repository, not caused by the new dashboard module.
- No automated tests were added for this change because it is a CLI output/view feature; manual inspection of `dashboard/metrics.ts` and `index.ts` changes was performed to ensure the dashboard import and call are wired correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac841ef9508325b4aa34d0bb4c99a1)