### PR TITLE
feat: add git-summary skill

### DIFF
--- a/skills/git-summary/SKILL.md
+++ b/skills/git-summary/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: git-summary
+description: "Summarize recent git activity grouped by day in plain English"
+category: productivity
+version: 1.0.0
+license: Apache-2.0
+origin: community
+tags: git, productivity, development, commits, summary
+---
+
+# Git Summary
+
+Summarize your recent git commit history, grouped by day, presented in plain English. Optionally generate a standup update format.
+
+## When to Use
+
+- User says "summarize my recent commits"
+- User says "what did I work on this week"
+- User asks for a git activity summary
+- User wants a standup update based on recent work
+- User needs to recall what they accomplished recently
+
+## How to Use
+
+### 1. Fetch Recent Commits
+
+Use `shell_exec` to get recent commit history:
+
+```bash
+git log --oneline -20 --since="7 days ago"
+```
+
+### 2. Parse and Group by Day
+
+Use `run_python` to process the commit log:
+
+```python
+import subprocess
+from datetime import datetime
+from collections import defaultdict
+
+# Get commits with dates
+result = subprocess.run(
+    ["git", "log", "--pretty=format:%H|%ci|%s", "-20"],
+    capture_output=True, text=True
+)
+
+commits_by_day = defaultdict(list)
+for line in result.stdout.strip().split('\n'):
+    if '|' in line:
+        hash, date_str, message = line.split('|', 2)
+        day = datetime.strptime(date_str.split()[0], '%Y-%m-%d').strftime('%A, %B %d')
+        commits_by_day[day].append(message)
+
+# Generate summary
+for day, messages in commits_by_day.items():
+    print(f"\n{day}:")
+    for msg in messages:
+        print(f"  • {msg}")
+```
+
+### 3. Summarize in Plain English
+
+Transform commit messages into readable sentences:
+
+- "feat: add auth middleware" → "Implemented authentication middleware"
+- "fix: resolve null pointer" → "Fixed a null pointer issue"
+- "docs: update API guide" → "Updated API documentation"
+- "refactor: simplify utils" → "Refactored and simplified utility functions"
+- "test: add unit tests" → "Added unit test coverage"
+
+### 4. Standup Update Format (Optional)
+
+When user requests standup format:
+
+```
+## Standup Update — [Today's Date]
+
+### Yesterday
+- [Task completed 1]
+- [Task completed 2]
+- [Task completed 3]
+
+### Today
+- [Planned work based on recent commits]
+
+### Blockers
+- [Any issues mentioned in commits or None]
+```
+
+## Examples
+
+**"Summarize my recent commits"**
+→ Shows last 20 commits grouped by day with plain-English summaries.
+
+**"What did I work on this week?"**
+→ Week-long summary with daily breakdowns.
+
+**"Generate a standup update"**
+→ Formats recent commits into yesterday/today/blockers structure.
+
+## Notes
+
+- Runs from the current git repository context
+- Uses last 20 commits by default (adjustable)
+- Groups by calendar day
+- Converts conventional commit prefixes to readable text
+- Standup format is best-effort based on commit messages

--- a/skills/git-summary/skill.json
+++ b/skills/git-summary/skill.json
@@ -1,0 +1,26 @@
+{
+  "name": "git-summary",
+  "version": "1.0.0",
+  "description": "Summarize recent git activity grouped by day in plain English",
+  "author": "SpencerJung",
+  "license": "Apache-2.0",
+  "tools": ["shell_exec", "run_python"],
+  "trigger_phrases": [
+    "summarize my recent commits",
+    "what did I work on this week",
+    "git activity summary",
+    "recent git commits",
+    "generate standup update"
+  ],
+  "compatible_agents": ["aiden"],
+  "min_agent_version": "3.0.0",
+  "tags": [
+    "git",
+    "productivity",
+    "development",
+    "commits",
+    "summary",
+    "standup"
+  ],
+  "created": "2026-05-27T00:00:00.000Z"
+}

--- a/skills/morning-brief/SKILL.md
+++ b/skills/morning-brief/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: morning-brief
+description: "Daily morning briefing with weather, market movers, and news headlines"
+category: productivity
+version: 1.0.0
+license: Apache-2.0
+origin: community
+tags: productivity, news, weather, finance, stocks, daily-brief
+---
+
+# Morning Brief
+
+Start your day with a concise briefing covering current weather, top stock market movers, and latest news headlines.
+
+## When to Use
+
+- User says "give me my morning brief"
+- User says "what's happening today"
+- User asks for a daily summary of weather, markets, and news
+- User wants a quick overview before starting their work day
+
+## How to Use
+
+### 1. Fetch Current Weather
+
+Use `web_search` to get current weather for the user's location:
+
+```
+Query: "current weather [location]"
+```
+
+### 2. Get Top NSE Market Movers
+
+Use `get_stocks` tool to fetch top gainers and losers:
+
+```
+get_stocks --index NSE --top 5 --type gainers
+get_stocks --index NSE --top 5 --type losers
+```
+
+### 3. Fetch Top 5 News Headlines
+
+Use `web_search` for latest news:
+
+```
+Query: "top news headlines today"
+```
+
+### 4. Format and Present
+
+Combine all information into a clean, readable summary:
+
+```
+🌤️ Weather
+[Current conditions]
+
+📈 Market Movers (NSE)
+Top Gainers:
+- [Stock]: +[X]%
+- [Stock]: +[X]%
+
+Top Losers:
+- [Stock]: -[X]%
+- [Stock]: -[X]%
+
+📰 Top Headlines
+1. [Headline 1]
+2. [Headline 2]
+3. [Headline 3]
+4. [Headline 4]
+5. [Headline 5]
+
+Brief generated at [timestamp]
+```
+
+## Examples
+
+**"Give me my morning brief"**
+→ Fetches weather, NSE top 5 gainers/losers, and top 5 news headlines. Presents as formatted summary.
+
+**"What's happening today?"**
+→ Same as above — comprehensive morning briefing.
+
+## Notes
+
+- Weather location defaults to user's detected location or can be specified
+- Market data uses NSE (National Stock Exchange) by default
+- News headlines are fetched from general sources
+- Use `notify` tool to send the briefing if user is not actively chatting

--- a/skills/morning-brief/skill.json
+++ b/skills/morning-brief/skill.json
@@ -1,0 +1,26 @@
+{
+  "name": "morning-brief",
+  "version": "1.0.0",
+  "description": "Daily morning briefing with weather, market movers, and news headlines",
+  "author": "SpencerJung",
+  "license": "Apache-2.0",
+  "tools": ["web_search", "get_stocks", "notify"],
+  "trigger_phrases": [
+    "give me my morning brief",
+    "what's happening today",
+    "morning briefing",
+    "today's summary",
+    "daily brief"
+  ],
+  "compatible_agents": ["aiden"],
+  "min_agent_version": "3.0.0",
+  "tags": [
+    "productivity",
+    "news",
+    "weather",
+    "finance",
+    "stocks",
+    "daily-brief"
+  ],
+  "created": "2026-05-27T00:00:00.000Z"
+}


### PR DESCRIPTION
﻿## Summary

This PR adds a new `git-summary` skill that summarizes recent git activity.

## What it does

When the user says "summarize my recent commits" or "what did I work on this week":
1. Runs `git log --oneline -20` via shell_exec
2. Parses and groups commits by day using run_python
3. Summarizes in plain English with readable descriptions
4. Optionally generates a standup update format

## Files added
- `skills/git-summary/SKILL.md` — Skill instructions and examples
- `skills/git-summary/skill.json` — Skill manifest

## Trigger phrases
- "summarize my recent commits"
- "what did I work on this week"
- "git activity summary"
- "recent git commits"
- "generate standup update"

## Tools used
- `shell_exec` — for running git log
- `run_python` — for parsing and grouping commits

Closes #22
