### PR TITLE
Add Mistral AI provider (rebased from #31 by @Genmin)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,10 @@ OPENAI_API_KEY=
 # Get key: https://console.groq.com/keys
 GROQ_API_KEY=
 
+# Mistral AI — Mistral Large/Small and Codestral models
+# Get key: https://console.mistral.ai/api-keys
+MISTRAL_API_KEY=
+
 # ElevenLabs — high-quality text-to-speech (voice layer)
 # Get key: https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=

--- a/api/server.ts
+++ b/api/server.ts
@@ -1883,6 +1883,7 @@ export function createApiServer(): Express {
       { id: 'groq',       label: 'Groq',           subtitle: 'Free tier · llama3.3:70b · blazing fast',  url: 'https://console.groq.com',                       models: ['llama-3.3-70b-versatile', 'llama-3.1-70b-versatile', 'mixtral-8x7b-32768'] },
       { id: 'openrouter', label: 'OpenRouter',      subtitle: 'Access 200+ models · pay per use',           url: 'https://openrouter.ai/keys',                     models: ['meta-llama/llama-3.3-70b-instruct', 'anthropic/claude-3.5-sonnet', 'openai/gpt-4o'] },
       { id: 'gemini',     label: 'Gemini',          subtitle: 'Free tier available · fast',                 url: 'https://aistudio.google.com/app/apikey',         models: ['gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-2.0-flash-exp'] },
+      { id: 'mistral',    label: 'Mistral AI',      subtitle: 'Mistral Large/Small · Codestral',            url: 'https://console.mistral.ai/api-keys',            models: ['mistral-large-latest', 'mistral-small-latest', 'codestral-latest'] },
       { id: 'cloudflare', label: 'Cloudflare AI',  subtitle: '60+ models · free tier · edge inference',  url: 'https://dash.cloudflare.com/profile/api-tokens', models: ['accountId|@cf/meta/llama-3.1-8b-instruct'] },
       { id: 'github',     label: 'GitHub Models',  subtitle: 'GPT-4o · free for GitHub users',             url: 'https://github.com/marketplace/models',          models: ['gpt-4o-mini', 'gpt-4o'] },
     ]
@@ -2907,6 +2908,17 @@ export function createApiServer(): Express {
           if (!r.ok) error = `${r.status}: ${await r.text()}`
           break
         }
+        case 'mistral': {
+          const r = await fetch('https://api.mistral.ai/v1/chat/completions', {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+            body:    JSON.stringify({ model: testModel, messages: testMessages, max_tokens: 5 }),
+            signal:  AbortSignal.timeout(8000),
+          })
+          valid = r.ok
+          if (!r.ok) error = `${r.status}: ${await r.text()}`
+          break
+        }
         case 'nvidia': {
           const r = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {
             method:  'POST',
@@ -2988,6 +3000,19 @@ export function createApiServer(): Express {
           }
         )
         return res.json({ valid: r.ok, status: r.status, provider: 'groq' })
+      }
+
+      if (provider === 'mistral') {
+        const r = await fetch(
+          'https://api.mistral.ai/v1/chat/completions',
+          {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+            body:    JSON.stringify({ model: 'mistral-large-latest', messages: [{ role: 'user', content: 'hi' }], max_tokens: 5 }),
+            signal:  AbortSignal.timeout(8000),
+          }
+        )
+        return res.json({ valid: r.ok, status: r.status, provider: 'mistral' })
       }
 
       if (provider === 'ollama') {
@@ -5583,6 +5608,7 @@ export function getDefaultModel(provider: string): string {
     gemini:     'gemini-1.5-flash',
     cerebras:   'llama3.1-8b',
     nvidia:     'meta/llama-3.3-70b-instruct',
+    mistral:    'mistral-large-latest',
   }
   return defaults[provider] || 'llama-3.3-70b-versatile'
 }
@@ -6212,6 +6238,7 @@ async function fetchProviderResponse(
       nvidia:     'https://integrate.api.nvidia.com/v1/chat/completions',
       github:     'https://models.inference.ai.azure.com/chat/completions',
       boa:        'https://api.bayofassets.com/v1/chat/completions',
+      mistral:    'https://api.mistral.ai/v1/chat/completions',
     }
     const endpoint = COMPAT_ENDPOINTS[providerType] ?? COMPAT_ENDPOINTS['groq']
     const resp = await fetch(endpoint, {
@@ -6325,6 +6352,7 @@ async function* streamTokens(
     openai:     'https://api.openai.com/v1/chat/completions',
     boa:        'https://api.bayofassets.com/v1/chat/completions',
     gemini:     'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
+    mistral:    'https://api.mistral.ai/v1/chat/completions',
   }
 
   // Shared tool-call buffering helper
@@ -6660,6 +6688,7 @@ ${cognitionHint}${memoryContext}${greetingPreamble}${sessionContext}${memoryInde
         cerebras:   'https://api.cerebras.ai/v1/chat/completions',
         openai:     'https://api.openai.com/v1/chat/completions',
         boa:        'https://api.bayofassets.com/v1/chat/completions',
+        mistral:    'https://api.mistral.ai/v1/chat/completions',
       }
       const endpoint = ENDPOINTS[providerType] ?? ENDPOINTS['groq']
       const resp = await fetch(endpoint, {
@@ -6713,6 +6742,7 @@ ${cognitionHint}${memoryContext}${greetingPreamble}${sessionContext}${memoryInde
             cerebras:   'https://api.cerebras.ai/v1/chat/completions',
             openai:     'https://api.openai.com/v1/chat/completions',
             boa:        'https://api.bayofassets.com/v1/chat/completions',
+            mistral:    'https://api.mistral.ai/v1/chat/completions',
           }
           const fbEndpoint = ENDPOINTS[cloudTier.providerName] ?? ENDPOINTS['groq']
           const fbHeaders: Record<string, string> = {

--- a/api/server.ts
+++ b/api/server.ts
@@ -6179,6 +6179,22 @@ export async function start(opts?: {
 // fetchProviderResponse: fires a single non-streaming request to a provider.
 // raceProviders: fires top-2 simultaneously, returns the fastest valid response.
 
+function extractChatMessageContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+
+  return content
+    .map((part) => {
+      if (typeof part === 'string') return part
+      if (part && typeof part === 'object' && 'text' in part) {
+        const text = (part as { text?: unknown }).text
+        return typeof text === 'string' ? text : ''
+      }
+      return ''
+    })
+    .join('')
+}
+
 async function fetchProviderResponse(
   api:      import('../providers/index').APIEntry,
   messages: { role: string; content: string }[],
@@ -6199,7 +6215,11 @@ async function fetchProviderResponse(
     })
     if (!resp.ok) throw new Error(`Gemini ${resp.status}`)
     const d = await resp.json() as any
-    return { text: d?.choices?.[0]?.message?.content || '', apiName: api.name, model }
+    return {
+      text: extractChatMessageContent(d?.choices?.[0]?.message?.content),
+      apiName: api.name,
+      model,
+    }
 
   } else if (providerType === 'ollama') {
     const resp = await fetch('http://localhost:11434/api/chat', {
@@ -6227,7 +6247,11 @@ async function fetchProviderResponse(
     })
     if (!resp.ok) throw new Error(`custom:${api.name} ${resp.status}`)
     const d = await resp.json() as any
-    return { text: d?.choices?.[0]?.message?.content || '', apiName: api.name, model }
+    return {
+      text: extractChatMessageContent(d?.choices?.[0]?.message?.content),
+      apiName: api.name,
+      model,
+    }
 
   } else {
     const COMPAT_ENDPOINTS: Record<string, string> = {
@@ -6253,7 +6277,11 @@ async function fetchProviderResponse(
     })
     if (!resp.ok) throw new Error(`${providerType} ${resp.status}`)
     const d = await resp.json() as any
-    return { text: d?.choices?.[0]?.message?.content || '', apiName: api.name, model }
+    return {
+      text: extractChatMessageContent(d?.choices?.[0]?.message?.content),
+      apiName: api.name,
+      model,
+    }
   }
 }
 

--- a/cli/aiden.ts
+++ b/cli/aiden.ts
@@ -4493,6 +4493,7 @@ async function handleCommand(cmd: string, rl: readline.Interface): Promise<boole
       openrouter: { defaultModel: 'openrouter/free',                                baseUrl: 'https://openrouter.ai/api/v1' },
       boa:        { defaultModel: 'gpt-4o-mini',                                    baseUrl: 'https://api.bayofassets.com/v1' },
       cerebras:   { defaultModel: 'llama3.1-8b',                                    baseUrl: 'https://api.cerebras.ai/v1' },
+      mistral:    { defaultModel: 'mistral-large-latest',                           baseUrl: 'https://api.mistral.ai/v1' },
       openai:     { defaultModel: 'gpt-4o-mini',                                    baseUrl: 'https://api.openai.com/v1' },
       together:   { defaultModel: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',   baseUrl: 'https://api.together.xyz/v1' },
       deepseek:   { defaultModel: 'deepseek-chat',                                  baseUrl: 'https://api.deepseek.com/v1' },

--- a/core/agentLoop.ts
+++ b/core/agentLoop.ts
@@ -452,6 +452,7 @@ const OPENAI_COMPAT_ENDPOINTS: Record<string, string> = {
   nvidia:     'https://integrate.api.nvidia.com/v1/chat/completions',
   github:     'https://models.inference.ai.azure.com/v1/chat/completions',
   boa:        'https://api.bayofassets.com/v1/chat/completions',
+  mistral:    'https://api.mistral.ai/v1/chat/completions',
 }
 
 function buildHeaders(providerName: string, apiKey: string): Record<string, string> {
@@ -3231,5 +3232,4 @@ Respond in JSON:
 
   return allResults.join('\n\n')
 }
-
 

--- a/core/agentLoop.ts
+++ b/core/agentLoop.ts
@@ -467,6 +467,22 @@ function buildHeaders(providerName: string, apiKey: string): Record<string, stri
   return headers
 }
 
+function extractChatMessageContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+
+  return content
+    .map((part) => {
+      if (typeof part === 'string') return part
+      if (part && typeof part === 'object' && 'text' in part) {
+        const text = (part as { text?: unknown }).text
+        return typeof text === 'string' ? text : ''
+      }
+      return ''
+    })
+    .join('')
+}
+
 /**
  * C9b: Resolve streaming URL for any provider — custom or known.
  *
@@ -714,7 +730,7 @@ async function racePlannerAPIs(
     })
     if (!r.ok) throw new Error(`${entry.provider} ${r.status}`)
     const d = await r.json() as any
-    const text = d?.choices?.[0]?.message?.content || ''
+    const text = extractChatMessageContent(d?.choices?.[0]?.message?.content)
     if (!text.trim() || !text.includes('{')) throw new Error('no JSON')
     return text
   }
@@ -3129,7 +3145,7 @@ export async function callLLM(
           opts?.traceId, opts?.isSystem ?? false,
         )
       } catch {}
-      return d?.choices?.[0]?.message?.content || ''
+      return extractChatMessageContent(d?.choices?.[0]?.message?.content)
 
     } else {
       // OpenAI-compatible: groq, openrouter, cerebras, nvidia, github
@@ -3157,7 +3173,7 @@ export async function callLLM(
           opts?.traceId, opts?.isSystem ?? false,
         )
       } catch {}
-      return d?.choices?.[0]?.message?.content || ''
+      return extractChatMessageContent(d?.choices?.[0]?.message?.content)
     }
   } catch (e: any) {
     if (e.name === 'AbortError') return ''
@@ -3232,4 +3248,3 @@ Respond in JSON:
 
   return allResults.join('\n\n')
 }
-

--- a/core/auxiliaryClient.ts
+++ b/core/auxiliaryClient.ts
@@ -24,6 +24,7 @@ const AUX_ENDPOINTS: Record<string, string> = {
   nvidia:     'https://integrate.api.nvidia.com/v1/chat/completions',
   github:     'https://models.inference.ai.azure.com/chat/completions',
   boa:        'https://api.boa.ai/v1/chat/completions',
+  mistral:    'https://api.mistral.ai/v1/chat/completions',
 }
 
 // ── Types ─────────────────────────────────────────────────────

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -14,6 +14,7 @@ import { createOpenRouterProvider } from './openrouter'
 import { createGeminiProvider } from './gemini'
 import { createBOAProvider } from './boa'
 import { createCerebrasProvider } from './cerebras'
+import { createMistralProvider } from './mistral'
 import { createCustomProvider } from './custom'
 
 // ── Config schema ─────────────────────────────────────────────
@@ -27,7 +28,7 @@ export interface TelegramConfig {
 
 export interface APIEntry {
   name:           string        // e.g. "groq-1", "groq-2"
-  provider:       string        // "groq" | "openrouter" | "gemini" | "cerebras" | "nvidia" | "custom"
+  provider:       string        // "groq" | "openrouter" | "gemini" | "cerebras" | "nvidia" | "mistral" | "custom"
   key:            string        // actual API key (or "env:VAR_NAME")
   model:          string        // default model for this entry
   enabled:        boolean       // user can disable without deleting
@@ -114,6 +115,15 @@ function defaultConfig(): DevOSConfig {
           rateLimited: false,
           usageCount:  0,
         },
+        {
+          name:        'mistral',
+          provider:    'mistral',
+          key:         'env:MISTRAL_API_KEY',
+          model:       'mistral-large-latest',
+          enabled:     false,
+          rateLimited: false,
+          usageCount:  0,
+        },
       ],
     },
     routing:            { mode: 'auto', fallbackToOllama: true },
@@ -181,6 +191,8 @@ export function getActiveProvider(): { provider: Provider; model: string; userNa
       return { provider: createBOAProvider(key), model: apiConfig.model || 'llama-3.3-70b', userName }
     case 'cerebras':
       return { provider: createCerebrasProvider(key), model: apiConfig.model || 'llama3.1-8b', userName }
+    case 'mistral':
+      return { provider: createMistralProvider(key), model: apiConfig.model || 'mistral-large-latest', userName }
     case 'custom': {
       const baseUrl = apiConfig.baseUrl || 'http://localhost:11434/v1'
       return { provider: createCustomProvider(baseUrl, key, apiConfig.name), model: apiConfig.model || 'gpt-4o-mini', userName }

--- a/providers/mistral.ts
+++ b/providers/mistral.ts
@@ -1,0 +1,121 @@
+// ============================================================
+// DevOS — Autonomous AI Execution System
+// Copyright (c) 2026 Shiva Deore. All rights reserved.
+// ============================================================
+
+// providers/mistral.ts — Mistral AI cloud provider (OpenAI-compatible)
+
+import { Provider, ToolCall } from './types'
+
+const MISTRAL_CHAT_COMPLETIONS_URL = 'https://api.mistral.ai/v1/chat/completions'
+
+function extractContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+
+  return content
+    .map(part => {
+      if (typeof part === 'string') return part
+      if (part && typeof part === 'object' && 'text' in part) {
+        return typeof (part as any).text === 'string' ? (part as any).text : ''
+      }
+      return ''
+    })
+    .join('')
+}
+
+function parseToolArguments(args: unknown): Record<string, unknown> {
+  if (!args) return {}
+  if (typeof args === 'object') return args as Record<string, unknown>
+  if (typeof args !== 'string') return {}
+  try {
+    return JSON.parse(args) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export function createMistralProvider(apiKey: string): Provider {
+  const headers = (): Record<string, string> => ({
+    'Content-Type':  'application/json',
+    'Authorization': `Bearer ${apiKey}`,
+  })
+
+  return {
+    name: 'mistral',
+
+    async generateWithTools(messages, model, tools) {
+      const res = await fetch(MISTRAL_CHAT_COMPLETIONS_URL, {
+        method:  'POST',
+        headers: headers(),
+        body: JSON.stringify({
+          model,
+          messages,
+          tools:       tools.map(t => ({ type: 'function', function: t })),
+          tool_choice: 'auto',
+          stream:      false,
+        }),
+      })
+      const data = await res.json() as any
+      if (!res.ok) throw new Error(`${res.status}: ${JSON.stringify(data)}`)
+
+      const message = data.choices?.[0]?.message
+      const toolCalls: ToolCall[] = (message?.tool_calls || []).map((tc: any) => ({
+        name:      tc.function.name,
+        arguments: parseToolArguments(tc.function.arguments),
+      }))
+
+      return { content: extractContent(message?.content), toolCalls }
+    },
+
+    async generate(messages, model) {
+      const res = await fetch(MISTRAL_CHAT_COMPLETIONS_URL, {
+        method:  'POST',
+        headers: headers(),
+        body:    JSON.stringify({ model, messages, stream: false }),
+      })
+      if (!res.ok) {
+        const err = await res.text()
+        throw new Error(`${res.status}: ${err}`)
+      }
+      const data = await res.json() as any
+      return extractContent(data?.choices?.[0]?.message?.content)
+    },
+
+    async generateStream(messages, model, onToken) {
+      const res = await fetch(MISTRAL_CHAT_COMPLETIONS_URL, {
+        method:  'POST',
+        headers: headers(),
+        body:    JSON.stringify({ model, messages, stream: true }),
+      })
+      if (!res.ok) {
+        const err = await res.text()
+        throw new Error(`${res.status}: ${err}`)
+      }
+      if (!res.body) return
+
+      const reader  = (res.body as any).getReader()
+      const decoder = new TextDecoder()
+      let   buf     = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const raw = line.replace('data: ', '').trim()
+          if (raw === '[DONE]') return
+          try {
+            const parsed  = JSON.parse(raw) as any
+            const content = parsed?.choices?.[0]?.delta?.content
+            const token   = extractContent(content)
+            if (token) onToken(token)
+          } catch { /* skip malformed SSE chunks */ }
+        }
+      }
+    },
+  }
+}

--- a/providers/router.ts
+++ b/providers/router.ts
@@ -14,6 +14,7 @@ import { createGeminiProvider } from './gemini'
 import { createCerebrasProvider } from './cerebras'
 import { createNvidiaProvider } from './nvidia'
 import { createBOAProvider } from './boa'
+import { createMistralProvider } from './mistral'
 import { createCustomProvider } from './custom'
 import { Provider } from './types'
 import { discoverLocalModels, DiscoveredModels } from '../core/modelDiscovery'
@@ -116,6 +117,7 @@ function buildProvider(entry: APIEntry): Provider {
     case 'cerebras':   return createCerebrasProvider(key)
     case 'nvidia':     return createNvidiaProvider(key)
     case 'boa':        return createBOAProvider(key)
+    case 'mistral':    return createMistralProvider(key)
     case 'custom':     return createCustomProvider(entry.baseUrl || '', key, entry.name)
     default:           return ollamaProvider
   }


### PR DESCRIPTION
Rebased version of #31 by @Genmin (Joey Roth) to resolve merge conflicts with recent commits to `api/server.ts` and `core/agentLoop.ts`.

All credit to @Genmin — original contribution thread: #31. Closes #31.

**What this adds:**
- `providers/mistral.ts` — full Provider implementation (generate, generateWithTools, generateStream)
- Mistral wired into `providers/index.ts`, `providers/router.ts`, `core/agentLoop.ts`, `core/auxiliaryClient.ts`, `api/server.ts`, `cli/aiden.ts`
- Default entry `enabled: false` — safe opt-in
- `extractChatMessageContent()` utility that hardens content extraction across the fallback path
- `.env.example` + setup wizard entry

**Conflict resolution:** `core/agentLoop.ts` had a conflict between `resolveStreamingUrl` (C9b) and `extractChatMessageContent`. Kept both — `resolveStreamingUrl` in its existing position, `extractChatMessageContent` added adjacent to it. TSC clean, build passes.