### PR TITLE
Use runtime OS shell selection and sandbox cwd for command execution

### DIFF
--- a/executor/actions/shellActions.ts
+++ b/executor/actions/shellActions.ts
@@ -9,7 +9,10 @@
 // shellActions.ts — DevOS Shell Action Executor
 // ============================================================
 
+import fs from "fs";
+import path from "path";
 import { execa } from "execa";
+import { getRuntimeShell } from "../os-adapter";
 
 const BLOCKED_PATTERNS = [
   "rm -rf /",
@@ -43,9 +46,15 @@ export async function executeShellAction(action: any, workspace: string): Promis
 
   console.log(`[ShellActions] Executing: ${command}`);
 
+  const { shell, flag } = getRuntimeShell();
+  const sandboxCwd = path.join(workspace, "sandbox");
+  const cwd = path.basename(workspace) === "sandbox"
+    ? workspace
+    : (fs.existsSync(sandboxCwd) ? sandboxCwd : workspace);
+
   try {
-    const result = await execa("bash", ["-c", command], {
-      cwd: workspace,
+    const result = await execa(shell, [flag, command], {
+      cwd,
       timeout: 30000,
       reject: false,
     });

--- a/executor/executor.ts
+++ b/executor/executor.ts
@@ -76,7 +76,8 @@ export class Executor {
         case "terminal.run": {
           const result: TerminalResult = await runTerminal(
             action.command,
-            action.timeoutMs
+            action.timeoutMs,
+            workspace
           );
 
           return {

--- a/executor/os-adapter.ts
+++ b/executor/os-adapter.ts
@@ -7,6 +7,11 @@
 
 import os from "os";
 
+export interface RuntimeShell {
+  shell: string;
+  flag: string;
+}
+
 // ─────────────────────────────────────────────
 // PLATFORM
 // ─────────────────────────────────────────────
@@ -18,6 +23,14 @@ export function detectPlatform(): Platform {
 }
 
 export const CURRENT_PLATFORM: Platform = detectPlatform();
+
+export function getRuntimeShell(): RuntimeShell {
+  const isWindows = os.platform() === "win32";
+  return {
+    shell: isWindows ? "cmd.exe" : "/bin/bash",
+    flag: isWindows ? "/c" : "-c",
+  };
+}
 
 // ─────────────────────────────────────────────
 // ADAPT RESULT TYPE

--- a/executor/terminal.ts
+++ b/executor/terminal.ts
@@ -5,7 +5,10 @@
 // of this software is strictly prohibited.
 // ============================================================
 
+import fs from "fs";
+import path from "path";
 import { spawn } from "child_process";
+import { getRuntimeShell } from "./os-adapter";
 
 export interface TerminalResult {
   success: boolean;
@@ -28,7 +31,8 @@ function isBlocked(command: string): boolean {
 
 export async function runTerminal(
   command: string,
-  timeoutMs = 20000
+  timeoutMs = 20000,
+  workspace?: string
 ): Promise<TerminalResult> {
   if (isBlocked(command)) {
     return {
@@ -43,8 +47,17 @@ export async function runTerminal(
   return new Promise((resolve) => {
     const start = Date.now();
 
+    const { shell } = getRuntimeShell();
+    const sandboxCwd = workspace ? path.join(workspace, "sandbox") : undefined;
+    const cwd = workspace
+      ? (path.basename(workspace) === "sandbox"
+        ? workspace
+        : (sandboxCwd && fs.existsSync(sandboxCwd) ? sandboxCwd : workspace))
+      : undefined;
+
     const child = spawn(command, {
-      shell: true,
+      shell,
+      cwd,
     });
 
     let stdout = "";


### PR DESCRIPTION
### Motivation
- Fix Windows compatibility where commands were hardcoded to run via `/bin/bash` which is not present on `win32` systems. 
- Ensure shell commands execute from the intended sandbox workspace so commands like `node server.js` run in the directory where files are written. 

### Description
- Added `getRuntimeShell()` in `executor/os-adapter.ts` to pick `cmd.exe /c` on Windows and `/bin/bash -c` on Unix at runtime. 
- Replaced hardcoded `bash -c` in `executor/actions/shellActions.ts` with the runtime shell/flag and prefer `<workspace>/sandbox` as the command `cwd` when that folder exists. 
- Updated `executor/terminal.ts` to use the runtime shell for `child_process.spawn` and to resolve `cwd` to the sandbox when appropriate, and extended `runTerminal()` to accept a `workspace` parameter. 
- Updated `executor/executor.ts` to pass the current `workspace` into `runTerminal()` so terminal actions inherit the correct working directory. 

### Testing
- Ran `npx tsc --noEmit` which reported many pre-existing, project-wide TypeScript errors not introduced by these executor changes, preventing a clean full-project typecheck. 
- Attempted `npm install` to restore dependencies for full type checking, but the install failed in this environment with a `403 Forbidden` for `@vitest/ui`, preventing dependency restoration and further verification. 
- Focused changes to executor files only and validated the modified files to use runtime shell selection and sandbox `cwd` logic; no executor-specific runtime errors were observed during edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8e8bcd808325b1354e54d909d053)