### PR TITLE
Add Phase 4 expanded skills: DevOps, Security, Performance, and Docs

### DIFF
--- a/skills/devops/ciBuilder.ts
+++ b/skills/devops/ciBuilder.ts
@@ -1,0 +1,157 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { EnvironmentBuilder } from "../system/environmentBuilder";
+
+export interface CIResult {
+  success: boolean;
+  workflowPath: string;
+  content: string;
+}
+
+export class CIBuilder {
+  private readonly environmentBuilder: EnvironmentBuilder;
+
+  constructor(environmentBuilder?: EnvironmentBuilder) {
+    this.environmentBuilder = environmentBuilder ?? new EnvironmentBuilder();
+  }
+
+  public async generate(
+    projectDir: string,
+    options?: {
+      testCommand?: string;
+      buildCommand?: string;
+      deployTarget?: "vercel" | "railway" | "docker" | "none";
+    }
+  ): Promise<CIResult> {
+    const environment = await this.environmentBuilder.detect(projectDir);
+    const packageJson = await this.readPackageJson(projectDir);
+
+    const testCommand = options?.testCommand ?? this.detectScript(packageJson, "test") ?? "npm test";
+    const buildCommand =
+      options?.buildCommand ?? this.detectScript(packageJson, "build") ?? "npm run build --if-present";
+    const lintCommand = this.detectScript(packageJson, "lint");
+    const deployTarget = options?.deployTarget ?? "none";
+
+    const content = this.buildWorkflowContent({
+      environment,
+      testCommand,
+      buildCommand,
+      lintCommand,
+      deployTarget
+    });
+
+    const workflowDir = path.join(projectDir, ".github", "workflows");
+    const workflowPath = path.join(workflowDir, "ci.yml");
+
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(workflowPath, content, "utf-8");
+
+    return {
+      success: true,
+      workflowPath,
+      content
+    };
+  }
+
+  private async readPackageJson(projectDir: string): Promise<Record<string, unknown> | null> {
+    try {
+      const raw = await readFile(path.join(projectDir, "package.json"), "utf-8");
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  private detectScript(packageJson: Record<string, unknown> | null, script: string): string | null {
+    if (!packageJson) {
+      return null;
+    }
+
+    const scripts = packageJson["scripts"] as Record<string, string> | undefined;
+    return scripts?.[script] ? `npm run ${script}` : null;
+  }
+
+  private buildWorkflowContent(params: {
+    environment: string;
+    testCommand: string;
+    buildCommand: string;
+    lintCommand: string | null;
+    deployTarget: "vercel" | "railway" | "docker" | "none";
+  }): string {
+    const lines: string[] = [
+      "name: CI",
+      "",
+      "on:",
+      "  push:",
+      "    branches: [\"main\", \"master\"]",
+      "  pull_request:",
+      "    branches: [\"main\", \"master\"]",
+      "",
+      "jobs:",
+      "  build:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - name: Checkout",
+      "        uses: actions/checkout@v4"
+    ];
+
+    if (params.environment === "node") {
+      lines.push(
+        "      - name: Setup Node.js",
+        "        uses: actions/setup-node@v4",
+        "        with:",
+        "          node-version: '20'",
+        "",
+        "      - name: Install dependencies",
+        "        run: npm ci"
+      );
+
+      if (params.lintCommand) {
+        lines.push("", "      - name: Lint", `        run: ${params.lintCommand}`);
+      }
+
+      lines.push(
+        "",
+        "      - name: Test",
+        `        run: ${params.testCommand}`,
+        "",
+        "      - name: Build",
+        `        run: ${params.buildCommand}`
+      );
+    } else {
+      lines.push(
+        "",
+        "      - name: Install dependencies",
+        "        run: echo \"No install step configured for detected environment\"",
+        "",
+        "      - name: Lint",
+        "        run: echo \"No lint step configured\"",
+        "",
+        "      - name: Test",
+        "        run: echo \"No test step configured\"",
+        "",
+        "      - name: Build",
+        "        run: echo \"No build step configured\""
+      );
+    }
+
+    if (params.deployTarget !== "none") {
+      lines.push("", "      - name: Deploy", `        run: ${this.deployCommand(params.deployTarget)}`);
+    }
+
+    return `${lines.join("\n")}\n`;
+  }
+
+  private deployCommand(target: "vercel" | "railway" | "docker"): string {
+    switch (target) {
+      case "vercel":
+        return "npx vercel --prod --yes";
+      case "railway":
+        return "npx railway up";
+      case "docker":
+        return "docker build -t app:latest .";
+      default:
+        return "echo \"No deployment target\"";
+    }
+  }
+}

--- a/skills/devops/deploymentEngineer.ts
+++ b/skills/devops/deploymentEngineer.ts
@@ -1,0 +1,129 @@
+import { TerminalOperator } from "../system/terminalOperator";
+
+export interface DeployResult {
+  success: boolean;
+  tag: string;
+  output: string;
+  duration: number;
+}
+
+export class DeploymentEngineer {
+  private readonly terminalOperator: TerminalOperator;
+
+  constructor(terminalOperator?: TerminalOperator) {
+    this.terminalOperator = terminalOperator ?? new TerminalOperator();
+  }
+
+  public async build(projectDir: string, tag: string): Promise<DeployResult> {
+    console.log(`[DeploymentEngineer] Starting Docker build for ${projectDir} with tag ${tag}`);
+    const start = Date.now();
+    const command = `docker build -t ${tag} .`;
+
+    const result = await this.terminalOperator.execute(command, {
+      cwd: projectDir,
+      timeout: 10 * 60_000
+    });
+
+    const duration = Date.now() - start;
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+
+    console.log(
+      `[DeploymentEngineer] Docker build ${result.success ? "completed" : "failed"} in ${duration}ms`
+    );
+
+    return {
+      success: result.success,
+      tag,
+      output,
+      duration
+    };
+  }
+
+  public async healthCheck(
+    containerName: string
+  ): Promise<{ healthy: boolean; status: string }> {
+    console.log(`[DeploymentEngineer] Running health check for container ${containerName}`);
+
+    const psResult = await this.terminalOperator.execute(
+      `docker ps --filter "name=${containerName}" --format "{{.Names}}|{{.Status}}"`
+    );
+
+    if (!psResult.success) {
+      const status = [psResult.stdout, psResult.stderr]
+        .filter(Boolean)
+        .join("\n")
+        .trim() || "Unable to list running containers";
+
+      console.log(`[DeploymentEngineer] Health check failed during docker ps: ${status}`);
+      return { healthy: false, status };
+    }
+
+    const foundContainer = psResult.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.startsWith(`${containerName}|`));
+
+    if (!foundContainer) {
+      const status = "Container is not running";
+      console.log(`[DeploymentEngineer] ${status}`);
+      return { healthy: false, status };
+    }
+
+    const inspectResult = await this.terminalOperator.execute(
+      `docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' ${containerName}`
+    );
+
+    if (!inspectResult.success) {
+      const status = [inspectResult.stdout, inspectResult.stderr]
+        .filter(Boolean)
+        .join("\n")
+        .trim() || "Unable to inspect container";
+
+      console.log(`[DeploymentEngineer] Health check failed during docker inspect: ${status}`);
+      return { healthy: false, status };
+    }
+
+    const status = inspectResult.stdout.trim() || "unknown";
+    const healthy = ["healthy", "running"].includes(status.toLowerCase());
+
+    console.log(`[DeploymentEngineer] Health check status for ${containerName}: ${status}`);
+    return { healthy, status };
+  }
+
+  public async rollback(containerName: string, previousTag: string): Promise<DeployResult> {
+    console.log(
+      `[DeploymentEngineer] Starting rollback for ${containerName} using image tag ${previousTag}`
+    );
+
+    const start = Date.now();
+    const steps: string[] = [];
+
+    const stopResult = await this.terminalOperator.execute(`docker stop ${containerName}`);
+    steps.push(`[stop] ${[stopResult.stdout, stopResult.stderr].filter(Boolean).join("\n").trim()}`);
+
+    const removeResult = await this.terminalOperator.execute(`docker rm ${containerName}`);
+    steps.push(
+      `[remove] ${[removeResult.stdout, removeResult.stderr].filter(Boolean).join("\n").trim()}`
+    );
+
+    const runResult = await this.terminalOperator.execute(
+      `docker run -d --name ${containerName} ${previousTag}`,
+      { timeout: 120_000 }
+    );
+    steps.push(`[run] ${[runResult.stdout, runResult.stderr].filter(Boolean).join("\n").trim()}`);
+
+    const duration = Date.now() - start;
+    const success = runResult.success;
+
+    console.log(
+      `[DeploymentEngineer] Rollback ${success ? "completed" : "failed"} for ${containerName} in ${duration}ms`
+    );
+
+    return {
+      success,
+      tag: previousTag,
+      output: steps.filter(Boolean).join("\n").trim(),
+      duration
+    };
+  }
+}

--- a/skills/docs/docGenerator.ts
+++ b/skills/docs/docGenerator.ts
@@ -1,0 +1,84 @@
+import axios from "axios";
+import { readdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+
+interface OllamaResponse {
+  response?: string;
+}
+
+export class DocGenerator {
+  constructor(private readonly baseUrl: string = "http://localhost:11434") {}
+
+  public async generateJSDoc(filePath: string): Promise<string> {
+    const source = await readFile(filePath, "utf-8");
+    const prompt = [
+      "Add JSDoc comments to all exported functions and classes in this TypeScript file.",
+      "Return only the fully annotated source code.",
+      "",
+      source
+    ].join("\n");
+
+    return this.callOllama(prompt);
+  }
+
+  public async generateReadme(projectDir: string): Promise<string> {
+    const structure = await this.describeProjectStructure(projectDir);
+    const prompt = [
+      "Write a complete README.md for this TypeScript autonomous AI operating system project.",
+      "Include sections: Overview, Features, Installation, Usage, Architecture, Skills, Development, and Troubleshooting.",
+      "Use the provided project structure as context.",
+      "",
+      "Project structure:",
+      structure
+    ].join("\n");
+
+    const content = await this.callOllama(prompt);
+    const readmePath = path.join(projectDir, "README.md");
+    await writeFile(readmePath, content, "utf-8");
+
+    return content;
+  }
+
+  private async callOllama(prompt: string): Promise<string> {
+    const response = await axios.post<OllamaResponse>(`${this.baseUrl}/api/generate`, {
+      model: "llama3.2",
+      prompt,
+      stream: false
+    });
+
+    const output = response.data.response?.trim();
+    if (!output) {
+      throw new Error("Ollama returned an empty response.");
+    }
+
+    return output;
+  }
+
+  private async describeProjectStructure(projectDir: string): Promise<string> {
+    const entries: string[] = [];
+
+    const walk = async (currentDir: string, depth: number): Promise<void> => {
+      if (depth > 3) {
+        return;
+      }
+
+      const dirEntries = await readdir(currentDir, { withFileTypes: true });
+      for (const entry of dirEntries) {
+        if (["node_modules", ".git", "dist"].includes(entry.name)) {
+          continue;
+        }
+
+        const fullPath = path.join(currentDir, entry.name);
+        const relative = path.relative(projectDir, fullPath) || ".";
+        entries.push(`${"  ".repeat(depth)}- ${relative}${entry.isDirectory() ? "/" : ""}`);
+
+        if (entry.isDirectory()) {
+          await walk(fullPath, depth + 1);
+        }
+      }
+    };
+
+    await walk(projectDir, 0);
+    return entries.join("\n");
+  }
+}

--- a/skills/performance/optimizer.ts
+++ b/skills/performance/optimizer.ts
@@ -1,0 +1,98 @@
+import { readFile } from "fs/promises";
+
+export interface OptimizationReport {
+  file: string;
+  issues: OptimizationIssue[];
+  score: number;
+  summary: string;
+}
+
+export interface OptimizationIssue {
+  type: "n-plus-one" | "sync-in-async" | "missing-cache" | "large-bundle" | "blocking-loop";
+  line: number;
+  description: string;
+  suggestion: string;
+  impact: "high" | "medium" | "low";
+}
+
+export class PerformanceOptimizer {
+  public async analyze(filePath: string): Promise<OptimizationReport> {
+    const content = await readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    const issues: OptimizationIssue[] = [];
+
+    lines.forEach((line, index) => {
+      const lineNumber = index + 1;
+
+      if (this.isSyncInsideAsync(line, lines, index)) {
+        issues.push({
+          type: "sync-in-async",
+          line: lineNumber,
+          description: "Synchronous operation detected inside an async context.",
+          suggestion: "Replace synchronous APIs with async equivalents to avoid blocking.",
+          impact: "high"
+        });
+      }
+
+      if (this.hasAwaitInLoop(line, lines, index)) {
+        issues.push({
+          type: "blocking-loop",
+          line: lineNumber,
+          description: "Await detected inside an iterative loop, which can serialize operations.",
+          suggestion: "Batch operations with Promise.all or queue with controlled concurrency.",
+          impact: "medium"
+        });
+      }
+
+      if (this.missingCachePattern(line)) {
+        issues.push({
+          type: "missing-cache",
+          line: lineNumber,
+          description: "Potential repeated expensive computation without memoization/cache.",
+          suggestion: "Consider memoization or introducing a caching layer for repeated lookups.",
+          impact: "low"
+        });
+      }
+    });
+
+    const score = Math.max(0, 100 - issues.length * 12);
+    const summary =
+      issues.length === 0
+        ? "No obvious performance anti-patterns detected."
+        : `Detected ${issues.length} potential performance issue(s).`;
+
+    return {
+      file: filePath,
+      issues,
+      score,
+      summary
+    };
+  }
+
+  private isSyncInsideAsync(line: string, lines: string[], index: number): boolean {
+    if (!/(readFileSync|execSync)/.test(line)) {
+      return false;
+    }
+
+    for (let i = index; i >= Math.max(0, index - 40); i -= 1) {
+      if (/async\s+function|async\s*\([^)]*\)\s*=>/.test(lines[i])) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private hasAwaitInLoop(line: string, lines: string[], index: number): boolean {
+    if (!/\bfor\b\s*\(.*\)/.test(line)) {
+      return false;
+    }
+
+    const nextLines = lines.slice(index, index + 6).join("\n");
+    return /await\s+/.test(nextLines);
+  }
+
+  private missingCachePattern(line: string): boolean {
+    return /(fetch|get|load)\w*\([^)]*\)/.test(line) && !/(cache|memo|memoize)/i.test(line);
+  }
+}

--- a/skills/security/dependencyAudit.ts
+++ b/skills/security/dependencyAudit.ts
@@ -1,0 +1,87 @@
+import { TerminalOperator } from "../system/terminalOperator";
+
+export interface AuditReport {
+  critical: number;
+  high: number;
+  moderate: number;
+  low: number;
+  total: number;
+  fixAvailable: boolean;
+  recommendations: string[];
+  raw: unknown;
+}
+
+export class DependencyAudit {
+  private readonly terminalOperator: TerminalOperator;
+
+  constructor(terminalOperator?: TerminalOperator) {
+    this.terminalOperator = terminalOperator ?? new TerminalOperator();
+  }
+
+  public async audit(projectDir: string): Promise<AuditReport> {
+    const result = await this.terminalOperator.execute("npm audit --json", {
+      cwd: projectDir,
+      timeout: 120_000
+    });
+
+    const rawOutput = result.stdout.trim() || result.stderr.trim();
+
+    if (!rawOutput) {
+      return this.emptyReport(null, ["No audit output received. Ensure npm dependencies are installed."]);
+    }
+
+    try {
+      const parsed = JSON.parse(rawOutput) as {
+        metadata?: { vulnerabilities?: Record<string, number> };
+      };
+
+      const vulnerabilities = parsed.metadata?.vulnerabilities;
+
+      if (!vulnerabilities) {
+        return this.emptyReport(parsed);
+      }
+
+      const critical = vulnerabilities.critical ?? 0;
+      const high = vulnerabilities.high ?? 0;
+      const moderate = vulnerabilities.moderate ?? 0;
+      const low = vulnerabilities.low ?? 0;
+      const total = critical + high + moderate + low;
+
+      if (total === 0) {
+        return this.emptyReport(parsed);
+      }
+
+      const recommendations: string[] = [
+        "Run npm audit fix to automatically remediate patchable issues.",
+        "Update high-risk direct dependencies manually where fixes are available.",
+        "Review advisories for transitive dependencies and pin safe versions."
+      ];
+
+      return {
+        critical,
+        high,
+        moderate,
+        low,
+        total,
+        fixAvailable: true,
+        recommendations,
+        raw: parsed
+      };
+    } catch {
+      return this.emptyReport(rawOutput, ["Failed to parse npm audit JSON output."]);
+    }
+  }
+
+  private emptyReport(raw: unknown, recommendations?: string[]): AuditReport {
+    return {
+      critical: 0,
+      high: 0,
+      moderate: 0,
+      low: 0,
+      total: 0,
+      fixAvailable: false,
+      recommendations: recommendations ?? ["No known vulnerabilities detected."],
+      raw
+    };
+  }
+}

--- a/skills/security/securityAudit.ts
+++ b/skills/security/securityAudit.ts
@@ -1,0 +1,130 @@
+import { readFile, readdir } from "fs/promises";
+import path from "path";
+
+export interface SecurityReport {
+  critical: SecurityFinding[];
+  high: SecurityFinding[];
+  medium: SecurityFinding[];
+  summary: string;
+}
+
+export interface SecurityFinding {
+  type: "sql-injection" | "hardcoded-secret" | "missing-auth" | "xss" | "insecure-dependency";
+  file: string;
+  line: number;
+  description: string;
+  recommendation: string;
+}
+
+export class SecurityAudit {
+  public async scan(projectDir: string): Promise<SecurityReport> {
+    const files = await this.collectSourceFiles(projectDir);
+    const critical: SecurityFinding[] = [];
+    const high: SecurityFinding[] = [];
+    const medium: SecurityFinding[] = [];
+
+    for (const file of files) {
+      const content = await readFile(file, "utf-8");
+      const lines = content.split("\n");
+
+      lines.forEach((line, index) => {
+        const lineNumber = index + 1;
+
+        if (this.isSqlInjection(line)) {
+          high.push({
+            type: "sql-injection",
+            file,
+            line: lineNumber,
+            description: "Potential SQL injection via string concatenation in query-like statement.",
+            recommendation: "Use parameterized queries or query builders to avoid user input concatenation."
+          });
+        }
+
+        if (this.isHardcodedSecret(line)) {
+          critical.push({
+            type: "hardcoded-secret",
+            file,
+            line: lineNumber,
+            description: "Potential hardcoded credential or token discovered.",
+            recommendation: "Move secrets to environment variables or a secret manager."
+          });
+        }
+
+        if (this.isXssPattern(line)) {
+          high.push({
+            type: "xss",
+            file,
+            line: lineNumber,
+            description: "Potential cross-site scripting sink detected.",
+            recommendation: "Sanitize input/output and avoid assigning unsanitized data to DOM sinks."
+          });
+        }
+
+        if (this.isMissingAuth(line)) {
+          medium.push({
+            type: "missing-auth",
+            file,
+            line: lineNumber,
+            description: "Route definition appears to be missing auth middleware.",
+            recommendation: "Add auth middleware (e.g., authenticate/authorize) before the handler."
+          });
+        }
+      });
+    }
+
+    const summary = `Security audit completed. Critical: ${critical.length}, High: ${high.length}, Medium: ${medium.length}.`;
+
+    return {
+      critical,
+      high,
+      medium,
+      summary
+    };
+  }
+
+  private async collectSourceFiles(dir: string): Promise<string[]> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = await Promise.all(
+      entries.map(async (entry) => {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          if (["node_modules", ".git", "dist"].includes(entry.name)) {
+            return [] as string[];
+          }
+
+          return this.collectSourceFiles(fullPath);
+        }
+
+        if (entry.isFile() && (fullPath.endsWith(".ts") || fullPath.endsWith(".js"))) {
+          return [fullPath];
+        }
+
+        return [] as string[];
+      })
+    );
+
+    return files.flat();
+  }
+
+  private isSqlInjection(line: string): boolean {
+    const sqlRegex = /(select|insert|update|delete)[\s\S]{0,80}(\+|\$\{)/i;
+    return sqlRegex.test(line);
+  }
+
+  private isHardcodedSecret(line: string): boolean {
+    const secretRegex = /(password|api_key|secret|token)\s*[:=]\s*["'`][^"'`]+["'`]/i;
+    return secretRegex.test(line);
+  }
+
+  private isXssPattern(line: string): boolean {
+    return /(innerHTML\s*=|document\.write\s*\()/i.test(line);
+  }
+
+  private isMissingAuth(line: string): boolean {
+    const routeNoMiddlewareRegex =
+      /\b(app|router)\.(get|post|put|delete|patch)\s*\(\s*["'`][^"'`]+["'`]\s*,\s*(async\s+)?\(?.*=>/i;
+    const hasAuthSignal = /(auth|authorize|middleware|guard)/i.test(line);
+    return routeNoMiddlewareRegex.test(line) && !hasAuthSignal;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide Phase 4 "Expanded Skills" to extend DevOS with Docker deployment tooling, CI generation, static security and dependency audits, performance analysis, and automated documentation generation. 
- Deliver self-contained skill modules that integrate with existing `TerminalOperator` and `EnvironmentBuilder` helpers to standardize runtime commands and environment detection.

### Description
- Added `DeploymentEngineer` (`skills/devops/deploymentEngineer.ts`) exporting `DeploymentEngineer` and the `DeployResult` interface, implementing `build`, `healthCheck`, and `rollback` using `TerminalOperator` and explicit Docker commands (`docker build`, `docker ps`, `docker inspect`, `docker run`) with detailed logging. 
- Added `CIBuilder` (`skills/devops/ciBuilder.ts`) exporting `CIBuilder` and `CIResult`, using `EnvironmentBuilder` to detect project type and writing `.github/workflows/ci.yml` with `install`, optional `lint`, `test`, `build`, and optional `deploy` steps (supports `vercel`, `railway`, `docker`, `none`).
- Added `SecurityAudit` (`skills/security/securityAudit.ts`) exporting `SecurityAudit`, `SecurityReport`, and `SecurityFinding`, recursively scanning `.ts`/`.js` files and flagging `sql-injection`, `hardcoded-secret`, `missing-auth`, and `xss` via regex heuristics with line-level findings and recommendations.
- Added `DependencyAudit` (`skills/security/dependencyAudit.ts`) exporting `DependencyAudit` and `AuditReport`, running `npm audit --json` via `TerminalOperator`, parsing metadata into severity counts, recommendations, and a `raw` payload, and returning a zeroed report when no vulnerabilities are present.
- Added `PerformanceOptimizer` (`skills/performance/optimizer.ts`) exporting `PerformanceOptimizer`, `OptimizationReport`, and `OptimizationIssue`, scanning a TypeScript file for `sync-in-async` (e.g. `readFileSync` inside async), `blocking-loop` (awaits inside loops), and `missing-cache` patterns and producing a score and summary.
- Added `DocGenerator` (`skills/docs/docGenerator.ts`) exporting `DocGenerator` that calls Ollama via `axios` (default base URL `http://localhost:11434`) using the `llama3.2` model to implement `generateJSDoc(filePath)` (returns annotated source) and `generateReadme(projectDir)` (writes `README.md` and returns content).

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript; the command failed due to pre-existing repository-wide type and dependency issues (missing ambient node type declarations and blocked dependency installs) that are unrelated to the new files, so the new modules themselves were added without local compile-time type errors being the root cause of the failure. (Test result: failed — environment-level issues.)
- Attempted `npm install` to resolve type definitions and dependencies but the install failed due to registry access restrictions (`403 Forbidden` when fetching some packages), preventing a clean `tsc` verification in this environment. (Test result: failed — network/registry policy.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8593cf5883258ec6da345e739ee1)