### PR TITLE
feat: add morning-brief skill

### DIFF
--- a/skills/morning-brief/SKILL.md
+++ b/skills/morning-brief/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: morning-brief
+description: "Daily morning briefing with weather, market movers, and news headlines"
+category: productivity
+version: 1.0.0
+license: Apache-2.0
+origin: community
+tags: productivity, news, weather, finance, stocks, daily-brief
+---
+
+# Morning Brief
+
+Start your day with a concise briefing covering current weather, top stock market movers, and latest news headlines.
+
+## When to Use
+
+- User says "give me my morning brief"
+- User says "what's happening today"
+- User asks for a daily summary of weather, markets, and news
+- User wants a quick overview before starting their work day
+
+## How to Use
+
+### 1. Fetch Current Weather
+
+Use `web_search` to get current weather for the user's location:
+
+```
+Query: "current weather [location]"
+```
+
+### 2. Get Top NSE Market Movers
+
+Use `get_stocks` tool to fetch top gainers and losers:
+
+```
+get_stocks --index NSE --top 5 --type gainers
+get_stocks --index NSE --top 5 --type losers
+```
+
+### 3. Fetch Top 5 News Headlines
+
+Use `web_search` for latest news:
+
+```
+Query: "top news headlines today"
+```
+
+### 4. Format and Present
+
+Combine all information into a clean, readable summary:
+
+```
+🌤️ Weather
+[Current conditions]
+
+📈 Market Movers (NSE)
+Top Gainers:
+- [Stock]: +[X]%
+- [Stock]: +[X]%
+
+Top Losers:
+- [Stock]: -[X]%
+- [Stock]: -[X]%
+
+📰 Top Headlines
+1. [Headline 1]
+2. [Headline 2]
+3. [Headline 3]
+4. [Headline 4]
+5. [Headline 5]
+
+Brief generated at [timestamp]
+```
+
+## Examples
+
+**"Give me my morning brief"**
+→ Fetches weather, NSE top 5 gainers/losers, and top 5 news headlines. Presents as formatted summary.
+
+**"What's happening today?"**
+→ Same as above — comprehensive morning briefing.
+
+## Notes
+
+- Weather location defaults to user's detected location or can be specified
+- Market data uses NSE (National Stock Exchange) by default
+- News headlines are fetched from general sources
+- Use `notify` tool to send the briefing if user is not actively chatting

--- a/skills/morning-brief/skill.json
+++ b/skills/morning-brief/skill.json
@@ -1,0 +1,26 @@
+{
+  "name": "morning-brief",
+  "version": "1.0.0",
+  "description": "Daily morning briefing with weather, market movers, and news headlines",
+  "author": "SpencerJung",
+  "license": "Apache-2.0",
+  "tools": ["web_search", "get_stocks", "notify"],
+  "trigger_phrases": [
+    "give me my morning brief",
+    "what's happening today",
+    "morning briefing",
+    "today's summary",
+    "daily brief"
+  ],
+  "compatible_agents": ["aiden"],
+  "min_agent_version": "3.0.0",
+  "tags": [
+    "productivity",
+    "news",
+    "weather",
+    "finance",
+    "stocks",
+    "daily-brief"
+  ],
+  "created": "2026-05-27T00:00:00.000Z"
+}


### PR DESCRIPTION
﻿## Summary

This PR adds a new `morning-brief` skill that provides users with a daily morning briefing.

## What it does

When the user says "give me my morning brief" or "what's happening today":
1. Fetches current weather via web_search
2. Gets top NSE market movers via get_stocks
3. Fetches top 5 news headlines via web_search
4. Formats and presents as a clean summary

## Files added
- `skills/morning-brief/SKILL.md` — Skill instructions and examples
- `skills/morning-brief/skill.json` — Skill manifest

## Trigger phrases
- "give me my morning brief"
- "what's happening today"
- "morning briefing"
- "today's summary"
- "daily brief"

## Tools used
- `web_search` — for weather and news
- `get_stocks` — for market data
- `notify` — for delivering briefings

Closes #21
