### PR TITLE
feat(mcp): one-tap /mcp connect + bank the device-flow, cleanup & personality foundation

### DIFF
--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -167,7 +167,7 @@ import { ChannelManager } from '../../core/channels/manager';
 import { TelegramAdapter } from '../../core/channels/telegram';
 import { registerEnvChannels } from './channelBoot';
 import { gateway } from '../../core/gateway';
-import { createBootLogger } from '../../core/v4/logger';
+import { createBootLogger, CoreLogger, FileSink } from '../../core/v4/logger';
 
 import { registerAllTools } from '../../tools/v4';
 import { setupMcpFromConfig } from '../../tools/v4/mcpSetup';
@@ -1849,10 +1849,28 @@ export async function buildAgentRuntime(
   }
 
   // MCP setup (best-effort — connection failures are non-fatal).
-  const mcpResult = await setupMcpFromConfig(config, toolRegistry, { paths }).catch(
+  // v4.14 Fix 1 — route ALL background MCP connection chatter (reconnect
+  // attempts, retry backoff, give-up, disconnects) to a FILE sink only, never
+  // stderr. The default mcpClient logger console.warn'd, which in an interactive
+  // REPL spliced into the user's chat stream. A file-only CoreLogger keeps
+  // housekeeping out of the conversation entirely.
+  const mcpLog = new CoreLogger({ sinks: paths.logsDir ? [new FileSink({ dir: paths.logsDir, name: 'aiden-mcp' })] : [] });
+  const mcpResult = await setupMcpFromConfig(config, toolRegistry, {
+    paths,
+    log: (level, msg) => { const fn = (mcpLog as unknown as Record<string, (m: string) => void>)[level]; if (typeof fn === 'function') fn.call(mcpLog, msg); },
+  }).catch(
     () => ({ client: null, connected: [], failures: {} }),
   );
   const mcpClient = mcpResult.client ?? null;
+  // v4.14 Fix 1 — the ONLY MCP thing that surfaces to the user: a calm, one-time
+  // actionable hint for servers that need authorization. Background chatter
+  // above stays in the log file.
+  try {
+    const needsAuth = (mcpClient?.list() ?? []).filter((s) => s.status === 'needs-auth').map((s) => s.config.name);
+    if (needsAuth.length > 0) {
+      display.dim(`  MCP: ${needsAuth.join(', ')} ${needsAuth.length === 1 ? 'needs' : 'need'} authorization — run \`/mcp auth ${needsAuth[0]}\`.`);
+    }
+  } catch { /* never let the hint break boot */ }
 
   // ── Phase 12 moat: resolve modes from config + CLI flags ─────────────
   const plannerGuardMode = coerceMode<PlannerGuardMode>(

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -24,6 +24,7 @@ import type {
   ApprovalDecision,
   RiskTier,
 } from '../../moat/approvalEngine';
+import { isNeverBlanketAllow } from '../../moat/autonomy';
 import type { SkillProposal } from '../../moat/skillTeacher';
 import type { PlannerGuardDecision } from '../../moat/plannerGuard';
 import type { CompressionResult } from '../../core/v4/contextCompressor';
@@ -120,14 +121,22 @@ function primaryArgKindFor(args: Record<string, unknown>): string {
   return 'this call';
 }
 
-function decisionChoicesFor(args: Record<string, unknown>): { name: string; value: ApprovalDecision }[] {
-  const kind = primaryArgKindFor(args);
-  return [
-    { name: 'Once',                     value: 'allow' },
-    { name: `Session (${kind})`,        value: 'allow_session' },
-    { name: `Always (${kind})`,         value: 'allow_always' },
-    { name: 'Deny',                     value: 'deny' },
+function decisionChoicesFor(req: ApprovalRequest): { name: string; value: ApprovalDecision }[] {
+  const kind = primaryArgKindFor(req.args);
+  const choices: { name: string; value: ApprovalDecision }[] = [
+    { name: 'Once', value: 'allow' },
   ];
+  // v4.14 UX (Bug 2) — Session / Always (blanket grants) are offered ONLY for
+  // safe, reversible classes. Destructive / external-send / spend calls get
+  // Once / Deny only: they must be confirmed every time, never blanket-allowed
+  // (which is how blind-yes gets trained). The engine enforces the same floor
+  // as a backstop even if a caller bypasses this UI.
+  if (!isNeverBlanketAllow(req)) {
+    choices.push({ name: `Session (${kind})`, value: 'allow_session' });
+    choices.push({ name: `Always (${kind})`,  value: 'allow_always' });
+  }
+  choices.push({ name: 'Deny', value: 'deny' });
+  return choices;
 }
 
 const KNOWN_TIERS: ReadonlySet<RiskTier> = new Set(['safe', 'caution', 'dangerous']);
@@ -528,7 +537,7 @@ export class CliCallbacks {
       // argSignature's primary-arg extractor).
       choice = await prompts.select({
         message: 'Decision',
-        choices: decisionChoicesFor(req.args),
+        choices: decisionChoicesFor(req),
       });
     } catch {
       // User hit Ctrl+C or otherwise cancelled — fail closed.

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -2887,7 +2887,14 @@ export class ChatSession implements ChatSessionLike {
         // suppression path was untested. `import()` resolves in both the runner
         // and the compiled CJS build.
         const { renderOnboardingIntro } = await import('./onboarding/speakFirst');
-        onboarded = await renderOnboardingIntro({ paths: this.opts.paths, out: process.stdout });
+        // v4.14 Personality L1 — pass the real memory manager so the captured
+        // name is stored via the existing write path (memory.add('user', …)),
+        // which fires the mutation listener → the name reaches the prompt.
+        onboarded = await renderOnboardingIntro({
+          paths:  this.opts.paths,
+          out:    process.stdout,
+          memory: this.opts.memoryManager,
+        });
         if (!onboarded) {
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { renderFirstRunHint } = require('./repl/firstRunHint') as typeof import('./repl/firstRunHint');

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -2881,8 +2881,12 @@ export class ChatSession implements ChatSessionLike {
         // v4.12 — speaks-first onboarding for a brand-new user (USER.md
         // empty + marker absent). When the intro fires, skip the
         // /walkthrough tip so the first screen stays uncluttered.
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { renderOnboardingIntro } = require('./onboarding/speakFirst') as typeof import('./onboarding/speakFirst');
+        // v4.14 — dynamic `import` (not a relative `require`): the require
+        // form fails to resolve under the test runner, which silently swallowed
+        // onboarding so its intro NEVER fired in tests and the greeter-
+        // suppression path was untested. `import()` resolves in both the runner
+        // and the compiled CJS build.
+        const { renderOnboardingIntro } = await import('./onboarding/speakFirst');
         onboarded = await renderOnboardingIntro({ paths: this.opts.paths, out: process.stdout });
         if (!onboarded) {
           // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/cli/v4/commands/mcpCatalog.ts
+++ b/cli/v4/commands/mcpCatalog.ts
@@ -33,6 +33,25 @@ export interface CatalogEntry {
   args?: string[];
   /** http (streamable/sse): the single endpoint URL. */
   baseUrl?: string;
+  /**
+   * v4.14 — static OAuth client config for providers with NO Dynamic Client
+   * Registration (e.g. GitHub). Carries the pre-registered PUBLIC client id
+   * (device flow uses no secret) + the RFC 8628 device-authorization endpoint
+   * (rarely published in AS metadata) + requested scopes. `clientId` may be
+   * empty in the shipped catalog when Aiden hasn't registered an app yet —
+   * it's then supplied at runtime via `AIDEN_MCP_<SLUG>_CLIENT_ID`.
+   */
+  oauth?: {
+    clientId: string;
+    deviceAuthorizationEndpoint: string;
+    scopes?: string[];
+  };
+  /**
+   * v4.14 — true ONLY once a real end-to-end OAuth connect has been proven for
+   * this entry. Unverified OAuth entries are surfaced honestly (never
+   * advertised as working). Defaults to false/absent.
+   */
+  oauthVerified?: boolean;
   /** Where the server comes from — shown so the user can vet it. */
   sourceUrl: string;
   /** Trust / footgun notes shown before the confirm gate. */
@@ -140,8 +159,19 @@ export const MCP_CATALOG: readonly CatalogEntry[] = [
     transport: 'streamable',
     auth: 'oauth',
     baseUrl: 'https://api.githubcopilot.com/mcp/',
+    // GitHub's authorization server has NO Dynamic Client Registration, so we
+    // use the RFC 8628 device flow with a pre-registered public client id. The
+    // device endpoint isn't in GitHub's metadata, so it's carried here. The
+    // client id ships empty until Aiden registers an official OAuth App; supply
+    // your own registered app via AIDEN_MCP_GITHUB_CLIENT_ID to try it now.
+    oauth: {
+      clientId: '',
+      deviceAuthorizationEndpoint: 'https://github.com/login/device/code',
+      scopes: ['repo', 'read:org', 'read:user'],
+    },
+    oauthVerified: false, // not proven end-to-end yet — never advertised as working
     sourceUrl: 'https://github.com/github/github-mcp-server',
-    securityNotes: 'Browser OAuth (no PAT). Grants access to your GitHub per the scopes you approve. After adding, run `/mcp auth github`.',
+    securityNotes: 'Browser device-code OAuth (no PAT, no secret). Grants access to your GitHub per the scopes you approve. After adding, run `/mcp auth github`.',
   },
 ] as const;
 
@@ -151,17 +181,33 @@ export function findCatalogEntry(slug: string): CatalogEntry | undefined {
   return MCP_CATALOG.find((e) => e.slug === s);
 }
 
+/** Static OAuth client config persisted under `mcp.servers.<name>.http.oauth`. */
+export interface McpServerOAuth {
+  clientId: string;
+  deviceAuthorizationEndpoint: string;
+  scopes?: string[];
+}
+
 /** Raw `mcp.servers.<name>` config from a catalog entry (+ user trailing args for stdio). */
 export function catalogEntryToRawConfig(
   entry: CatalogEntry,
   extraArgs: string[] = [],
 ):
   | { type: 'stdio'; stdio: { command: string; args: string[] } }
-  | { type: 'http'; http: { baseUrl: string; transport: 'streamable' | 'sse' } } {
+  | { type: 'http'; http: { baseUrl: string; transport: 'streamable' | 'sse'; oauth?: McpServerOAuth } } {
   if (entry.transport === 'stdio') {
     if (!entry.command) throw new Error(`Catalog entry '${entry.slug}' is stdio but has no command`);
     return { type: 'stdio', stdio: { command: entry.command, args: [...(entry.args ?? []), ...extraArgs] } };
   }
   if (!entry.baseUrl) throw new Error(`Catalog entry '${entry.slug}' is ${entry.transport} but has no baseUrl`);
-  return { type: 'http', http: { baseUrl: entry.baseUrl, transport: entry.transport === 'sse' ? 'sse' : 'streamable' } };
+  return {
+    type: 'http',
+    http: {
+      baseUrl: entry.baseUrl,
+      transport: entry.transport === 'sse' ? 'sse' : 'streamable',
+      // Carry the static OAuth client through to the server config so /mcp auth
+      // can drive the device flow without re-reading the catalog.
+      ...(entry.oauth ? { oauth: { ...entry.oauth } } : {}),
+    },
+  };
 }

--- a/cli/v4/commands/mcpCatalog.ts
+++ b/cli/v4/commands/mcpCatalog.ts
@@ -162,14 +162,18 @@ export const MCP_CATALOG: readonly CatalogEntry[] = [
     // GitHub's authorization server has NO Dynamic Client Registration, so we
     // use the RFC 8628 device flow with a pre-registered public client id. The
     // device endpoint isn't in GitHub's metadata, so it's carried here. The
-    // client id ships empty until Aiden registers an official OAuth App; supply
-    // your own registered app via AIDEN_MCP_GITHUB_CLIENT_ID to try it now.
+    // client id ships empty until Aiden registers an official OAuth App; the
+    // user supplies their own app's PUBLIC client id (device flow — no secret)
+    // once via `/mcp connect github` (prompted, then persisted) or --client-id.
     oauth: {
       clientId: '',
       deviceAuthorizationEndpoint: 'https://github.com/login/device/code',
       scopes: ['repo', 'read:org', 'read:user'],
     },
-    oauthVerified: false, // not proven end-to-end yet — never advertised as working
+    // Device flow proven end-to-end against real GitHub (live connect, tools
+    // listed) — so one-tap `/mcp connect github` is offered. The user still
+    // supplies their own public client id (no official Aiden OAuth app ships).
+    oauthVerified: true,
     sourceUrl: 'https://github.com/github/github-mcp-server',
     securityNotes: 'Browser device-code OAuth (no PAT, no secret). Grants access to your GitHub per the scopes you approve. After adding, run `/mcp auth github`.',
   },
@@ -179,6 +183,18 @@ export const MCP_CATALOG: readonly CatalogEntry[] = [
 export function findCatalogEntry(slug: string): CatalogEntry | undefined {
   const s = slug.toLowerCase();
   return MCP_CATALOG.find((e) => e.slug === s);
+}
+
+/**
+ * Honest catalog — one-tap `/mcp connect` is offered ONLY for entries whose
+ * connect path is PROVEN. Non-oauth entries connect directly; an oauth entry
+ * must be `oauthVerified` (its device/loopback flow demonstrated end-to-end
+ * against the real server). An unverified oauth entry is never advertised as
+ * one-tap-connectable — the user is pointed at the manual add + auth path.
+ */
+export function isConnectable(entry: CatalogEntry): boolean {
+  if (entry.auth !== 'oauth') return true;
+  return entry.oauthVerified === true;
 }
 
 /** Static OAuth client config persisted under `mcp.servers.<name>.http.oauth`. */

--- a/cli/v4/commands/mcpManage.ts
+++ b/cli/v4/commands/mcpManage.ts
@@ -28,12 +28,13 @@ import type { SlashCommand, SlashCommandContext } from '../commandRegistry';
 import type { McpServer, McpServerConfig } from '../../../core/v4/mcpClient';
 import { promises as fs } from 'node:fs';
 import { mapStandardMcpServers } from '../../../tools/v4/mcpImport';
-import { ensureMcpOAuthConfig } from '../../../core/v4/mcp/oauthDiscovery';
+import { ensureMcpOAuthConfig, type StaticOAuthClient } from '../../../core/v4/mcp/oauthDiscovery';
 import {
   runLoopbackAuthFlow,
   loopbackRedirectUris,
   persistMcpTokens,
 } from '../../../core/v4/mcp/oauthLoginFlow';
+import { runMcpDeviceFlow } from '../../../core/v4/mcp/deviceFlow';
 import type { OAuthUserAgent } from '../../../core/v4/auth/oauthFlow';
 import { openOAuthBrowserUrl } from '../auth/loadProvider';
 import {
@@ -41,6 +42,7 @@ import {
   findCatalogEntry,
   catalogEntryToRawConfig,
   type CatalogAuth,
+  type McpServerOAuth,
 } from './mcpCatalog';
 
 const STATUS_GLYPH: Record<McpServer['status'], string> = {
@@ -149,7 +151,7 @@ function toolCountLabel(n: number): string {
 /** Raw config union written under `mcp.servers.<name>`. */
 type RawServerEntry =
   | RawStdioEntry
-  | { type: 'http'; http: { baseUrl: string; transport: 'streamable' | 'sse' } };
+  | { type: 'http'; http: { baseUrl: string; transport: 'streamable' | 'sse'; oauth?: McpServerOAuth } };
 
 /**
  * Shared add core (Slice 1b + Slice 4): collision check → security gate
@@ -259,7 +261,11 @@ function handleCatalog(ctx: SlashCommandContext): void {
   const { display } = ctx;
   display.info(`MCP catalog — ${MCP_CATALOG.length} curated servers`);
   for (const e of MCP_CATALOG) {
-    const auth = e.auth === 'oauth' ? ' · 🔑 oauth' : '';
+    // Surface OAuth honestly: an unverified entry (no proven end-to-end connect
+    // yet) is labelled so, never advertised as working.
+    const auth = e.auth === 'oauth'
+      ? (e.oauthVerified ? ' · 🔑 oauth' : ' · 🔑 oauth (unverified)')
+      : '';
     display.write(`  ${e.slug}  —  ${e.name}  (${e.transport}${auth})\n`);
     display.dim(`      ${e.description}`);
   }
@@ -440,7 +446,7 @@ async function handleAuth(ctx: SlashCommandContext): Promise<void> {
   if (!ctx.config) { display.printError('Cannot read server config — config is not available.');   return; }
 
   const mcpCfg = ctx.config.getValue<{
-    servers?: Record<string, { type?: string; http?: { baseUrl?: string } }>;
+    servers?: Record<string, { type?: string; http?: { baseUrl?: string; oauth?: McpServerOAuth } }>;
   }>('mcp');
   const entry = mcpCfg?.servers?.[name];
   if (!entry) {
@@ -453,12 +459,45 @@ async function handleAuth(ctx: SlashCommandContext): Promise<void> {
   }
 
   const serverUrl = entry.http.baseUrl;
+  // v4.14 — resolve a static device-flow client for providers without DCR. The
+  // client id is PUBLIC (device flow, no secret); it comes from the server
+  // config, overridable at runtime via AIDEN_MCP_<NAME>_CLIENT_ID so a user can
+  // supply their own registered app without editing the shipped catalog.
+  const oauthCfg = entry.http.oauth;
+  let staticClient: StaticOAuthClient | undefined;
+  if (oauthCfg?.deviceAuthorizationEndpoint) {
+    const clientId = (process.env[`AIDEN_MCP_${name.toUpperCase()}_CLIENT_ID`] ?? oauthCfg.clientId ?? '').trim();
+    if (!clientId) {
+      display.printError(
+        `'${name}' needs a registered OAuth client id to authorize.`,
+        `Set AIDEN_MCP_${name.toUpperCase()}_CLIENT_ID to your registered app's client id, then retry.`,
+      );
+      return;
+    }
+    staticClient = { clientId, deviceAuthorizationEndpoint: oauthCfg.deviceAuthorizationEndpoint, scopes: oauthCfg.scopes };
+  }
+
   try {
     const config = await ensureMcpOAuthConfig(ctx.paths, name, serverUrl, {
       fetchFn: fetch,
       redirectUris: loopbackRedirectUris(),
+      staticClient,
     });
-    const result = await runLoopbackAuthFlow({ config, server: name, ua: buildMcpUserAgent(ctx) });
+    // Route by what the resolved config carries: a device-authorization endpoint
+    // ⇒ RFC 8628 device flow; otherwise the DCR + loopback flow. Both hand the
+    // same OAuthFlowResult to the same token store.
+    const result = config.endpoints.deviceAuthorizationEndpoint
+      ? await runMcpDeviceFlow({
+          config: {
+            deviceAuthorizationEndpoint: config.endpoints.deviceAuthorizationEndpoint,
+            tokenEndpoint: config.endpoints.tokenEndpoint,
+            clientId: config.clientId,
+            scope: config.scopes?.join(' '),
+          },
+          server: name,
+          ua: buildMcpUserAgent(ctx),
+        })
+      : await runLoopbackAuthFlow({ config, server: name, ua: buildMcpUserAgent(ctx) });
     await persistMcpTokens(ctx.paths, name, result);
 
     // Handoff: token persisted → (re)connect so the tools register immediately.

--- a/cli/v4/commands/mcpManage.ts
+++ b/cli/v4/commands/mcpManage.ts
@@ -284,9 +284,36 @@ async function handleCatalogAdd(ctx: SlashCommandContext, slug: string, extraArg
     display.printError(`No catalog entry '${slug}'.`, 'Run /mcp catalog to see available servers.');
     return;
   }
+  // v4.14 Fix 3 — pull `--client-id <id>` out of the args and PERSIST it with the
+  // server entry (public OAuth client id — safe to store, no secret). /mcp auth
+  // then reads it from the stored config first, so add-once → auth works on every
+  // future boot with zero env vars.
+  const { clientId, rest } = extractClientIdFlag(extraArgs);
   // Surface the entry's security notes before the gate.
   if (entry.securityNotes) display.dim(entry.securityNotes);
-  await addServer(ctx, entry.slug, catalogEntryToRawConfig(entry, extraArgs), { authType: entry.auth });
+  const raw = catalogEntryToRawConfig(entry, rest);
+  if (clientId) {
+    if (raw.type === 'http' && raw.http.oauth) {
+      raw.http.oauth = { ...raw.http.oauth, clientId };
+    } else {
+      display.dim(`(--client-id ignored — '${entry.slug}' is not an OAuth server)`);
+    }
+  }
+  await addServer(ctx, entry.slug, raw, { authType: entry.auth });
+}
+
+/** Pull `--client-id <id>` (or `--client-id=<id>`) out of a catalog-add arg list. */
+export function extractClientIdFlag(args: string[]): { clientId?: string; rest: string[] } {
+  const rest: string[] = [];
+  let clientId: string | undefined;
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--client-id' && i + 1 < args.length) { clientId = args[i + 1]; i += 1; continue; }
+    if (a.startsWith('--client-id=')) { clientId = a.slice('--client-id='.length); continue; }
+    rest.push(a);
+  }
+  const trimmed = clientId?.trim();
+  return { clientId: trimmed ? trimmed : undefined, rest };
 }
 
 /** `/mcp remove <name>` — light confirm → disconnect live → prune config. */
@@ -466,11 +493,16 @@ async function handleAuth(ctx: SlashCommandContext): Promise<void> {
   const oauthCfg = entry.http.oauth;
   let staticClient: StaticOAuthClient | undefined;
   if (oauthCfg?.deviceAuthorizationEndpoint) {
-    const clientId = (process.env[`AIDEN_MCP_${name.toUpperCase()}_CLIENT_ID`] ?? oauthCfg.clientId ?? '').trim();
+    // v4.14 Fix 3 — read the client id from the STORED server config FIRST (set
+    // via `/mcp catalog add <slug> --client-id <id>`), env var only as an
+    // optional fallback. The public client id persists with the entry, so
+    // add-once → auth works on every future boot with zero env vars.
+    const clientId = (oauthCfg.clientId || process.env[`AIDEN_MCP_${name.toUpperCase()}_CLIENT_ID`] || '').trim();
     if (!clientId) {
       display.printError(
         `'${name}' needs a registered OAuth client id to authorize.`,
-        `Set AIDEN_MCP_${name.toUpperCase()}_CLIENT_ID to your registered app's client id, then retry.`,
+        `Re-add it with the id: \`/mcp catalog add ${name} --client-id <your-app-client-id>\` ` +
+          `(or set AIDEN_MCP_${name.toUpperCase()}_CLIENT_ID).`,
       );
       return;
     }

--- a/cli/v4/commands/mcpManage.ts
+++ b/cli/v4/commands/mcpManage.ts
@@ -41,6 +41,7 @@ import {
   MCP_CATALOG,
   findCatalogEntry,
   catalogEntryToRawConfig,
+  isConnectable,
   type CatalogAuth,
   type McpServerOAuth,
 } from './mcpCatalog';
@@ -164,7 +165,7 @@ async function addServer(
   ctx: SlashCommandContext,
   name: string,
   rawEntry: RawServerEntry,
-  opts: { authType?: CatalogAuth } = {},
+  opts: { authType?: CatalogAuth; chained?: boolean } = {},
 ): Promise<void> {
   const { display } = ctx;
   if (!ctx.mcpClient) { display.warn('MCP client is not available in this session.'); return; }
@@ -218,9 +219,15 @@ async function addServer(
   ctx.config.set(`mcp.servers.${name}`, rawEntry);
   await ctx.config.save();
 
-  // OAuth: defer the connect to the explicit /mcp auth (no token yet).
+  // OAuth: defer the connect to the explicit /mcp auth (no token yet). When the
+  // one-tap wrapper drives this it authorizes right after, so skip the manual
+  // hint and just confirm the add calmly.
   if (isOauth) {
-    display.success(`Saved '${name}'. Run /mcp auth ${name} to authorize and connect.`);
+    display.success(
+      opts.chained
+        ? `Added '${name}' ✓`
+        : `Saved '${name}'. Run /mcp auth ${name} to authorize and connect.`,
+    );
     return;
   }
 
@@ -273,7 +280,12 @@ function handleCatalog(ctx: SlashCommandContext): void {
 }
 
 /** `/mcp catalog add <slug> [args]` / `/mcp install <slug> [args]` — pre-fill → shared gate. */
-async function handleCatalogAdd(ctx: SlashCommandContext, slug: string, extraArgs: string[]): Promise<void> {
+async function handleCatalogAdd(
+  ctx: SlashCommandContext,
+  slug: string,
+  extraArgs: string[],
+  opts: { chained?: boolean } = {},
+): Promise<void> {
   const { display } = ctx;
   if (!slug) {
     display.printError('Usage: /mcp catalog add <slug> [args]', 'Run /mcp catalog to see slugs.');
@@ -299,7 +311,7 @@ async function handleCatalogAdd(ctx: SlashCommandContext, slug: string, extraArg
       display.dim(`(--client-id ignored — '${entry.slug}' is not an OAuth server)`);
     }
   }
-  await addServer(ctx, entry.slug, raw, { authType: entry.auth });
+  await addServer(ctx, entry.slug, raw, { authType: entry.auth, chained: opts.chained });
 }
 
 /** Pull `--client-id <id>` (or `--client-id=<id>`) out of a catalog-add arg list. */
@@ -548,6 +560,102 @@ async function handleAuth(ctx: SlashCommandContext): Promise<void> {
   }
 }
 
+/**
+ * `/mcp connect <name> [--client-id <id>]` — the ONE-TAP wrapper. Collapses the
+ * 3-step connect (catalog add → auth → device-code) into a single command for a
+ * PROVEN catalog entry: add it (if not already) → authorize via device flow
+ * (shows the URL + user code) → connected. If a device-flow entry needs a
+ * public client id that isn't stored yet, it's prompted for ONCE (or taken from
+ * --client-id) and PERSISTED — the user is NEVER sent to set an env var.
+ *
+ * A thin, friendly shortcut OVER the existing commands (catalog add / auth all
+ * still work), not a replacement. Honest catalog: only offered for entries
+ * `isConnectable` marks proven; unverified oauth entries are pointed at the
+ * manual add + auth path, never advertised as one-tap.
+ */
+async function handleConnect(ctx: SlashCommandContext, slug: string, extraArgs: string[]): Promise<void> {
+  const { display } = ctx;
+  if (!ctx.mcpClient) { display.warn('MCP client is not available in this session.'); return; }
+  if (!ctx.config)    { display.printError('Cannot persist — config is not available in this context.'); return; }
+  if (!slug) {
+    display.printError('Usage: /mcp connect <name> [--client-id <id>]', 'Run /mcp catalog to see servers.');
+    return;
+  }
+  const entry = findCatalogEntry(slug);
+  if (!entry) {
+    display.printError(`No catalog entry '${slug}'.`, 'Run /mcp catalog to see available servers.');
+    return;
+  }
+
+  // Honest catalog — never advertise a connect that isn't proven end-to-end.
+  if (!isConnectable(entry)) {
+    display.printError(
+      `'${entry.slug}' isn't verified for one-tap connect yet.`,
+      `Its OAuth flow isn't proven end-to-end — add it manually: /mcp catalog add ${entry.slug} · /mcp auth ${entry.slug}.`,
+    );
+    return;
+  }
+
+  // Already connected? Nothing to do.
+  const live = ctx.mcpClient.get(entry.slug);
+  if (live && (live.status === 'ready' || (live.tools?.length ?? 0) > 0)) {
+    display.success(`'${entry.slug}' is already connected — ${toolCountLabel(live.tools?.length ?? 0)} available.`);
+    return;
+  }
+
+  const { clientId: providedClientId, rest } = extractClientIdFlag(extraArgs);
+  const servers = ctx.config.getValue<Record<string, { http?: { oauth?: { clientId?: string } } }>>('mcp.servers') ?? {};
+  const alreadyAdded = Object.prototype.hasOwnProperty.call(servers, entry.slug);
+  const storedClientId = servers[entry.slug]?.http?.oauth?.clientId?.trim();
+
+  // A device-flow entry that ships no client id needs the user's public one.
+  const needsClientId = entry.auth === 'oauth'
+    && Boolean(entry.oauth?.deviceAuthorizationEndpoint)
+    && !entry.oauth?.clientId;
+
+  let clientId = providedClientId;
+  if (needsClientId && !clientId && !storedClientId) {
+    // Prompt inline ONCE — never an env var. Persisted via the add below.
+    if (!ctx.prompt) {
+      display.printError(
+        `'${entry.slug}' needs a public OAuth client id to connect.`,
+        `Re-run with it: /mcp connect ${entry.slug} --client-id <id>`,
+      );
+      return;
+    }
+    display.info(`One-tap connect for ${entry.name}.`);
+    display.dim(`Needs your registered app's PUBLIC client id (device flow — no secret, safe to store). Asked once, then persisted.`);
+    clientId = (await ctx.prompt(`${entry.name} client id`)).trim();
+    if (!clientId) {
+      display.printError('No client id entered — aborting.', `Re-run: /mcp connect ${entry.slug} --client-id <id>`);
+      return;
+    }
+  }
+
+  // ── Step 1 — ADD (if not already configured). The confirm gate + security
+  //    notes live in addServer; a declined confirm leaves nothing in config.
+  if (!alreadyAdded) {
+    const addArgs = clientId ? ['--client-id', clientId, ...rest] : rest;
+    await handleCatalogAdd(ctx, entry.slug, addArgs, { chained: true });
+    if (!ctx.config.getValue(`mcp.servers.${entry.slug}`)) return; // declined/failed → addServer already spoke
+  } else {
+    display.dim(`Added '${entry.slug}' ✓ (already configured)`);
+    // A --client-id supplied for an already-added entry updates the stored id.
+    if (clientId && clientId !== storedClientId) {
+      const cur = ctx.config.getValue<{ http?: { oauth?: Record<string, unknown> } }>(`mcp.servers.${entry.slug}`);
+      if (cur?.http?.oauth) {
+        cur.http.oauth = { ...cur.http.oauth, clientId };
+        ctx.config.set(`mcp.servers.${entry.slug}`, cur);
+        await ctx.config.save();
+      }
+    }
+  }
+
+  // ── Step 2 — AUTHORIZE (device flow prints the URL + code, waits) → connect.
+  //    handleAuth reads the server name from ctx.args[1] (= slug here).
+  await handleAuth(ctx);
+}
+
 export const mcp: SlashCommand = {
   name: 'mcp',
   description: 'List connected MCP servers and their tools (read-only).',
@@ -600,6 +708,9 @@ export const mcp: SlashCommand = {
       return {};
     }
     if (sub === 'install') { await handleCatalogAdd(ctx, ctx.args[1] ?? '', ctx.args.slice(2)); return {}; }
+
+    // v4.14 — one-tap wrapper: add → auth → device-code in a single command.
+    if (sub === 'connect') { await handleConnect(ctx, ctx.args[1] ?? '', ctx.args.slice(2)); return {}; }
 
     if (sub && sub !== 'list') {
       ctx.display.printError(`Unknown subcommand '${sub}'.`, 'Try `/mcp` or `/mcp status [name]`.');

--- a/cli/v4/greeter/history.ts
+++ b/cli/v4/greeter/history.ts
@@ -62,6 +62,8 @@ export async function readHistory(
       v:               1,
       firstLaunchAt:   typeof parsed.firstLaunchAt   === 'string' ? parsed.firstLaunchAt   : new Date().toISOString(),
       lastGreetingAt:  typeof parsed.lastGreetingAt  === 'string' ? parsed.lastGreetingAt  : new Date().toISOString(),
+      // Optional durable session marker; absent in files written before v4.14.
+      lastSessionAt:   typeof parsed.lastSessionAt   === 'string' ? parsed.lastSessionAt   : undefined,
       lastCwd:         typeof parsed.lastCwd === 'string' ? parsed.lastCwd : undefined,
       offers:          Array.isArray(parsed.offers) ? parsed.offers : [],
       disabled:        parsed.disabled === true,

--- a/cli/v4/greeter/history.ts
+++ b/cli/v4/greeter/history.ts
@@ -64,6 +64,7 @@ export async function readHistory(
       lastGreetingAt:  typeof parsed.lastGreetingAt  === 'string' ? parsed.lastGreetingAt  : new Date().toISOString(),
       // Optional durable session marker; absent in files written before v4.14.
       lastSessionAt:   typeof parsed.lastSessionAt   === 'string' ? parsed.lastSessionAt   : undefined,
+      lastFallbackIndex: typeof parsed.lastFallbackIndex === 'number' ? parsed.lastFallbackIndex : undefined,
       lastCwd:         typeof parsed.lastCwd === 'string' ? parsed.lastCwd : undefined,
       offers:          Array.isArray(parsed.offers) ? parsed.offers : [],
       disabled:        parsed.disabled === true,

--- a/cli/v4/greeter/index.ts
+++ b/cli/v4/greeter/index.ts
@@ -31,6 +31,7 @@ import { readHistory, writeHistory, reconcilePending } from './history';
 import { runScans } from './scan';
 import { selectOffer } from './selectOffer';
 import type { GreeterHistory, Offer } from './types';
+import { readUserName } from '../onboarding/speakFirst';
 
 /**
  * Minimal Display surface the greeter needs. We accept this narrow
@@ -114,6 +115,11 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
   // still shows a real gap instead of the old frozen distillation-mtime value.
   const lastSessionAt = existing.lastSessionAt ?? existing.lastGreetingAt ?? null;
   const distillation = await loadLatestDistillation(opts.paths, fsImpl);
+  // v4.14 Personality L1 — read the stored call-name so the welcome greets by
+  // name (the USE half of onboarding's ask→store→use loop). Derive USER.md from
+  // the paths, tolerating the narrow test-paths shape that only carries `root`.
+  const userMdPath = opts.paths.userMd ?? path.join(opts.paths.root, 'memories', 'USER.md');
+  const userName = await readUserName(userMdPath, fsImpl);
   const offer: Offer | null = selectOffer({
     scan:          scanForReconcile,
     history:       reconciled,
@@ -123,6 +129,7 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
     openItem:      distillation?.openItem,
     lastDecision:  distillation?.lastDecision,
     lastSessionAt,
+    userName,
     // Deterministic per-day rotation for the no-history fallback line.
     rotateSeed:    now.getDate(),
   });

--- a/cli/v4/greeter/index.ts
+++ b/cli/v4/greeter/index.ts
@@ -82,6 +82,7 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
       v:               1,
       firstLaunchAt:   now.toISOString(),
       lastGreetingAt:  now.toISOString(),
+      lastSessionAt:   now.toISOString(),   // durable marker — seeds the NEXT boot's gap
       lastCwd:         cwd,
       offers:          [],
       disabled:        false,
@@ -107,15 +108,23 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
   });
 
   // ── Pick at most one offer to render this boot ----------------------
+  // v4.14 Bug 1 — the durable "previous session" timestamp. `lastSessionAt`
+  // is written every boot; on files predating it, fall back to
+  // `lastGreetingAt` (also rewritten every boot) so the first upgraded boot
+  // still shows a real gap instead of the old frozen distillation-mtime value.
+  const lastSessionAt = existing.lastSessionAt ?? existing.lastGreetingAt ?? null;
   const distillation = await loadLatestDistillation(opts.paths, fsImpl);
   const offer: Offer | null = selectOffer({
-    scan:         scanForReconcile,
-    history:      reconciled,
+    scan:          scanForReconcile,
+    history:       reconciled,
     now,
-    paintMuted:   (s) => opts.display.paint(s, 'muted'),
-    paintAccent:  (s) => c.accent(s),
-    openItem:     distillation?.openItem,
-    lastDecision: distillation?.lastDecision,
+    paintMuted:    (s) => opts.display.paint(s, 'muted'),
+    paintAccent:   (s) => c.accent(s),
+    openItem:      distillation?.openItem,
+    lastDecision:  distillation?.lastDecision,
+    lastSessionAt,
+    // Deterministic per-day rotation for the no-history fallback line.
+    rotateSeed:    now.getDate(),
   });
 
   // ── Render (or stay silent) -----------------------------------------
@@ -125,9 +134,14 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
   }
 
   // ── Persist updated history -----------------------------------------
+  // v4.14 Bug 1 — refresh the durable session marker on EVERY boot. This is
+  // the write that was missing: because the old code leaned on distillation
+  // mtime (rarely written), the gap froze. Session-start is the durable
+  // write point — it always runs, unlike a clean-exit handler.
   const updated: GreeterHistory = {
     ...reconciled,
     lastGreetingAt: now.toISOString(),
+    lastSessionAt:  now.toISOString(),
     lastCwd:        cwd,
     offers: offer
       ? [...reconciled.offers, {

--- a/cli/v4/greeter/index.ts
+++ b/cli/v4/greeter/index.ts
@@ -31,6 +31,7 @@ import { readHistory, writeHistory, reconcilePending } from './history';
 import { runScans } from './scan';
 import { selectOffer } from './selectOffer';
 import type { GreeterHistory, Offer } from './types';
+import { WELCOME_FALLBACKS } from './welcomeLine';
 import { readUserName } from '../onboarding/speakFirst';
 
 /**
@@ -120,6 +121,11 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
   // the paths, tolerating the narrow test-paths shape that only carries `root`.
   const userMdPath = opts.paths.userMd ?? path.join(opts.paths.root, 'memories', 'USER.md');
   const userName = await readUserName(userMdPath, fsImpl);
+  // v4.14 — round-robin the warm fallback so it never repeats the previous
+  // boot's line. Advance from the persisted index (wrapping the pool).
+  const nextFallbackIndex =
+    (((existing.lastFallbackIndex ?? -1) + 1) % WELCOME_FALLBACKS.length + WELCOME_FALLBACKS.length)
+    % WELCOME_FALLBACKS.length;
   const offer: Offer | null = selectOffer({
     scan:          scanForReconcile,
     history:       reconciled,
@@ -130,9 +136,10 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
     lastDecision:  distillation?.lastDecision,
     lastSessionAt,
     userName,
-    // Deterministic per-day rotation for the no-history fallback line.
-    rotateSeed:    now.getDate(),
+    fallbackIndex: nextFallbackIndex,
   });
+  // Only persist the advance when the fallback actually fired this boot.
+  const fallbackFired = offer?.id.startsWith('welcome-fallback-') === true;
 
   // ── Render (or stay silent) -----------------------------------------
   if (offer) {
@@ -149,6 +156,7 @@ async function renderGreeterUnsafe(opts: RenderGreeterOptions): Promise<void> {
     ...reconciled,
     lastGreetingAt: now.toISOString(),
     lastSessionAt:  now.toISOString(),
+    lastFallbackIndex: fallbackFired ? nextFallbackIndex : reconciled.lastFallbackIndex,
     lastCwd:        cwd,
     offers: offer
       ? [...reconciled.offers, {

--- a/cli/v4/greeter/selectOffer.ts
+++ b/cli/v4/greeter/selectOffer.ts
@@ -61,6 +61,9 @@ export interface SelectOfferInput {
   lastSessionAt?: string | null;
   /** v4.14 Bug 1 — deterministic rotation seed for the no-history fallback. */
   rotateSeed?:    number;
+  /** v4.14 Personality L1 — the user's stored call-name, so the welcome
+   *  greets them by name. Read from USER.md by the orchestrator. */
+  userName?:      string | null;
 }
 
 export function selectOffer(input: SelectOfferInput): Offer | null {
@@ -88,6 +91,7 @@ export function selectOffer(input: SelectOfferInput): Offer | null {
       now:           input.now,
       lastSessionAt: input.lastSessionAt ?? null,
       recallSummary,
+      userName:      input.userName ?? null,
       paintMuted:    input.paintMuted,
       paintAccent:   input.paintAccent,
       rotateSeed:    input.rotateSeed,

--- a/cli/v4/greeter/selectOffer.ts
+++ b/cli/v4/greeter/selectOffer.ts
@@ -31,6 +31,7 @@ import {
   WELCOME_BACK_THRESHOLD_HOURS,
 } from './types';
 import { TEMPLATES } from './templates';
+import { buildWelcomeLine } from './welcomeLine';
 
 /**
  * The selector takes a `paint` bag rather than building one — keeps the
@@ -51,6 +52,15 @@ export interface SelectOfferInput {
   openItem?:      string | null;
   /** Most-recent distillation's decisions[0] (or null when none). */
   lastDecision?:  string | null;
+  /**
+   * v4.14 Bug 1 — the durable "previous session" timestamp (ISO-8601) or
+   * null. This is the RELIABLE basis for the welcome-back time-gap; the old
+   * distillation-mtime path (scan.hoursSinceLastSession) froze on a stale
+   * value. Supplied by the orchestrator from history.lastSessionAt.
+   */
+  lastSessionAt?: string | null;
+  /** v4.14 Bug 1 — deterministic rotation seed for the no-history fallback. */
+  rotateSeed?:    number;
 }
 
 export function selectOffer(input: SelectOfferInput): Offer | null {
@@ -59,30 +69,35 @@ export function selectOffer(input: SelectOfferInput): Offer | null {
 
   const today = isoDateLocal(input.now);
 
-  // ── Tier 2: continuity ----------------------------------------------
-  // The orchestrator wires open_items + decisions from the most-recent
-  // distillation. Prefer open-item over decision (open work is more
-  // actionable; closed decisions are recap).
-  if (input.openItem && input.openItem.length > 0) {
-    return buildOffer('continuity-open-item', 2, undefined, {
-      openItem: input.openItem,
-    }, input);
-  }
-  if (input.lastDecision && input.lastDecision.length > 0) {
-    return buildOffer('continuity-decision', 2, undefined, {
-      decision: input.lastDecision,
-    }, input);
-  }
-
-  // welcome-back: always fires when hoursSinceLastSession >= 24, no
-  // decay. (Per dispatch: not really an offer — a continuity signal.)
-  if (
-    input.scan.hoursSinceLastSession !== null &&
-    input.scan.hoursSinceLastSession >= WELCOME_BACK_THRESHOLD_HOURS
-  ) {
-    return buildOffer('welcome-back', 2, undefined, {
-      hoursAgo: input.scan.hoursSinceLastSession,
-    }, input);
+  // ── Tier 2: welcome / continuity ------------------------------------
+  // v4.14 Bug 1 — one warm, recall-aware line via the pure buildWelcomeLine,
+  // replacing the three old templates (continuity-open-item /
+  // continuity-decision / the raw-hours welcome-back). It fires when EITHER:
+  //   • a recall summary exists (open item preferred over last decision —
+  //     open work is more actionable), regardless of elapsed time, OR
+  //   • the durable last-session gap has crossed the welcome threshold.
+  // The gap is computed from history.lastSessionAt (reliable), NOT the
+  // frozen distillation mtime that caused the stuck "934h ago".
+  const recallSummary =
+    (input.openItem && input.openItem.length > 0) ? input.openItem :
+    (input.lastDecision && input.lastDecision.length > 0) ? input.lastDecision :
+    null;
+  const gapHours = hoursSince(input.lastSessionAt ?? null, input.now);
+  if (recallSummary || (gapHours !== null && gapHours >= WELCOME_BACK_THRESHOLD_HOURS)) {
+    const speech = buildWelcomeLine({
+      now:           input.now,
+      lastSessionAt: input.lastSessionAt ?? null,
+      recallSummary,
+      paintMuted:    input.paintMuted,
+      paintAccent:   input.paintAccent,
+      rotateSeed:    input.rotateSeed,
+    });
+    return {
+      id:         `welcome-back-${today}`,
+      templateId: 'welcome-back',
+      tier:       2,
+      speech,
+    };
   }
 
   // ── Tier 3: environment ---------------------------------------------
@@ -138,6 +153,18 @@ function isDecayedRecently(
     o.response === 'ignored' &&
     Date.parse(o.offeredAt) >= cutoffMs,
   );
+}
+
+/**
+ * Elapsed hours since an ISO-8601 timestamp, or null when the timestamp is
+ * missing / unparseable. v4.14 Bug 1 — drives the welcome-back time gate off
+ * the durable last-session marker instead of the frozen distillation mtime.
+ */
+function hoursSince(iso: string | null, now: Date): number | null {
+  if (!iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+  return Math.max(0, (now.getTime() - then) / (1000 * 60 * 60));
 }
 
 /** YYYY-MM-DD in the local timezone (matches the "good evening at 6pm

--- a/cli/v4/greeter/selectOffer.ts
+++ b/cli/v4/greeter/selectOffer.ts
@@ -61,6 +61,11 @@ export interface SelectOfferInput {
   lastSessionAt?: string | null;
   /** v4.14 Bug 1 — deterministic rotation seed for the no-history fallback. */
   rotateSeed?:    number;
+  /**
+   * v4.14 — explicit round-robin index for the warm fallback greeting, chosen
+   * by the orchestrator so it never repeats the previous boot's line.
+   */
+  fallbackIndex?: number;
   /** v4.14 Personality L1 — the user's stored call-name, so the welcome
    *  greets them by name. Read from USER.md by the orchestrator. */
   userName?:      string | null;
@@ -134,7 +139,27 @@ export function selectOffer(input: SelectOfferInput): Offer | null {
     }
   }
 
-  return null;  // silence rule
+  // ── Tier 5: warm fallback -------------------------------------------
+  // v4.14 — nothing specific to say, but boot shouldn't feel canned or cold.
+  // Show a short, warm line that ROTATES (never the previous boot's line — the
+  // orchestrator supplies a persisted round-robin `fallbackIndex`). First-ever
+  // launch stays silent (the orchestrator returns before selectOffer runs) and
+  // `/greeter off` is honoured at the top; otherwise a returning user always
+  // gets a friendly hello instead of the old silence.
+  return {
+    id:         `welcome-fallback-${today}`,
+    templateId: 'welcome-back',
+    tier:       4,
+    speech: buildWelcomeLine({
+      now:           input.now,
+      lastSessionAt: null,
+      recallSummary: null,
+      paintMuted:    input.paintMuted,
+      paintAccent:   input.paintAccent,
+      fallbackIndex: input.fallbackIndex,
+      rotateSeed:    input.rotateSeed,
+    }),
+  };
 }
 
 // ── helpers ----------------------------------------------------------

--- a/cli/v4/greeter/templates.ts
+++ b/cli/v4/greeter/templates.ts
@@ -56,7 +56,10 @@ export const TEMPLATES: Record<TemplateId, (ctx: TemplateContext) => string> = {
   },
 
   // ── Tier 4 (update) --------------------------------------------------
+  // v4.14 — personified, advisory voice (tell, don't auto-update; the user
+  // stays in control, same discipline as skill freshness). Reuses the boot
+  // update-check cache via the greeter's scanUpdate — no new network path.
   'update-available': (ctx) =>
-    `aiden-runtime ${ctx.installed ?? '?'} → ${ctx.latest ?? '?'} available. ` +
-    `${ctx.paintAccent('/update install')} to ship.`,
+    `There's a newer version of me available (${ctx.installed ?? '?'} → ${ctx.latest ?? '?'}). ` +
+    `Run ${ctx.paintAccent('/update install')} to upgrade — or just say the word.`,
 };

--- a/cli/v4/greeter/types.ts
+++ b/cli/v4/greeter/types.ts
@@ -124,6 +124,23 @@ export interface GreeterHistory {
   v:               1;
   firstLaunchAt:   string;          // ISO-8601 — never mutated after first write
   lastGreetingAt:  string;          // ISO-8601 — updated on every renderGreeter call
+  /**
+   * ISO-8601 — the durable "last real session" marker. Written = now on
+   * EVERY boot (session start), so on the NEXT boot the value read here is
+   * the previous session's start time — the reliable basis for the
+   * "welcome back" time-gap. Session-start is chosen over clean-exit because
+   * boot always happens; an exit handler can be skipped by a crash, a
+   * `kill -9`, or a closed terminal. Optional for back-compat: files written
+   * before this field existed fall back to `lastGreetingAt` (which the
+   * greeter has always rewritten every boot).
+   *
+   * Bug-fix note (v4.14): the pre-fix greeter derived "hours since last
+   * session" from the newest distillation file's mtime — a value that only
+   * refreshes when a distillation is written, NOT on ordinary use. That made
+   * the banner freeze on a stale number ("934h ago") every boot. This field
+   * is the durable replacement.
+   */
+  lastSessionAt?:  string;
   lastCwd?:        string;
   offers:          GreeterOfferRecord[];
   /** Kill switch from /greeter off. Defaults to false. */

--- a/cli/v4/greeter/types.ts
+++ b/cli/v4/greeter/types.ts
@@ -142,6 +142,12 @@ export interface GreeterHistory {
    */
   lastSessionAt?:  string;
   lastCwd?:        string;
+  /**
+   * v4.14 — index of the LAST warm fallback greeting shown. The orchestrator
+   * advances it round-robin each time the fallback fires so boot never shows
+   * the same canned line twice running. Absent until the first fallback.
+   */
+  lastFallbackIndex?: number;
   offers:          GreeterOfferRecord[];
   /** Kill switch from /greeter off. Defaults to false. */
   disabled:        boolean;

--- a/cli/v4/greeter/welcomeLine.ts
+++ b/cli/v4/greeter/welcomeLine.ts
@@ -39,6 +39,12 @@ export interface WelcomeLineContext {
    * the recall tier.
    */
   recallSummary:  string | null;
+  /**
+   * v4.14 Personality L1 — the user's stored call-name (from USER.md), or null.
+   * When set, the welcome addresses them by name ("Welcome back, Shiva"). This
+   * is the USE half of onboarding's ask→store→use loop.
+   */
+  userName?:      string | null;
   paintMuted:     (s: string) => string;
   paintAccent:    (s: string) => string;
   /**
@@ -99,18 +105,22 @@ export function humanGap(lastSessionAt: string | null, now: Date): string | null
  * greeter chooses to show it (vs stay silent) is the orchestrator's call.
  */
 export function buildWelcomeLine(ctx: WelcomeLineContext): string {
+  // Personality L1 — greet by name when we know it: "Welcome back, Shiva".
+  const name = ctx.userName && ctx.userName.trim().length > 0 ? ctx.userName.trim() : null;
+  const back = name ? `Welcome back, ${name}` : 'Welcome back';
+
   // ── Tier 1: recall-aware ────────────────────────────────────────────
   const summary = ctx.recallSummary && ctx.recallSummary.trim().length > 0
     ? oneLine(ctx.recallSummary)
     : null;
   if (summary) {
-    return `Welcome back! Last time: ${ctx.paintMuted(summary)}. Continue, or something new?`;
+    return `${back}! Last time: ${ctx.paintMuted(summary)}. Continue, or something new?`;
   }
 
   // ── Tier 2: human time-gap ──────────────────────────────────────────
   const gap = humanGap(ctx.lastSessionAt, ctx.now);
   if (gap) {
-    return `Welcome back — ${gapSentence(gap)}`;
+    return `${back} — ${gapSentence(gap)}`;
   }
 
   // ── Tier 3: rotate a friendly fallback ──────────────────────────────

--- a/cli/v4/greeter/welcomeLine.ts
+++ b/cli/v4/greeter/welcomeLine.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/greeter/welcomeLine.ts — v4.14 UX polish (Bug 1).
+ *
+ * The warm, recall-aware "welcome back" line. Replaces the old raw-hours
+ * template ("Last session ended 934h ago") with a single PURE function:
+ * identical ctx in ⇒ identical string out. No clock peek (now is a param),
+ * no IO, no randomness — the fallback rotation is a deterministic function
+ * of `rotateSeed`.
+ *
+ * Three tiers, in priority order:
+ *   1. RECALL  — a one-line summary of last session is known:
+ *        "Welcome back! Last time: <summary>. Continue, or something new?"
+ *   2. TIME-GAP — no summary, but a durable last-session timestamp exists.
+ *        A HUMAN phrase only (never raw hours): earlier today / yesterday /
+ *        a few days ago / last week / been a while (30d+).
+ *   3. FALLBACK — no useful history at all → a short friendly line, rotated
+ *        by `rotateSeed` so it isn't the same string every boot.
+ *
+ * One logical line. Width-safe (the recall summary is clamped). ≤1 emoji.
+ */
+
+export interface WelcomeLineContext {
+  /** The reference clock. */
+  now:            Date;
+  /**
+   * ISO-8601 timestamp of the PREVIOUS session (durable marker), or null
+   * when unknown. Drives the time-gap tier.
+   */
+  lastSessionAt:  string | null;
+  /**
+   * One-line title/summary of what last session was about (from the newest
+   * distillation's open item or last decision), or null when none. Drives
+   * the recall tier.
+   */
+  recallSummary:  string | null;
+  paintMuted:     (s: string) => string;
+  paintAccent:    (s: string) => string;
+  /**
+   * Deterministic rotation index for the no-history fallback. Same seed ⇒
+   * same friendly line; a changing seed (e.g. day-of-month) rotates it.
+   * Defaults to 0.
+   */
+  rotateSeed?:    number;
+}
+
+/** Max width for the recalled summary before it's clamped with an ellipsis. */
+const SUMMARY_MAX = 60;
+
+/**
+ * No-history friendly lines. Short, Aiden's voice, width-safe, ≤1 emoji.
+ * Rotated deterministically by rotateSeed so the greeter doesn't say the
+ * exact same thing every single boot.
+ */
+export const WELCOME_FALLBACKS: readonly string[] = [
+  'Ready when you are.',
+  "Let's build something.",
+  'What are we working on?',
+  'Fresh start — where to?',
+];
+
+/** Collapse whitespace/newlines to a single line and clamp the width. */
+function oneLine(s: string): string {
+  const flat = s.replace(/\s+/g, ' ').trim();
+  if (flat.length <= SUMMARY_MAX) return flat;
+  return flat.slice(0, SUMMARY_MAX - 1).trimEnd() + '…';
+}
+
+/**
+ * Human phrase for an elapsed gap. Bucketed purely by elapsed duration
+ * (NOT calendar boundaries) so the mapping is deterministic and matches the
+ * documented contract: 23h → "earlier today", 40d → "been a while".
+ *
+ * Returns null when the timestamp is missing or unparseable (caller then
+ * falls through to the rotate tier rather than inventing a gap).
+ */
+export function humanGap(lastSessionAt: string | null, now: Date): string | null {
+  if (!lastSessionAt) return null;
+  const then = Date.parse(lastSessionAt);
+  if (Number.isNaN(then)) return null;
+  const ms = now.getTime() - then;
+  if (ms < 0) return 'earlier today';                 // clock skew → safest phrase
+  const hours = ms / (1000 * 60 * 60);
+  const days  = hours / 24;
+  if (hours < 24) return 'earlier today';
+  if (hours < 48) return 'yesterday';
+  if (days  < 7)  return 'a few days ago';
+  if (days  < 30) return 'last week';
+  return 'been a while';
+}
+
+/**
+ * Build the one-line welcome. Always returns a non-empty line; WHEN the
+ * greeter chooses to show it (vs stay silent) is the orchestrator's call.
+ */
+export function buildWelcomeLine(ctx: WelcomeLineContext): string {
+  // ── Tier 1: recall-aware ────────────────────────────────────────────
+  const summary = ctx.recallSummary && ctx.recallSummary.trim().length > 0
+    ? oneLine(ctx.recallSummary)
+    : null;
+  if (summary) {
+    return `Welcome back! Last time: ${ctx.paintMuted(summary)}. Continue, or something new?`;
+  }
+
+  // ── Tier 2: human time-gap ──────────────────────────────────────────
+  const gap = humanGap(ctx.lastSessionAt, ctx.now);
+  if (gap) {
+    return `Welcome back — ${gapSentence(gap)}`;
+  }
+
+  // ── Tier 3: rotate a friendly fallback ──────────────────────────────
+  const seed = Number.isFinite(ctx.rotateSeed) ? Math.abs(Math.trunc(ctx.rotateSeed as number)) : 0;
+  return WELCOME_FALLBACKS[seed % WELCOME_FALLBACKS.length];
+}
+
+/**
+ * Wrap a bucket phrase in a natural sentence tail. Each tail CONTAINS the
+ * canonical phrase verbatim so downstream copy checks stay stable.
+ */
+function gapSentence(gap: string): string {
+  switch (gap) {
+    case 'earlier today':  return 'you were here earlier today.';
+    case 'yesterday':      return 'last session was yesterday.';
+    case 'a few days ago': return 'last time was a few days ago.';
+    case 'last week':      return 'last session was last week.';
+    default:               return "it's been a while.";      // 'been a while'
+  }
+}

--- a/cli/v4/greeter/welcomeLine.ts
+++ b/cli/v4/greeter/welcomeLine.ts
@@ -50,9 +50,15 @@ export interface WelcomeLineContext {
   /**
    * Deterministic rotation index for the no-history fallback. Same seed ⇒
    * same friendly line; a changing seed (e.g. day-of-month) rotates it.
-   * Defaults to 0.
+   * Defaults to 0. Superseded by `fallbackIndex` when that is supplied.
    */
   rotateSeed?:    number;
+  /**
+   * v4.14 — an explicit index into WELCOME_FALLBACKS, chosen by the
+   * orchestrator to never repeat the previous boot's line (persisted round-
+   * robin). Takes precedence over `rotateSeed`. Out-of-range values wrap.
+   */
+  fallbackIndex?: number;
 }
 
 /** Max width for the recalled summary before it's clamped with an ellipsis. */
@@ -67,7 +73,11 @@ export const WELCOME_FALLBACKS: readonly string[] = [
   'Ready when you are.',
   "Let's build something.",
   'What are we working on?',
-  'Fresh start — where to?',
+  'Back at it — where to?',
+  "Good to see you. What's the plan?",
+  'Standing by — point me at it.',
+  "Fresh page. What's first?",
+  "Right here when you need me. Let's go.",
 ];
 
 /** Collapse whitespace/newlines to a single line and clamp the width. */
@@ -123,9 +133,16 @@ export function buildWelcomeLine(ctx: WelcomeLineContext): string {
     return `${back} — ${gapSentence(gap)}`;
   }
 
-  // ── Tier 3: rotate a friendly fallback ──────────────────────────────
-  const seed = Number.isFinite(ctx.rotateSeed) ? Math.abs(Math.trunc(ctx.rotateSeed as number)) : 0;
-  return WELCOME_FALLBACKS[seed % WELCOME_FALLBACKS.length];
+  // ── Tier 3: warm, non-repeating fallback ────────────────────────────
+  // Prefer the orchestrator's explicit round-robin index (never repeats the
+  // previous boot); fall back to the deterministic seed, then 0.
+  const n = WELCOME_FALLBACKS.length;
+  const idx = Number.isFinite(ctx.fallbackIndex)
+    ? ((Math.trunc(ctx.fallbackIndex as number) % n) + n) % n
+    : Number.isFinite(ctx.rotateSeed)
+      ? Math.abs(Math.trunc(ctx.rotateSeed as number)) % n
+      : 0;
+  return WELCOME_FALLBACKS[idx];
 }
 
 /**

--- a/cli/v4/onboarding/speakFirst.ts
+++ b/cli/v4/onboarding/speakFirst.ts
@@ -5,44 +5,70 @@
  * Aiden — local-first agent.
  */
 /**
- * cli/v4/onboarding/speakFirst.ts — v4.12 speaks-first onboarding.
+ * cli/v4/onboarding/speakFirst.ts — v4.12 speaks-first onboarding,
+ * v4.14 Personality Layer 1: first-meeting name capture that CLOSES the loop.
  *
- * For a BRAND-NEW user, Aiden opens the first REPL session with a short,
- * utility-framed intro asking their name + what they're working on. The
- * user's reply is then honestly extracted into the existing USER.md store
- * (the model saves ONLY stated facts via memory_add(file:'user'); the
- * extraction nudge lives in core/v4/promptBuilder.ts, gated on an empty
- * USER.md). USER.md is already injected into context every turn, so from
- * the next session on, Aiden knows the user.
+ * On the very first REPL session, Aiden introduces itself and asks ONE thing —
+ * what to call you — then STORES the answer to USER.md via the existing memory
+ * write path (memory.add('user', …)), the same store the `memory_add` tool
+ * uses. Because USER.md is injected into the system prompt (promptBuilder), the
+ * name is available to the model from the next prompt build, and the boot
+ * greeter (buildWelcomeLine) reads it back to greet by name on later boots.
+ * Ask → store → USE. Not theater.
  *
- * Personalization, NOT companionship: the copy is warm-but-professional —
- * a good colleague's first hello — framed around working better together,
- * never emotional/intimacy framing. Stored facts are work-relevant
- * (name, projects, conventions), never feelings.
+ * Trigger guard (same bug class as the wizard config-detection fix): onboard
+ * ONLY when the marker is absent AND USER.md is empty. An existing user (marker
+ * present OR a non-empty USER.md) is NEVER re-onboarded.
  *
- * Trigger guard (same bug class as the wizard config-detection fix):
- * onboard ONLY when the marker is absent AND USER.md is empty. An existing
- * user (marker present OR a non-empty USER.md) is NEVER re-onboarded.
- * Mirrors the firstRunHint marker-idempotency pattern.
+ * No-hang contract: the whole intro is gated on an interactive OUTPUT tty, and
+ * the name question is only read when STDIN is a tty — a piped / daemon / test
+ * run reads nothing and proceeds gracefully (no store, marker set, no re-ask).
+ *
+ * Personalization, NOT companionship: calm-and-capable with a warm edge — a
+ * good colleague's first hello. Never bubbly, never robotic, never emotional.
  */
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { createInterface } from 'node:readline/promises';
 
 import { c } from '../../../core/v4/ui/theme';
 import type { AidenPaths } from '../../../core/v4/paths';
 
 const MARKER_NAME = '.onboarding-shown';
+/** Keep a captured name short — it's a call-name, not a bio. */
+const NAME_MAX = 40;
+
+function markerPath(paths: AidenPaths): string {
+  return path.join(paths.root, MARKER_NAME);
+}
+
+/** The minimal memory writer onboarding needs — satisfied by MemoryManager. */
+export interface OnboardingMemory {
+  add(file: string, content: string): Promise<{ ok: boolean }>;
+}
 
 export interface OnboardingOptions {
   paths:  AidenPaths;
   out?:   NodeJS.WriteStream;
   /** Injectable fs for tests. */
   fsImpl?: typeof fs;
-}
-
-function markerPath(paths: AidenPaths): string {
-  return path.join(paths.root, MARKER_NAME);
+  /** Injectable stdin for tests. Default: process.stdin. */
+  input?:  NodeJS.ReadStream;
+  /**
+   * Reuse the real memory store. When provided AND a name is captured, the
+   * name is written via `memory.add('user', …)`. Omitted in harness sessions
+   * that don't wire memory — onboarding then still runs, just doesn't persist.
+   */
+  memory?: OnboardingMemory;
+  /**
+   * Read the user's one-line answer (the question is already printed by the
+   * intro, so this just captures a line). Injectable for tests. Default: a
+   * transient readline on `input` — but ONLY when `input.isTTY`; otherwise
+   * returns null immediately so onboarding never blocks on a non-interactive
+   * stdin.
+   */
+  readAnswer?: () => Promise<string | null>;
 }
 
 /** True when the onboarding marker exists (already onboarded). */
@@ -68,8 +94,7 @@ async function isUserProfileEmpty(paths: AidenPaths, fsImpl: typeof fs = fs): Pr
 /**
  * Onboard ONLY a brand-new user: marker absent AND USER.md empty. Never
  * re-onboards (marker present) and never onboards a user who already has a
- * profile (non-empty USER.md) — the trigger guard that keeps this off the
- * config-detection-bug class.
+ * profile (non-empty USER.md).
  */
 export async function shouldOnboard(paths: AidenPaths, fsImpl: typeof fs = fs): Promise<boolean> {
   if (await isOnboardingShown(paths, fsImpl)) return false;
@@ -86,27 +111,123 @@ export async function markOnboardingShown(paths: AidenPaths, fsImpl: typeof fs =
   }
 }
 
+// ── name capture ─────────────────────────────────────────────────────────────
+
 /**
- * Aiden speaks first for a brand-new user. Returns true when the intro was
- * painted (so the caller can skip the /walkthrough tip to avoid clutter).
- * Mark-on-render + idempotent: paints at most once, never for an existing
- * user, and never on a non-TTY caller (no interactive reply to extract).
+ * Extract a clean call-name from a free-form answer. Strips common lead-ins
+ * ("I'm", "my name is", "call me"…) and surrounding quotes/punctuation, caps
+ * the length. Returns null when nothing usable remains (empty / skipped).
+ */
+export function normalizeOnboardingName(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let s = raw.replace(/[\r\n]+/g, ' ').trim();
+  s = s.replace(/^(?:i['’]?m|i am|my name is|call me|it['’]?s|this is|name['’]?s)\s+/i, '').trim();
+  s = s.replace(/^["'`]+/, '').replace(/["'`.,!?]+$/, '').trim();
+  if (!s) return null;
+  if (s.length > NAME_MAX) s = s.slice(0, NAME_MAX).trim();
+  return s || null;
+}
+
+/** The stored name line. Single source of truth for the write AND the read. */
+export function onboardingNameEntry(name: string): string {
+  return `User's name is ${name}. (source: onboarding)`;
+}
+
+/** Parse the stored call-name back out of USER.md content. null if absent. */
+export function parseUserName(userMdContent: string): string | null {
+  const m = /User's name is\s+(.+?)\s*\.\s*(?:\(source:[^)]*\))?/i.exec(userMdContent);
+  if (!m) return null;
+  const name = m[1].trim();
+  return name.length > 0 ? name : null;
+}
+
+/** Read the stored user name from USER.md. Never throws; null when unset. */
+export async function readUserName(userMdPath: string, fsImpl: typeof fs = fs): Promise<string | null> {
+  try {
+    return parseUserName(await fsImpl.readFile(userMdPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default one-line reader: a transient readline on `input`, used ONLY when
+ * `input.isTTY`. On a non-interactive stdin (piped / daemon / test) it returns
+ * null immediately — the no-hang guarantee. The interface is closed on every
+ * path so stdin is left clean for the REPL that starts afterwards.
+ */
+function defaultReadAnswer(
+  input: NodeJS.ReadStream,
+  out:   NodeJS.WriteStream,
+): () => Promise<string | null> {
+  return async () => {
+    if (!input.isTTY) return null;
+    const rl = createInterface({ input, output: out });
+    try {
+      // The question is already on screen (written by the intro); read a line
+      // with an empty prompt so readline doesn't re-print anything.
+      return await rl.question('');
+    } catch {
+      return null;
+    } finally {
+      rl.close();
+    }
+  };
+}
+
+/**
+ * Aiden speaks first for a brand-new user: a calm intro + ONE question (the
+ * name), stored to USER.md. Returns true when the intro was shown (so the
+ * caller skips the /walkthrough tip AND the boot greeter — the intro owns the
+ * first screen). Idempotent + guarded: shows at most once, never for an
+ * existing user, never on a non-TTY caller.
  */
 export async function renderOnboardingIntro(opts: OnboardingOptions): Promise<boolean> {
-  const out    = opts.out ?? process.stdout;
+  const out    = opts.out    ?? process.stdout;
   const fsImpl = opts.fsImpl ?? fs;
+  const input  = opts.input  ?? process.stdin;
   if (!out.isTTY) return false;
   if (!(await shouldOnboard(opts.paths, fsImpl))) return false;
 
-  // Utility-framed, warm-but-professional. No feelings/intimacy framing.
-  const intro = [
-    '',
-    `  ${c.accent("Hi — I'm Aiden.")} ${c.muted("I'll work better if I know a bit about you.")}`,
-    `  ${c.muted('What should I call you, and what are you working on?')}`,
-    '',
-  ].join('\n');
-  out.write(intro + '\n');
+  // Calm-and-capable, warm edge. Local-first framing; no feelings/intimacy.
+  // One question only — just the name. Light, optional. The question is
+  // written HERE (not by the reader) so it's always on screen, whichever
+  // reader captures the line.
+  out.write(
+    '\n' +
+    `  ${c.accent("Hi — I'm Aiden.")} ` +
+    `${c.muted("I run right here on your machine, and I'll remember what matters as we work.")}\n\n` +
+    '  What should I call you? ',
+  );
+
+  const read = opts.readAnswer ?? defaultReadAnswer(input, out);
+  let name: string | null = null;
+  try {
+    name = normalizeOnboardingName(await read());
+  } catch {
+    name = null;   // reader fault → graceful no-name
+  }
+  out.write('\n');   // close the question line before the acknowledgement
+
+  // Mark shown BEFORE the store so a store failure can never trigger a re-ask.
   await markOnboardingShown(opts.paths, fsImpl);
+
+  if (name && opts.memory) {
+    let stored = false;
+    try {
+      stored = (await opts.memory.add('user', onboardingNameEntry(name))).ok === true;
+    } catch {
+      stored = false;   // store best-effort; never crash boot
+    }
+    out.write(
+      stored
+        ? `  ${c.muted(`Good to meet you, ${name}. I'll remember that.`)}\n\n`
+        : `  ${c.muted(`Good to meet you, ${name}.`)}\n\n`,
+    );
+  } else {
+    // Skipped / empty / non-interactive → graceful, no store, never re-asks.
+    out.write(`  ${c.muted("No problem — just say the word when you're ready.")}\n\n`);
+  }
   return true;
 }
 

--- a/core/v4/config.ts
+++ b/core/v4/config.ts
@@ -34,7 +34,7 @@ import yaml from 'js-yaml';
 
 import type { AidenPaths } from './paths';
 import type { ConfigProvider } from '../../providers/v4/runtimeResolver';
-import { type AutonomyLevel, isAutonomyLevel, levelFromApprovalMode } from '../../moat/autonomy';
+import { type AutonomyLevel, isAutonomyLevel } from '../../moat/autonomy';
 
 export type ApprovalMode = 'manual' | 'smart' | 'off';
 
@@ -207,17 +207,34 @@ function setDotted(obj: Record<string, unknown>, key: string, value: unknown): v
 
 /**
  * v4.12.1 Pillar 2 — resolve the configured autonomy level. Explicit
- * `agent.autonomy` wins; otherwise derive from `approval_mode` (back-compat,
- * → 'Assistant'). Invalid values fall back to the derived default rather than
- * throwing — a typo must never silently RAISE autonomy.
+ * `agent.autonomy` wins; a typo must never silently RAISE autonomy, so an
+ * invalid value falls through to the default rather than throwing.
+ *
+ * v4.14 UX (Bug 2) — the DEFAULT is now `Partner`, not `Assistant`.
+ *
+ * Why: the old default (Assistant, `allowWrite: 'ask'`) prompted on EVERY
+ * write, including routine safe/reversible workspace-internal writes and
+ * moves — the "asks too often" nag that trains blind-yes. `Partner` is the
+ * level the dial already defines as "acts freely INSIDE the workspace;
+ * destructive + external-send + out-of-scope still ask." It auto-allows only
+ * the genuinely-safe class and KEEPS EVERY FLOOR intact (destructive,
+ * external send, spend, shell, out-of-workspace all still ask; the hard-block
+ * set still denies). Choosing Partner-as-default — rather than loosening
+ * Assistant (which would collapse two distinct levels into one) — keeps all
+ * three levels meaningful: Observer (read-only) < Assistant (asks at every
+ * write) < Partner (workspace writes auto). No floor is touched.
+ *
+ * A user who explicitly opted into the cautious `approval_mode: manual` is
+ * respected → Assistant (asks at every write boundary). Everything else
+ * (smart / off / unset) → Partner.
  */
 export function resolveConfiguredAutonomyLevel(config: {
   getValue<T = unknown>(key: string, fallback?: T): T;
 }): AutonomyLevel {
   const raw = config.getValue<string | undefined>('agent.autonomy', undefined);
   if (isAutonomyLevel(raw)) return raw;
-  const mode = config.getValue<'manual' | 'smart' | 'off'>('agent.approval_mode', 'smart');
-  return levelFromApprovalMode(mode);
+  const mode = config.getValue<'manual' | 'smart' | 'off' | undefined>('agent.approval_mode', undefined);
+  return mode === 'manual' ? 'Assistant' : 'Partner';
 }
 
 export class ConfigManager implements ConfigProvider {

--- a/core/v4/failureClassifier.ts
+++ b/core/v4/failureClassifier.ts
@@ -54,6 +54,7 @@
 
 import type { ToolCallResult } from '../../providers/v4/types';
 import type { VerificationResult } from './verifier';
+import { readAuthRequired } from './mcp/authRequired';
 
 // ── Public types ────────────────────────────────────────────────────────────
 
@@ -171,6 +172,23 @@ export class FailureClassifier {
     result:       ToolCallResult,
   ): ClassificationResult | null {
     if (verification.ok) return null;
+    // v4.14 — GLOBAL pre-check: a typed `auth_required` envelope (from ANY tool,
+    // e.g. an MCP call whose token died and couldn't refresh) is an auth wall.
+    // Classify it as NON-RECOVERABLE auth so recovery never blind-retries it —
+    // this is the anti-fake-success guarantee, robust where the substring auth
+    // patterns below are not (the old raw "needs re-authorization" string
+    // matched none of them and fell through to `other`/recoverable).
+    const authEnv = readAuthRequired(result);
+    if (authEnv) {
+      return {
+        category:    'auth',
+        confidence:  0.99,
+        reason:      `needs reauth for ${authEnv.provider}`,
+        recoverable: false,
+        recoveryHint: { action: 'request_user_action', detail: authEnv.reauth_hint || `re-authorize ${authEnv.provider}` },
+        matchedPattern: 'auth_required',
+      };
+    }
     return this.resolve(toolName)(verification, toolName, args, result);
   }
 }

--- a/core/v4/mcp/authRequired.ts
+++ b/core/v4/mcp/authRequired.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * core/v4/mcp/authRequired.ts — v4.14: the typed `auth_required` tool result.
+ *
+ * DESIGN NORTH STAR: auth is RUNTIME infrastructure, not setup-only. A token
+ * can die mid-task. The worst bug is an autonomous job hitting expired auth,
+ * refresh failing, a RAW 401 coming back, the model reading it as transient,
+ * and writing "done" when the remote action never happened — a fake-success,
+ * the exact disease verify-before-done exists to kill.
+ *
+ * So an unrecoverable auth failure must be a TYPED, first-class RESULT the
+ * runtime understands — never a raw exception the model can misread. This
+ * module defines that result. It carries `success: false` so the per-tool
+ * verifier (core/v4/verifier.ts) flags it `failed`, and a structured
+ * `auth_required` envelope the failure classifier (core/v4/failureClassifier.ts)
+ * reads to return a NON-RECOVERABLE `auth` category. Because the failure is on a
+ * mutating tool and verifier-!ok, decideTaskVerdict (core/v4/taskVerification.ts)
+ * returns `verification_failed` — the task cannot reach `completed`; it surfaces
+ * "needs reauth for <provider>" instead. Same shape as the `sandbox_violation`
+ * typed envelope; provider-agnostic.
+ */
+
+import type { ToolCallResult } from '../../../providers/v4/types';
+
+/** The structured auth-failure envelope. `retryable` is always false — an auth
+ *  wall never clears on a blind retry; the user must re-authorize. */
+export interface McpAuthRequiredEnvelope {
+  error:       'auth_required';
+  /** Which connection needs re-auth (the MCP server / provider name). */
+  provider:    string;
+  /** Short machine/human reason (token revoked, refresh failed, expired…). */
+  reason:      string;
+  /** ALWAYS false — never blind-retry an auth wall. */
+  retryable:   false;
+  /** Exact next action for the user (e.g. "Run /mcp auth github"). */
+  reauth_hint: string;
+}
+
+/** The tool result the runtime returns instead of a raw 401. */
+export interface AuthRequiredToolResult {
+  success:       false;
+  /** Human string — starts with `auth_required:` and names the provider. */
+  error:         string;
+  auth_required: McpAuthRequiredEnvelope;
+}
+
+/** Build the typed auth-required result for a provider that needs re-auth. */
+export function buildMcpAuthRequiredResult(
+  provider:    string,
+  reason:      string,
+  reauthHint:  string,
+): AuthRequiredToolResult {
+  return {
+    success: false,
+    error:   `auth_required: needs reauth for ${provider} — ${reason}`,
+    auth_required: {
+      error:       'auth_required',
+      provider,
+      reason,
+      retryable:   false,
+      reauth_hint: reauthHint,
+    },
+  };
+}
+
+/**
+ * Read the `auth_required` envelope from a tool result, or null when absent.
+ * Defensive — an unexpected shape yields null, never a throw. Used by the
+ * failure classifier so ANY tool returning this envelope is classified as a
+ * non-recoverable auth wall.
+ */
+export function readAuthRequired(result: ToolCallResult): McpAuthRequiredEnvelope | null {
+  const inner = result.result;
+  if (!inner || typeof inner !== 'object' || Array.isArray(inner)) return null;
+  const env = (inner as { auth_required?: unknown }).auth_required;
+  if (!env || typeof env !== 'object' || Array.isArray(env)) return null;
+  const e = env as Record<string, unknown>;
+  if (e.error !== 'auth_required' || typeof e.provider !== 'string') return null;
+  return {
+    error:       'auth_required',
+    provider:    e.provider,
+    reason:      typeof e.reason === 'string' ? e.reason : '',
+    retryable:   false,
+    reauth_hint: typeof e.reauth_hint === 'string' ? e.reauth_hint : '',
+  };
+}

--- a/core/v4/mcp/deviceFlow.ts
+++ b/core/v4/mcp/deviceFlow.ts
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * core/v4/mcp/deviceFlow.ts — v4.14: OAuth 2.0 Device Authorization Grant (RFC 8628).
+ *
+ * The secret-free login path for STATIC-CLIENT MCP providers — servers whose
+ * authorization server publishes no `registration_endpoint` (no RFC 7591
+ * Dynamic Client Registration), so Aiden can't self-register a client. GitHub
+ * is the first such provider, but NOTHING here is GitHub-specific: it's plain
+ * RFC 8628 driven by a `{ deviceAuthorizationEndpoint, tokenEndpoint, clientId,
+ * scope }` config that any provider can fill.
+ *
+ * Why device flow (not a client_secret): no shared secret baked into an open-
+ * source local tool, and no loopback redirect/port juggling — the user just
+ * opens a URL and types a short code. It's how the `gh` CLI authenticates.
+ *
+ * This is a SIBLING to the loopback flow (oauthLoginFlow.ts), not a rewrite:
+ * both produce an `OAuthFlowResult` that the SAME encrypted 0600 token store
+ * and the SAME `refreshTokens` path consume — nothing downstream cares HOW the
+ * token was obtained. Reuses the shared primitives from `../auth/oauthFlow`.
+ *
+ *   1. POST the device-authorization endpoint (client_id [+ scope]) →
+ *      { device_code, user_code, verification_uri, interval, expires_in }.
+ *   2. Show the user the URL + code (and best-effort open the browser).
+ *   3. Poll the token endpoint with the device_code grant, honouring the
+ *      RFC 8628 §3.5 poll responses: authorization_pending (keep polling),
+ *      slow_down (back off +5s), access_denied / expired_token (clean stop),
+ *      success (return the token).
+ */
+
+import type { FetchImpl, OAuthFlowResult, OAuthUserAgent } from '../auth/oauthFlow';
+import { CONTENT_TYPE_FORM } from '../auth/oauthFlow';
+
+/** RFC 8628 §3.4 — the device-code token grant type. */
+const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+/** RFC 8628 §3.5 — bump the poll interval by this much on a `slow_down`. */
+const SLOW_DOWN_BUMP_SEC = 5;
+const DEFAULT_INTERVAL_SEC = 5;
+const DEFAULT_EXPIRES_SEC = 900;
+const CONTENT_TYPE_JSON = 'application/json';
+
+export interface DeviceFlowConfig {
+  /** RFC 8628 §3.1 device-authorization endpoint (carried per-provider — many,
+   *  like GitHub, do NOT publish it in AS metadata). */
+  deviceAuthorizationEndpoint: string;
+  /** The AS token endpoint (usually discovered from AS metadata). */
+  tokenEndpoint: string;
+  /** The pre-registered PUBLIC client id (device flow uses no secret). */
+  clientId: string;
+  /** Space-delimited scopes to request, or undefined for the provider default. */
+  scope?: string;
+}
+
+/** RFC 8628 §3.2 device-authorization response (the fields we consume). */
+export interface DeviceAuthorization {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  /** RFC 8628 §3.3.1 — URL with the code pre-filled (optional). */
+  verificationUriComplete?: string;
+  expiresInSeconds: number;
+  intervalSeconds: number;
+}
+
+/** The outcome of a single token poll — the RFC 8628 §3.5 state machine. */
+export type DevicePollOutcome =
+  | { kind: 'success'; result: OAuthFlowResult }
+  | { kind: 'pending' }
+  | { kind: 'slow_down' }
+  | { kind: 'denied' }
+  | { kind: 'expired' }
+  | { kind: 'error'; message: string };
+
+function asObj(text: string): Record<string, unknown> | null {
+  try {
+    const j = JSON.parse(text);
+    return j && typeof j === 'object' ? (j as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+function str(v: unknown): string { return typeof v === 'string' ? v : ''; }
+function num(v: unknown, dflt: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : dflt;
+}
+
+/** Build an OAuthFlowResult from a token-endpoint success body. */
+function toResult(j: Record<string, unknown>): OAuthFlowResult {
+  const extras: Record<string, unknown> = {};
+  for (const k of ['token_type', 'scope', 'account', 'email']) {
+    if (j[k] !== undefined) extras[k] = j[k];
+  }
+  return {
+    accessToken: str(j.access_token),
+    // Classic OAuth Apps (e.g. GitHub) often return no refresh_token — that's
+    // fine; persistMcpTokens keeps any prior one and the access token is used
+    // directly. Providers that DO rotate refresh tokens refresh identically.
+    refreshToken: j.refresh_token ? String(j.refresh_token) : null,
+    expiresInSeconds: Number(j.expires_in ?? 3600),
+    extras: Object.keys(extras).length > 0 ? extras : undefined,
+  };
+}
+
+/** RFC 8628 §3.1/§3.2 — request the device + user codes. */
+export async function requestDeviceAuthorization(
+  cfg: DeviceFlowConfig,
+  fetchImpl: FetchImpl,
+): Promise<DeviceAuthorization> {
+  const body = new URLSearchParams({ client_id: cfg.clientId });
+  if (cfg.scope) body.set('scope', cfg.scope);
+  const res = await fetchImpl(cfg.deviceAuthorizationEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': CONTENT_TYPE_FORM, Accept: CONTENT_TYPE_JSON },
+    body: body.toString(),
+  });
+  const text = await res.text();
+  if (res.status !== 200) {
+    throw new Error(`Device authorization request failed: HTTP ${res.status} at ${cfg.deviceAuthorizationEndpoint}: ${text.slice(0, 200)}`);
+  }
+  const j = asObj(text);
+  if (!j) throw new Error(`Device authorization response is not JSON: ${text.slice(0, 200)}`);
+  const deviceCode = str(j.device_code);
+  const userCode = str(j.user_code);
+  const verificationUri = str(j.verification_uri) || str(j.verification_url); // some servers use *_url
+  if (!deviceCode || !userCode || !verificationUri) {
+    throw new Error('Device authorization response missing device_code / user_code / verification_uri.');
+  }
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    verificationUriComplete: str(j.verification_uri_complete) || undefined,
+    expiresInSeconds: num(j.expires_in, DEFAULT_EXPIRES_SEC),
+    intervalSeconds: Math.max(1, num(j.interval, DEFAULT_INTERVAL_SEC)),
+  };
+}
+
+/**
+ * One token poll (RFC 8628 §3.4/§3.5). Classifies the response into the poll
+ * state machine. Tolerates the GitHub quirk of returning HTTP 200 with an
+ * `error` field for pending/slow_down by keying off the body, not the status.
+ */
+export async function pollDeviceTokenOnce(
+  cfg: DeviceFlowConfig,
+  deviceCode: string,
+  fetchImpl: FetchImpl,
+): Promise<DevicePollOutcome> {
+  const body = new URLSearchParams({
+    grant_type: DEVICE_GRANT_TYPE,
+    device_code: deviceCode,
+    client_id: cfg.clientId,
+  });
+  const res = await fetchImpl(cfg.tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': CONTENT_TYPE_FORM, Accept: CONTENT_TYPE_JSON },
+    body: body.toString(),
+  });
+  const text = await res.text();
+  const j = asObj(text);
+  if (j && str(j.access_token)) return { kind: 'success', result: toResult(j) };
+
+  const err = j ? str(j.error) : '';
+  switch (err) {
+    case 'authorization_pending': return { kind: 'pending' };
+    case 'slow_down':             return { kind: 'slow_down' };
+    case 'access_denied':         return { kind: 'denied' };
+    case 'expired_token':         return { kind: 'expired' };
+    case '':                      return { kind: 'error', message: `Unexpected device-token response: HTTP ${res.status}: ${text.slice(0, 200)}` };
+    default:                      return { kind: 'error', message: `Device authorization failed: ${err}${j && str(j.error_description) ? ` — ${str(j.error_description)}` : ''}` };
+  }
+}
+
+export interface RunDeviceFlowDeps {
+  config: DeviceFlowConfig;
+  server: string;
+  ua: OAuthUserAgent;
+  fetchImpl?: FetchImpl;
+  /** Injected clock for deterministic tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Drive the whole RFC 8628 flow: request codes → brief the user → poll until
+ * success / denial / expiry / timeout. Returns the token (caller persists it
+ * via the same `persistMcpTokens` the loopback flow uses).
+ */
+export async function runMcpDeviceFlow(deps: RunDeviceFlowDeps): Promise<OAuthFlowResult> {
+  const fetchImpl = deps.fetchImpl ?? (fetch as unknown as FetchImpl);
+  const now = deps.now ?? Date.now;
+
+  const auth = await requestDeviceAuthorization(deps.config, fetchImpl);
+
+  deps.ua.log('');
+  deps.ua.log(`To connect "${deps.server}":`);
+  deps.ua.log(`  1. Open:        ${auth.verificationUri}`);
+  deps.ua.log(`  2. Enter code:  ${auth.userCode}`);
+  deps.ua.log('');
+  deps.ua.log('Waiting for you to authorize in the browser…');
+  // Best-effort browser open (prefer the pre-filled URL when the server gives one).
+  await deps.ua.openBrowser(auth.verificationUriComplete ?? auth.verificationUri).catch(() => undefined);
+
+  let intervalSec = auth.intervalSeconds;
+  const deadline = now() + auth.expiresInSeconds * 1000;
+
+  // Give the user a moment before the first poll.
+  await deps.ua.sleep(intervalSec * 1000);
+
+  while (now() < deadline) {
+    const outcome = await pollDeviceTokenOnce(deps.config, auth.deviceCode, fetchImpl);
+    switch (outcome.kind) {
+      case 'success':
+        return outcome.result;
+      case 'denied':
+        throw new Error(`Authorization denied — you declined the "${deps.server}" connection.`);
+      case 'expired':
+        throw new Error(`The device code expired before authorization completed. Run \`/mcp auth ${deps.server}\` again.`);
+      case 'error':
+        throw new Error(outcome.message);
+      case 'slow_down':
+        intervalSec += SLOW_DOWN_BUMP_SEC; // RFC 8628 §3.5 — then keep polling
+        break;
+      case 'pending':
+        break; // keep polling
+    }
+    await deps.ua.sleep(intervalSec * 1000);
+  }
+  throw new Error(`Timed out waiting for you to authorize "${deps.server}".`);
+}

--- a/core/v4/mcp/deviceFlow.ts
+++ b/core/v4/mcp/deviceFlow.ts
@@ -182,6 +182,11 @@ export interface RunDeviceFlowDeps {
   fetchImpl?: FetchImpl;
   /** Injected clock for deterministic tests. Defaults to Date.now. */
   now?: () => number;
+  /**
+   * Cancel the poller cleanly (Ctrl+C). Checked at each poll boundary; when
+   * aborted the flow throws a clear "cancelled" error instead of polling on.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -194,23 +199,30 @@ export async function runMcpDeviceFlow(deps: RunDeviceFlowDeps): Promise<OAuthFl
   const now = deps.now ?? Date.now;
 
   const auth = await requestDeviceAuthorization(deps.config, fetchImpl);
+  const aborted = (): boolean => deps.signal?.aborted === true;
+  const cancel = (): Error => new Error(`Cancelled device authorization for "${deps.server}".`);
 
+  // Clear terminal UX: ALWAYS print the URL + code (SSH/WSL/headless-safe), the
+  // expiry, the waiting state, and the cancel instruction — then best-effort
+  // open the browser (never rely on it).
+  const expiresMin = Math.max(1, Math.round(auth.expiresInSeconds / 60));
   deps.ua.log('');
-  deps.ua.log(`To connect "${deps.server}":`);
-  deps.ua.log(`  1. Open:        ${auth.verificationUri}`);
-  deps.ua.log(`  2. Enter code:  ${auth.userCode}`);
+  deps.ua.log(`To connect "${deps.server}", authorize in your browser:`);
+  deps.ua.log(`  1. Open this URL:  ${auth.verificationUri}`);
+  deps.ua.log(`  2. Enter the code: ${auth.userCode}`);
   deps.ua.log('');
-  deps.ua.log('Waiting for you to authorize in the browser…');
-  // Best-effort browser open (prefer the pre-filled URL when the server gives one).
+  deps.ua.log(`This code expires in ~${expiresMin} min. Waiting for approval…  (press Ctrl+C to cancel)`);
   await deps.ua.openBrowser(auth.verificationUriComplete ?? auth.verificationUri).catch(() => undefined);
 
   let intervalSec = auth.intervalSeconds;
   const deadline = now() + auth.expiresInSeconds * 1000;
 
   // Give the user a moment before the first poll.
+  if (aborted()) throw cancel();
   await deps.ua.sleep(intervalSec * 1000);
 
   while (now() < deadline) {
+    if (aborted()) throw cancel();
     const outcome = await pollDeviceTokenOnce(deps.config, auth.deviceCode, fetchImpl);
     switch (outcome.kind) {
       case 'success':
@@ -229,5 +241,5 @@ export async function runMcpDeviceFlow(deps: RunDeviceFlowDeps): Promise<OAuthFl
     }
     await deps.ua.sleep(intervalSec * 1000);
   }
-  throw new Error(`Timed out waiting for you to authorize "${deps.server}".`);
+  throw new Error(`The code expired before "${deps.server}" was authorized. Run \`/mcp auth ${deps.server}\` to try again.`);
 }

--- a/core/v4/mcp/oauthDiscovery.ts
+++ b/core/v4/mcp/oauthDiscovery.ts
@@ -33,6 +33,12 @@ export interface DiscoveredOAuth {
   authorizationEndpoint: string;
   tokenEndpoint: string;
   registrationEndpoint?: string;
+  /**
+   * v4.14 — RFC 8628 device-authorization endpoint. Rarely published in AS
+   * metadata (GitHub, for one, does not), so it's usually supplied by the
+   * static per-provider config rather than discovered.
+   */
+  deviceAuthorizationEndpoint?: string;
   scopesSupported?: string[];
   codeChallengeMethods?: string[];
 }
@@ -51,6 +57,23 @@ export interface McpOAuthConfig {
   clientId: string;
   clientSecret?: string;
   redirectUris: string[];
+  /**
+   * v4.14 — requested scopes (space-joined by the flow). Carried for the
+   * device-flow path, which asks for scopes at device-authorization time.
+   */
+  scopes?: string[];
+}
+
+/**
+ * v4.14 — a pre-registered (static) client config for providers with NO
+ * Dynamic Client Registration. When present + the AS has no
+ * `registration_endpoint`, Aiden uses the RFC 8628 device flow (secret-free)
+ * instead of throwing. Provider-agnostic: GitHub is just the first to fill it.
+ */
+export interface StaticOAuthClient {
+  clientId: string;
+  deviceAuthorizationEndpoint: string;
+  scopes?: string[];
 }
 
 /** tokenStore id for an MCP server's OAuth record. Isolated from provider ids. */
@@ -249,7 +272,7 @@ export async function ensureMcpOAuthConfig(
   paths: AidenPaths,
   server: string,
   serverUrl: string,
-  deps: { fetchFn: FetchLike; redirectUris: string[]; clientName?: string },
+  deps: { fetchFn: FetchLike; redirectUris: string[]; clientName?: string; staticClient?: StaticOAuthClient },
 ): Promise<McpOAuthConfig> {
   const existing = await loadMcpOAuthConfig(paths, server);
   if (existing?.clientId) return existing; // idempotent — reuse the registered client
@@ -259,9 +282,26 @@ export async function ensureMcpOAuthConfig(
     throw new Error(`No OAuth metadata found for MCP server "${server}" (${serverUrl}) — it may not require OAuth.`);
   }
   if (!discovered.endpoints.registrationEndpoint) {
+    // v4.14 — no Dynamic Client Registration. If a static device-flow client is
+    // configured (RFC 8628), use it (secret-free) instead of failing. Otherwise
+    // keep the honest throw — we can't self-register and have nothing to fall
+    // back to.
+    const sc = deps.staticClient;
+    if (sc?.clientId && sc.deviceAuthorizationEndpoint) {
+      const deviceConfig: McpOAuthConfig = {
+        resource: discovered.resource,
+        endpoints: { ...discovered.endpoints, deviceAuthorizationEndpoint: sc.deviceAuthorizationEndpoint },
+        clientId: sc.clientId,
+        redirectUris: [], // device flow has no redirect
+        scopes: sc.scopes,
+      };
+      await saveMcpOAuthConfig(paths, server, deviceConfig);
+      return deviceConfig;
+    }
     throw new Error(
       `MCP server "${server}" authorization server has no registration_endpoint ` +
-        '(no Dynamic Client Registration) — manual client pre-registration is not yet supported.',
+        '(no Dynamic Client Registration), and no device-flow client is configured — ' +
+        'this connector needs a pre-registered client id to authorize.',
     );
   }
   const client = await registerClient(discovered.endpoints.registrationEndpoint, {

--- a/core/v4/mcpClient.ts
+++ b/core/v4/mcpClient.ts
@@ -54,6 +54,7 @@ import { McpToolFilter, type ToolFilterConfig } from './mcp/filters';
 import { McpCredentialFilter } from './mcp/credentialFilter';
 import { scrubString } from './logger/redact';
 import type { McpAuthProvider } from './mcp/mcpAuth';
+import { buildMcpAuthRequiredResult } from './mcp/authRequired';
 
 // v4.12 — MCP success results are EXTERNAL, untrusted content reaching the model
 // (same threat class as B5.1 browser-extracted content): T1 secrets-into-model
@@ -631,8 +632,14 @@ export class McpClient {
       );
     }
     if (server.status === 'needs-auth') {
-      throw new Error(
-        `MCP server "${serverName}" needs authorization — run /mcp auth ${serverName} (do NOT retry).`,
+      // v4.14 — a TYPED auth_required result (success:false), NOT a raw throw:
+      // the verifier flags it failed, the classifier marks it non-recoverable
+      // auth, and verify-before-done blocks the task from reaching `completed`
+      // on an auth-failed side effect. Never a raw error the model misreads.
+      return buildMcpAuthRequiredResult(
+        serverName,
+        'server needs authorization (no valid token)',
+        `Run /mcp auth ${serverName} to authorize.`,
       );
     }
     // Slice 2b — tool-call circuit breaker. Only for a ready server: 2a's
@@ -664,10 +671,17 @@ export class McpClient {
       // 3b — token rejected even after the transport's refresh+retry-once → the
       // server is locked. Transition to needs-auth (not a flapping-tool breaker
       // failure) so /mcp shows 🔑 and the model stops trying until re-auth.
+      // v4.14 — RETURN the typed auth_required result rather than throwing a raw
+      // string: the old throw ("needs re-authorization") matched NO auth pattern
+      // and classified as `other`/recoverable — a blind-retry-the-auth-wall risk
+      // and a fake-success vector. Typed → non-recoverable auth → completion is
+      // blocked ("needs reauth for <provider>"), never narrated as done.
       if (this.isAuthError(message)) {
         this.markNeedsAuth(server);
-        throw new Error(
-          `MCP server "${serverName}" needs re-authorization — run /mcp auth ${serverName} (do NOT retry).`,
+        return buildMcpAuthRequiredResult(
+          serverName,
+          'token rejected after refresh (revoked or expired)',
+          `Run /mcp auth ${serverName} to re-authorize.`,
         );
       }
       if (useBreaker) this.recordBreakerFailure(server);          // call-level failure

--- a/core/v4/mcpClient.ts
+++ b/core/v4/mcpClient.ts
@@ -81,6 +81,14 @@ export interface McpHttpConfig {
   /** v4.12 Slice 3c — wire shape. 'streamable' (MCP 2025-03-26, default) or the
    *  legacy 'sse' (2024-11-05 POST /messages + GET /sse). */
   transport?: 'streamable' | 'sse';
+  /**
+   * v4.14 — static OAuth client for providers without Dynamic Client
+   * Registration (public client id + RFC 8628 device endpoint; no secret). Its
+   * presence means "this server needs OAuth": until a token is stored, connect()
+   * marks the server `needs-auth` QUIETLY rather than running the reconnect-retry
+   * loop against an un-authorized endpoint.
+   */
+  oauth?: { clientId?: string; deviceAuthorizationEndpoint?: string; scopes?: string[] };
 }
 
 export interface McpServerConfig {
@@ -341,7 +349,14 @@ export class McpClient {
     // v4.12 Slice 3a.3 — resolve OAuth state for hosted servers before connecting.
     if (config.type === 'http' && this.authProvider) {
       const auth = await this.authProvider.resolve(config.name);
-      if (auth.state === 'needs-auth') {
+      // v4.14 Fix 2 — a server whose config DECLARES OAuth but has no token yet
+      // resolves to 'none' (nothing persisted until /mcp auth runs). Treat that
+      // exactly like 'needs-auth': mark it quietly, do NOT establish, do NOT run
+      // the reconnect-retry loop against an un-authorized endpoint. Reconnect-
+      // retry is only for servers that WERE authorized and then dropped. No token
+      // = wait quietly, never a "giving up" alarm.
+      const declaresOAuth = !!config.http?.oauth?.deviceAuthorizationEndpoint;
+      if (auth.state === 'needs-auth' || (auth.state === 'none' && declaresOAuth)) {
         // Known but locked: visible, NOT connected, never blocks. No handshake,
         // no reconnect timer — `/mcp auth <name>` transitions it to ready.
         const locked: McpServer = {

--- a/moat/approvalEngine.ts
+++ b/moat/approvalEngine.ts
@@ -42,6 +42,7 @@
 import {
   matchesHardBlock,
   decideAutonomy,
+  isNeverBlanketAllow,
   levelRank,
   type AutonomyPolicy,
 } from './autonomy';
@@ -546,6 +547,16 @@ export class ApprovalEngine {
     }
 
     // Allowlist short-circuit (user-recorded).
+    //
+    // v4.14 UX (Bug 2) — a recorded grant IS honoured here, including a
+    // destructive op the user explicitly reviewed and approved in a
+    // `plan_approval` BATCH (which records `allowForSession` for that exact
+    // signature). What's prevented — one layer up — is a destructive/external/
+    // spend call ever becoming a BLANKET grant from a single-tool prompt: the
+    // prompt UI withholds the Session/Always choices for those classes
+    // (callbacks.decisionChoicesFor) and the recording path below refuses to
+    // store one (isNeverBlanketAllow). So "ask each time" holds for ad-hoc
+    // dangerous calls, while a reviewed per-batch approval still executes.
     const sig = argSignature(req.toolName, req.args);
     const key = `${req.toolName}::${sig}`;
     if (this.sessionAllow.has(key)) {
@@ -663,12 +674,18 @@ export class ApprovalEngine {
 
     if (decision === 'deny') return false;
     if (decision === 'allow') return true;
+    // v4.14 UX (Bug 2) — a blanket grant (session or always) is recorded ONLY
+    // for safe classes. If the user picks Session/Always on a destructive /
+    // external-send / spend call, honour it as a ONE-TIME allow (run it now)
+    // but do NOT record the blanket — the next such call asks again. The UI
+    // (callbacks.decisionChoicesFor) already withholds these options for
+    // floor-gated calls; this is the engine-level backstop.
     if (decision === 'allow_session') {
-      this.allowForSession(req.toolName, sig);
+      if (!isNeverBlanketAllow(req)) this.allowForSession(req.toolName, sig);
       return true;
     }
     if (decision === 'allow_always') {
-      this.allowAlways(req.toolName, sig);
+      if (!isNeverBlanketAllow(req)) this.allowAlways(req.toolName, sig);
       return true;
     }
     return false;

--- a/moat/autonomy.ts
+++ b/moat/autonomy.ts
@@ -36,6 +36,8 @@
  *   • Reads always allowed. Budgets (BE.1) are orthogonal and always enforced.
  */
 
+import path from 'node:path';
+
 import type { ApprovalRequest, RiskTier } from './approvalEngine';
 import { detectDangerousPatterns } from './dangerousPatterns';
 
@@ -157,10 +159,43 @@ function writePathOf(req: ApprovalRequest): string | null {
     || null;
   return raw ? normalizePath(raw) : null;
 }
+/** True when a normalized path string is absolute (POSIX `/…` or Windows `X:…`). */
+function isAbsoluteNorm(p: string): boolean {
+  return p.startsWith('/') || /^[A-Za-z]:/.test(p);
+}
+
+/**
+ * Workspace containment, resolving RELATIVE paths against the workspace root
+ * first. v4.14 (Bug 2): tools frequently pass a relative path (`notes.txt`,
+ * `src/x.ts`) rather than an absolute one — those are relative to the cwd,
+ * which IS the workspace root, so they belong under it. Resolving also
+ * collapses `..`, so an ESCAPING relative path (`../../etc/passwd`) lands
+ * OUTSIDE the root and correctly still asks. Empty roots → never contained.
+ */
 function isUnderWorkspace(p: string, roots: string[]): boolean {
   if (roots.length === 0) return false;
   const np = normalizePath(p);
-  return roots.some((r) => np === r || np.startsWith(r.endsWith('/') ? r : r + '/'));
+  // Absolute → compare as-is; relative → resolve against the first root (cwd).
+  const abs = isAbsoluteNorm(np)
+    ? np
+    : normalizePath(path.posix.normalize(`${roots[0]}/${np}`));
+  return roots.some((r) => abs === r || abs.startsWith(r.endsWith('/') ? r : r + '/'));
+}
+
+/**
+ * v4.14 UX (Bug 2) — action classes that must be confirmed per-occurrence and
+ * may NEVER be blanket-allowed (neither "allow for session" nor "allow
+ * always"): destructive / irreversible, external sends, and external spend.
+ * The ApprovalEngine consults this so a Session/Always grant can suppress the
+ * SAME safe category twenty times over, but a destructive/external/spend call
+ * still asks every single time. Reuses `decideAutonomy`'s own floor
+ * classifiers so the "always ask" set and the "never blanket" set can't drift.
+ */
+export function isNeverBlanketAllow(req: ApprovalRequest): boolean {
+  if (req.riskTier === 'dangerous' || req.effects?.irreversible === true) return true;
+  if (isExternalSend(req)) return true;                 // includes effects.externalSpend
+  if (req.effects?.externalSpend === true) return true; // explicit, in case a spend isn't a "send"
+  return false;
 }
 
 /**

--- a/tests/v4/cli/commands/mcpCatalog.test.ts
+++ b/tests/v4/cli/commands/mcpCatalog.test.ts
@@ -83,7 +83,10 @@ describe('MCP catalog — data integrity', () => {
     const fs = catalogEntryToRawConfig(findCatalogEntry('filesystem')!, ['/some/dir']);
     expect(fs).toEqual({ type: 'stdio', stdio: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem', '/some/dir'] } });
     const gh = catalogEntryToRawConfig(findCatalogEntry('github')!);
-    expect(gh).toEqual({ type: 'http', http: { baseUrl: 'https://api.githubcopilot.com/mcp/', transport: 'streamable' } });
+    expect(gh).toEqual({ type: 'http', http: {
+      baseUrl: 'https://api.githubcopilot.com/mcp/', transport: 'streamable',
+      oauth: { clientId: '', deviceAuthorizationEndpoint: 'https://github.com/login/device/code', scopes: ['repo', 'read:org', 'read:user'] },
+    } });
   });
 });
 
@@ -142,7 +145,10 @@ describe('/mcp catalog add — funnels the gate', () => {
     const { ctx, display } = buildCtx(['install', 'github'], client, { config: cfg as never, confirm });
     await mcp.handler(ctx);
     const out = text(display);
-    expect(cfg.getValue('mcp.servers').github).toEqual({ type: 'http', http: { baseUrl: 'https://api.githubcopilot.com/mcp/', transport: 'streamable' } });
+    expect(cfg.getValue('mcp.servers').github).toEqual({ type: 'http', http: {
+      baseUrl: 'https://api.githubcopilot.com/mcp/', transport: 'streamable',
+      oauth: { clientId: '', deviceAuthorizationEndpoint: 'https://github.com/login/device/code', scopes: ['repo', 'read:org', 'read:user'] },
+    } });
     expect(out).toContain('https://api.githubcopilot.com/mcp/');
     expect(out).toContain("Saved 'github'"); // written, not connected
     expect(out).toContain('/mcp auth github'); // hint to authorize

--- a/tests/v4/cli/commands/mcpCatalog.test.ts
+++ b/tests/v4/cli/commands/mcpCatalog.test.ts
@@ -10,7 +10,7 @@
  * (pre-fill, transport:'streamable' for http, oauth defers connect + hints).
  */
 import { describe, it, expect, vi } from 'vitest';
-import { mcp } from '../../../../cli/v4/commands/mcpManage';
+import { mcp, extractClientIdFlag } from '../../../../cli/v4/commands/mcpManage';
 import {
   MCP_CATALOG,
   findCatalogEntry,
@@ -171,5 +171,42 @@ describe('/mcp catalog add — funnels the gate', () => {
     await mcp.handler(ctx);
     expect(text(display)).toContain('already configured');
     expect(confirm).not.toHaveBeenCalled();
+  });
+});
+
+// ── Fix 3 — --client-id persists with the entry (no env var required) ─────────
+describe('extractClientIdFlag', () => {
+  it('parses --client-id <id> and removes it from the rest', () => {
+    expect(extractClientIdFlag(['--client-id', 'Ov23abc'])).toEqual({ clientId: 'Ov23abc', rest: [] });
+  });
+  it('parses --client-id=<id>', () => {
+    expect(extractClientIdFlag(['--client-id=Ov23xyz', '/dir'])).toEqual({ clientId: 'Ov23xyz', rest: ['/dir'] });
+  });
+  it('no flag → undefined, args pass through', () => {
+    expect(extractClientIdFlag(['/some/dir'])).toEqual({ clientId: undefined, rest: ['/some/dir'] });
+  });
+  it('blank value → undefined', () => {
+    expect(extractClientIdFlag(['--client-id', '  '])).toEqual({ clientId: undefined, rest: [] });
+  });
+});
+
+describe('/mcp catalog add github --client-id — persists the public client id', () => {
+  it('stores --client-id into the server config oauth.clientId (safe to persist)', async () => {
+    const cfg = fakeConfig();
+    const confirm = vi.fn(async () => true);
+    const { ctx } = buildCtx(['catalog', 'add', 'github', '--client-id', 'Ov23-live-id'], fakeClient(), { config: cfg as never, confirm });
+    await mcp.handler(ctx);
+    const stored = cfg.getValue('mcp.servers.github') as { http?: { oauth?: { clientId?: string } } };
+    expect(stored?.http?.oauth?.clientId).toBe('Ov23-live-id'); // read back on every future boot
+    expect(JSON.stringify(stored)).not.toMatch(/secret/i);       // no secret stored (device flow)
+  });
+
+  it('--client-id on a non-OAuth entry is ignored with a note (not stored)', async () => {
+    const cfg = fakeConfig();
+    const confirm = vi.fn(async () => true);
+    const { ctx, display } = buildCtx(['catalog', 'add', 'memory', '--client-id', 'X'], fakeClient(), { config: cfg as never, confirm });
+    await mcp.handler(ctx);
+    expect(text(display)).toMatch(/--client-id ignored/);
+    expect(JSON.stringify(cfg.getValue('mcp.servers.memory'))).not.toContain('X');
   });
 });

--- a/tests/v4/cli/commands/mcpCatalogOAuth.test.ts
+++ b/tests/v4/cli/commands/mcpCatalogOAuth.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — catalog OAuth fields: the static device-client config carries through
+ * to the persisted server config, and every OAuth entry declares an honest
+ * `oauthVerified` flag (unverified until a real connect is proven).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { MCP_CATALOG, findCatalogEntry, catalogEntryToRawConfig } from '../../../../cli/v4/commands/mcpCatalog';
+
+describe('catalog — OAuth static-client + verified flag', () => {
+  it('every OAuth entry declares oauthVerified (honest; never silently "working")', () => {
+    for (const e of MCP_CATALOG) {
+      if (e.auth === 'oauth') {
+        expect(typeof e.oauthVerified).toBe('boolean');
+      }
+    }
+  });
+
+  it('github carries a device-flow client config and is UNVERIFIED (not yet proven)', () => {
+    const gh = findCatalogEntry('github')!;
+    expect(gh.auth).toBe('oauth');
+    expect(gh.oauthVerified).toBe(false);
+    expect(gh.oauth?.deviceAuthorizationEndpoint).toBe('https://github.com/login/device/code');
+    expect(gh.oauth?.scopes).toContain('repo');
+    // Ships with an empty client id (no Aiden OAuth App registered yet) — supplied
+    // at runtime via AIDEN_MCP_GITHUB_CLIENT_ID. Device flow → no secret anywhere.
+    expect(gh.oauth?.clientId).toBe('');
+    expect(JSON.stringify(gh)).not.toMatch(/client_secret|clientSecret/);
+  });
+
+  it('catalogEntryToRawConfig carries oauth into the persisted http config', () => {
+    const raw = catalogEntryToRawConfig(findCatalogEntry('github')!);
+    expect(raw.type).toBe('http');
+    if (raw.type === 'http') {
+      expect(raw.http.oauth?.deviceAuthorizationEndpoint).toBe('https://github.com/login/device/code');
+      expect(raw.http.oauth?.scopes).toContain('repo');
+    }
+  });
+
+  it('stdio entries carry no oauth block (unaffected)', () => {
+    const raw = catalogEntryToRawConfig(findCatalogEntry('memory')!);
+    expect(raw.type).toBe('stdio');
+    expect(JSON.stringify(raw)).not.toContain('oauth');
+  });
+});

--- a/tests/v4/cli/commands/mcpCatalogOAuth.test.ts
+++ b/tests/v4/cli/commands/mcpCatalogOAuth.test.ts
@@ -22,14 +22,17 @@ describe('catalog — OAuth static-client + verified flag', () => {
     }
   });
 
-  it('github carries a device-flow client config and is UNVERIFIED (not yet proven)', () => {
+  it('github carries a device-flow client config and is VERIFIED (proven live → one-tap connect)', () => {
     const gh = findCatalogEntry('github')!;
     expect(gh.auth).toBe('oauth');
-    expect(gh.oauthVerified).toBe(false);
+    // v4.14 — device flow proven end-to-end against real GitHub, so github is
+    // marked verified and offered for one-tap `/mcp connect`.
+    expect(gh.oauthVerified).toBe(true);
     expect(gh.oauth?.deviceAuthorizationEndpoint).toBe('https://github.com/login/device/code');
     expect(gh.oauth?.scopes).toContain('repo');
-    // Ships with an empty client id (no Aiden OAuth App registered yet) — supplied
-    // at runtime via AIDEN_MCP_GITHUB_CLIENT_ID. Device flow → no secret anywhere.
+    // Ships with an empty client id (no Aiden OAuth App registered yet) — the
+    // user supplies their own PUBLIC client id via `/mcp connect` (prompted once,
+    // then persisted) or --client-id. Device flow → no secret anywhere.
     expect(gh.oauth?.clientId).toBe('');
     expect(JSON.stringify(gh)).not.toMatch(/client_secret|clientSecret/);
   });

--- a/tests/v4/cli/commands/mcpConnect.test.ts
+++ b/tests/v4/cli/commands/mcpConnect.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — one-tap `/mcp connect <name>`: collapse catalog-add → auth →
+ * device-code into ONE command. These tests drive the wrapper through the
+ * public `mcp` handler (so the dispatch is covered too) and stop at the auth
+ * boundary network-free by omitting `ctx.paths` (handleAuth bails there) — the
+ * live device-flow connect is the Shiva smoke, not a unit test. What IS proven
+ * here: the honest-catalog gate, the add→auth orchestration, inline client-id
+ * prompt + persistence (never an env var), skip-re-add, already-connected, and
+ * that the old 3 commands are untouched.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { mcp } from '../../../../cli/v4/commands/mcpManage';
+import { isConnectable, findCatalogEntry } from '../../../../cli/v4/commands/mcpCatalog';
+import { CommandRegistry, type SlashCommandContext } from '../../../../cli/v4/commandRegistry';
+
+function fakeConfig(servers: Record<string, unknown> = {}) {
+  const store: any = Object.keys(servers).length ? { mcp: { servers: { ...servers } } } : {};
+  return {
+    store,
+    save: vi.fn(async () => {}),
+    getValue: (key: string) => { let c: any = store; for (const p of key.split('.')) { if (c == null) return undefined; c = c[p]; } return c; },
+    set: (key: string, val: unknown) => {
+      const parts = key.split('.'); let c: any = store;
+      for (let i = 0; i < parts.length - 1; i += 1) { if (typeof c[parts[i]] !== 'object' || c[parts[i]] == null) c[parts[i]] = {}; c = c[parts[i]]; }
+      c[parts[parts.length - 1]] = val;
+    },
+  };
+}
+function fakeClient(over: Record<string, unknown> = {}) {
+  return {
+    list: () => [],
+    get: () => undefined,
+    connect: vi.fn(async (cfg: { name: string }) => ({ config: cfg, tools: [{ rawName: 't', prefixedName: `mcp_${cfg.name}_t` }], status: 'ready' })),
+    ...over,
+  };
+}
+function captured() {
+  const o: any = { out: [] as string[] };
+  o.info = (m: string) => o.out.push(`info:${m}`);
+  o.warn = (m: string) => o.out.push(`warn:${m}`);
+  o.dim = (m: string) => o.out.push(`dim:${m}`);
+  o.write = (m: string) => o.out.push(m.replace(/\n$/, ''));
+  o.success = (m: string) => o.out.push(`ok:${m}`);
+  o.printError = (m: string, s?: string) => o.out.push(`err:${m}${s ? ` | ${s}` : ''}`);
+  return o;
+}
+function buildCtx(args: string[], client: unknown, extra: Partial<SlashCommandContext> = {}) {
+  const display = captured();
+  const ctx = { args, rawArgs: args.join(' '), display: display as never, registry: new CommandRegistry(), mcpClient: client as never, ...extra } as SlashCommandContext;
+  return { ctx, display };
+}
+const text = (d: any) => d.out.join('\n');
+const githubEntry = () => findCatalogEntry('github')!;
+
+describe('isConnectable — honest catalog', () => {
+  it('a VERIFIED oauth entry (github, proven live) is connectable', () => {
+    expect(isConnectable(githubEntry())).toBe(true);
+  });
+  it('an UNVERIFIED oauth entry is NOT connectable (never advertised)', () => {
+    const unverified = { ...githubEntry(), oauthVerified: false };
+    expect(isConnectable(unverified)).toBe(false);
+  });
+  it('a non-oauth entry connects directly (no verification gate)', () => {
+    expect(isConnectable(findCatalogEntry('memory')!)).toBe(true);
+  });
+});
+
+describe('/mcp connect — one-tap wrapper', () => {
+  it('fresh github + --client-id: adds (ONE confirm) → persists the id → reaches authorize', async () => {
+    const cfg = fakeConfig();
+    const confirm = vi.fn(async () => true);
+    const prompt = vi.fn(async () => 'should-not-ask');
+    const { ctx, display } = buildCtx(['connect', 'github', '--client-id', 'Ov23-live'], fakeClient(), { config: cfg as never, confirm, prompt });
+    await mcp.handler(ctx);
+    const out = text(display);
+    expect((cfg.getValue('mcp.servers.github') as any)?.http?.oauth?.clientId).toBe('Ov23-live'); // persisted, no env var
+    expect(confirm).toHaveBeenCalledTimes(1);   // one add gate
+    expect(prompt).not.toHaveBeenCalled();       // id supplied → no inline prompt
+    expect(out).toMatch(/Added 'github'/);       // step 1 done
+    expect(out).toMatch(/Cannot store tokens/);  // step 2 reached handleAuth (paths omitted → bails here, network-free)
+  });
+
+  it('missing client-id → prompts inline ONCE, then persists the prompted id (never env var)', async () => {
+    const cfg = fakeConfig();
+    const confirm = vi.fn(async () => true);
+    const prompt = vi.fn(async () => 'Ov23-prompted');
+    const { ctx } = buildCtx(['connect', 'github'], fakeClient(), { config: cfg as never, confirm, prompt });
+    await mcp.handler(ctx);
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect((cfg.getValue('mcp.servers.github') as any)?.http?.oauth?.clientId).toBe('Ov23-prompted');
+  });
+
+  it('blank inline client-id → clean abort, nothing added', async () => {
+    const cfg = fakeConfig();
+    const { ctx, display } = buildCtx(['connect', 'github'], fakeClient(), { config: cfg as never, confirm: vi.fn(async () => true), prompt: vi.fn(async () => '   ') });
+    await mcp.handler(ctx);
+    expect(cfg.getValue('mcp.servers.github')).toBeUndefined();
+    expect(text(display)).toMatch(/No client id entered/);
+  });
+
+  it('already-added github: SKIPS re-add (no confirm), goes straight to authorize', async () => {
+    const cfg = fakeConfig({ github: { type: 'http', http: { baseUrl: 'https://api.githubcopilot.com/mcp/', transport: 'streamable', oauth: { clientId: 'Ov23-stored', deviceAuthorizationEndpoint: 'https://github.com/login/device/code', scopes: [] } } } });
+    const confirm = vi.fn(async () => true);
+    const prompt = vi.fn(async () => 'x');
+    const { ctx, display } = buildCtx(['connect', 'github'], fakeClient(), { config: cfg as never, confirm, prompt });
+    await mcp.handler(ctx);
+    const out = text(display);
+    expect(confirm).not.toHaveBeenCalled();       // not re-added
+    expect(prompt).not.toHaveBeenCalled();         // stored id → no prompt
+    expect(out).toMatch(/already configured/);
+    expect(out).toMatch(/Cannot store tokens/);    // proceeded to authorize
+  });
+
+  it('already CONNECTED github: reports it and does nothing else', async () => {
+    const cfg = fakeConfig();
+    const confirm = vi.fn(async () => true);
+    const client = fakeClient({ get: () => ({ status: 'ready', tools: [{}, {}] }) });
+    const { ctx, display } = buildCtx(['connect', 'github'], client, { config: cfg as never, confirm });
+    await mcp.handler(ctx);
+    expect(text(display)).toMatch(/already connected/);
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it('confirm=NO on a fresh add → clean stop, never reaches authorize', async () => {
+    const cfg = fakeConfig();
+    const confirm = vi.fn(async () => false);
+    const { ctx, display } = buildCtx(['connect', 'github', '--client-id', 'X'], fakeClient(), { config: cfg as never, confirm, prompt: vi.fn() });
+    await mcp.handler(ctx);
+    expect(cfg.getValue('mcp.servers.github')).toBeUndefined();   // not added
+    expect(text(display)).not.toMatch(/Cannot store tokens/);      // auth never attempted
+  });
+
+  it('unknown slug → error, no add, no auth', async () => {
+    const { ctx, display } = buildCtx(['connect', 'nope'], fakeClient(), { config: fakeConfig() as never, confirm: vi.fn(async () => true) });
+    await mcp.handler(ctx);
+    expect(text(display)).toMatch(/No catalog entry 'nope'/);
+  });
+});
+
+describe('old 3 commands still work (the wrapper is additive)', () => {
+  it('/mcp catalog add memory still connects directly (non-oauth, unchanged)', async () => {
+    const cfg = fakeConfig();
+    const { ctx, display } = buildCtx(['catalog', 'add', 'memory'], fakeClient(), { config: cfg as never, confirm: vi.fn(async () => true) });
+    await mcp.handler(ctx);
+    expect(cfg.getValue('mcp.servers.memory')).toBeTruthy();
+    expect(text(display)).toMatch(/Connected 'memory'/);
+  });
+
+  it('/mcp install github still adds + shows the MANUAL /mcp auth hint (not chained)', async () => {
+    const cfg = fakeConfig();
+    const { ctx, display } = buildCtx(['install', 'github'], fakeClient(), { config: cfg as never, confirm: vi.fn(async () => true) });
+    await mcp.handler(ctx);
+    expect(cfg.getValue('mcp.servers.github')).toBeTruthy();
+    expect(text(display)).toMatch(/Run \/mcp auth github/);   // old two-step hint preserved
+  });
+});

--- a/tests/v4/cli/greeter/integration-real-boot.test.ts
+++ b/tests/v4/cli/greeter/integration-real-boot.test.ts
@@ -238,7 +238,7 @@ describe('renderStartupCard — greeter wiring', () => {
     expect(h!.disabled).toBe(true);
   });
 
-  it('with seeded distillation containing open_items[0]: continuity-open-item appears in real chatSession output', async () => {
+  it('with seeded distillation containing open_items[0]: the warm recall welcome appears in real chatSession output', async () => {
     // Pre-seed: a prior history file (so we're not in first-launch path)
     // + a distillation with an open item. Force lastCwd to match
     // process.cwd() so the cwd-changed offer doesn't shadow Tier 2.
@@ -260,10 +260,10 @@ describe('renderStartupCard — greeter wiring', () => {
 
     const text = chunks.join('');
     // The exact greeter speech must appear in the captured output.
-    // This is the proof-of-life: the chatSession's real boot path
-    // invoked renderGreeter, which selected the continuity-open-item
-    // template, which wrote to display.
-    expect(text).toContain('Last session left this open: "decide on redis vs postgres for session store"');
+    // This is the proof-of-life: the chatSession's real boot path invoked
+    // renderGreeter, which built the recall welcome (buildWelcomeLine) from
+    // the distillation's open item, which wrote to display.
+    expect(text).toContain('Welcome back! Last time: decide on redis vs postgres for session store');
   });
 
   it('with seeded update cache: update-available appears in real chatSession output', async () => {
@@ -281,6 +281,10 @@ describe('renderStartupCard — greeter wiring', () => {
     const now = new Date();
     await writeHistory(paths, mkHistory({
       lastCwd: process.cwd(),
+      // v4.14 — a RECENT last session so the Tier-2 time-gap welcome doesn't
+      // fire and shadow the update (the greeter reads the real clock; the
+      // default seed's old lastGreetingAt would otherwise read as a >24h gap).
+      lastSessionAt: now.toISOString(),
       offers: [{
         id:        `time-of-day-evening-${isoDateLocal(now)}`,
         offeredAt: now.toISOString(),

--- a/tests/v4/cli/greeter/integration-real-boot.test.ts
+++ b/tests/v4/cli/greeter/integration-real-boot.test.ts
@@ -303,7 +303,8 @@ describe('renderStartupCard — greeter wiring', () => {
 
     const text = chunks.join('');
     const escapedNewer = NEWER_VERSION.replace(/\./g, '\\.');
-    expect(text).toMatch(new RegExp(`aiden-runtime .* → ${escapedNewer} available\\.`));
+    // v4.14 — warm advisory voice: "There's a newer version of me available (X → Y)."
+    expect(text).toMatch(new RegExp(`newer version of me available \\(.* → ${escapedNewer}\\)`));
     expect(text).toContain('/update install');
   });
 

--- a/tests/v4/cli/greeter/integration.test.ts
+++ b/tests/v4/cli/greeter/integration.test.ts
@@ -211,6 +211,27 @@ describe('renderGreeter — durable last-session marker (v4.14 Bug 1)', () => {
   });
 });
 
+describe('renderGreeter — greets by stored name (v4.14 Personality L1)', () => {
+  it('reads USER.md and addresses the user by name on a returning boot', async () => {
+    // Returning user: a stale gap so the time-gap welcome fires, plus a name
+    // stored by onboarding in the exact durable format.
+    await writeHistory(paths, mkHistory({ lastSessionAt: '2026-05-20T00:00:00.000Z', lastCwd: process.cwd() }));
+    await fs.mkdir(path.join(root, 'memories'), { recursive: true });
+    await fs.writeFile(path.join(root, 'memories', 'USER.md'), "User's name is Shiva. (source: onboarding)", 'utf8');
+
+    await renderGreeter({ paths, version: VERSION, display, now: NOW });
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain('Welcome back, Shiva');
+  });
+
+  it('no stored name → the plain welcome (no dangling comma)', async () => {
+    await writeHistory(paths, mkHistory({ lastSessionAt: '2026-05-20T00:00:00.000Z', lastCwd: process.cwd() }));
+    await renderGreeter({ paths, version: VERSION, display, now: NOW });
+    expect(writes[0]).toContain('Welcome back —');
+    expect(writes[0]).not.toContain('Welcome back,');
+  });
+});
+
 describe('renderGreeter — never throws', () => {
   it('returns cleanly when the paths root is read-only / inaccessible (does not crash REPL)', async () => {
     // Construct a paths object pointing at a definitely-nonexistent root

--- a/tests/v4/cli/greeter/integration.test.ts
+++ b/tests/v4/cli/greeter/integration.test.ts
@@ -134,7 +134,7 @@ describe('renderGreeter — speaks when an offer wins', () => {
 });
 
 describe('renderGreeter — continuity from distillation', () => {
-  it('reads newest distillation and emits continuity-open-item when open_items[0] exists', async () => {
+  it('reads newest distillation and emits the warm recall welcome from open_items[0]', async () => {
     // Seed a distillation.
     const distDir = path.join(root, 'distillations');
     await fs.mkdir(distDir, { recursive: true });
@@ -149,9 +149,11 @@ describe('renderGreeter — continuity from distillation', () => {
     await writeHistory(paths, mkHistory({ lastCwd: process.cwd() }));
     await renderGreeter({ paths, version: VERSION, display, now: NOW });
 
+    // v4.14 Bug 1 — the recall tier now renders buildWelcomeLine (identity
+    // paint), not the old "Last session left this open" template.
     expect(writes).toHaveLength(1);
     expect(writes[0]).toBe(
-      '  Last session left this open: "decide redis vs postgres for session store".\n\n',
+      '  Welcome back! Last time: decide redis vs postgres for session store. Continue, or something new?\n\n',
     );
   });
 });
@@ -172,6 +174,40 @@ describe('renderGreeter — reconciliation closes pending offers from prior boot
     const h = await readHistory(paths);
     expect(h!.offers).toHaveLength(1);
     expect(h!.offers[0].response).toBe('accepted');
+  });
+});
+
+describe('renderGreeter — durable last-session marker (v4.14 Bug 1)', () => {
+  it('refreshes lastSessionAt to ~now on every boot (the stuck-timestamp fix)', async () => {
+    // Seed a STALE marker — the exact failure mode of the bug (a frozen
+    // timestamp that never moved). A real session must refresh it.
+    const OLD = '2026-05-01T00:00:00.000Z';
+    await writeHistory(paths, mkHistory({
+      lastSessionAt: OLD, lastGreetingAt: OLD, lastCwd: process.cwd(),
+    }));
+    await renderGreeter({ paths, version: VERSION, display, now: NOW });
+
+    const h = await readHistory(paths);
+    expect(h!.lastSessionAt).toBe(NOW.toISOString());   // refreshed on use
+    expect(h!.lastSessionAt).not.toBe(OLD);             // no longer frozen
+  });
+
+  it('first-ever launch seeds lastSessionAt so the NEXT boot has a real gap', async () => {
+    expect(await readHistory(paths)).toBeNull();         // first launch
+    await renderGreeter({ paths, version: VERSION, display, now: NOW });
+    const h = await readHistory(paths);
+    expect(h!.lastSessionAt).toBe(NOW.toISOString());
+  });
+
+  it('writes lastSessionAt even for a pre-v4.14 file that lacks it', async () => {
+    // Old file: lastGreetingAt present, lastSessionAt absent (mkHistory omits it).
+    await writeHistory(paths, mkHistory({ lastCwd: process.cwd() }));
+    const before = await readHistory(paths);
+    expect(before!.lastSessionAt).toBeUndefined();       // absent in the old file
+
+    await renderGreeter({ paths, version: VERSION, display, now: NOW });
+    const after = await readHistory(paths);
+    expect(after!.lastSessionAt).toBe(NOW.toISOString()); // now durable
   });
 });
 

--- a/tests/v4/cli/greeter/integration.test.ts
+++ b/tests/v4/cli/greeter/integration.test.ts
@@ -21,6 +21,7 @@ import os from 'node:os';
 
 import { renderGreeter, type GreeterDisplay } from '../../../../cli/v4/greeter';
 import { historyPath, readHistory, writeHistory } from '../../../../cli/v4/greeter/history';
+import { WELCOME_FALLBACKS } from '../../../../cli/v4/greeter/welcomeLine';
 import type { AidenPaths, GreeterHistory } from '../../../../cli/v4/greeter/types';
 
 let root: string;
@@ -88,13 +89,38 @@ describe('renderGreeter — silence when disabled', () => {
   });
 });
 
-describe('renderGreeter — silence when nothing observable', () => {
-  it('writes ZERO bytes when no offer wins', async () => {
-    // Morning, no update cache, no distillations → silence.
+describe('renderGreeter — warm fallback when nothing else fires (v4.14)', () => {
+  it('shows a warm rotating greeting (not cold silence) on a no-signal boot', async () => {
+    // Morning, no update cache, no distillations, a RECENT session (so no
+    // welcome-back regardless of the runner timezone), cwd unchanged.
     const NOON = new Date(2026, 4, 25, 12, 0, 0);
-    await writeHistory(paths, mkHistory({ lastCwd: process.cwd() }));
+    await writeHistory(paths, mkHistory({
+      lastCwd: process.cwd(),
+      lastSessionAt: new Date(NOON.getTime() - 3 * 3600 * 1000).toISOString(),
+    }));
     await renderGreeter({ paths, version: VERSION, display, now: NOON });
-    expect(writes).toEqual([]);
+    expect(writes).toHaveLength(1);
+    expect(WELCOME_FALLBACKS).toContain(writes[0].trim());
+  });
+
+  it('rotates the fallback across consecutive boots — never the same line twice running', async () => {
+    const MORN = new Date(2026, 4, 25, 9, 0, 0);   // hour 9 → no time-of-day tier
+    await writeHistory(paths, mkHistory({
+      lastCwd: process.cwd(),
+      lastSessionAt: new Date(MORN.getTime() - 3 * 3600 * 1000).toISOString(),  // recent → no welcome-back
+    }));
+    const lines: string[] = [];
+    for (let i = 0; i < WELCOME_FALLBACKS.length + 1; i++) {
+      writes.length = 0;
+      await renderGreeter({ paths, version: VERSION, display, now: MORN });
+      lines.push((writes[0] ?? '').trim());
+    }
+    // Every boot showed a warm fallback…
+    for (const l of lines) expect(WELCOME_FALLBACKS).toContain(l);
+    // …and never repeated the previous boot's line.
+    for (let i = 1; i < lines.length; i++) expect(lines[i]).not.toBe(lines[i - 1]);
+    // The rotation index is persisted so it survives across boots.
+    expect(typeof (await readHistory(paths))!.lastFallbackIndex).toBe('number');
   });
 });
 
@@ -110,10 +136,10 @@ describe('renderGreeter — speaks when an offer wins', () => {
     await writeHistory(paths, mkHistory({ lastCwd: process.cwd() }));
     await renderGreeter({ paths, version: VERSION, display, now: MORN });
 
-    // One write call, with the canonical layout.
+    // One write call, with the canonical layout + the warm advisory voice.
     expect(writes).toHaveLength(1);
     expect(writes[0]).toBe(
-      '  aiden-runtime 4.9.3 → 4.9.4 available. /update install to ship.\n\n',
+      "  There's a newer version of me available (4.9.3 → 4.9.4). Run /update install to upgrade — or just say the word.\n\n",
     );
   });
 
@@ -168,12 +194,13 @@ describe('renderGreeter — reconciliation closes pending offers from prior boot
         // response: undefined — pending
       }],
     }));
-    // Running 4.9.3 now → should reconcile as accepted.
+    // Running 4.9.3 now → should reconcile as accepted. (The warm fallback
+    // also fires this boot and appends its own offer, so assert on the
+    // reconciled update offer specifically rather than array length.)
     const MORN = new Date(2026, 4, 25, 9, 0, 0);
     await renderGreeter({ paths, version: '4.9.3', display, now: MORN });
     const h = await readHistory(paths);
-    expect(h!.offers).toHaveLength(1);
-    expect(h!.offers[0].response).toBe('accepted');
+    expect(h!.offers.find((o) => o.id === 'update-available-4.9.3')?.response).toBe('accepted');
   });
 });
 

--- a/tests/v4/cli/greeter/selectOffer.test.ts
+++ b/tests/v4/cli/greeter/selectOffer.test.ts
@@ -39,6 +39,12 @@ const paint = {
   paintAccent: (s: string) => `<a>${s}</a>`,
 };
 
+/** ISO timestamp N hours before NOW — drives the durable last-session gate
+ *  (v4.14 Bug 1: welcome-back now keys off history.lastSessionAt, not the
+ *  frozen distillation mtime). */
+const hoursAgoIso = (h: number, from: Date = NOW): string =>
+  new Date(from.getTime() - h * 3600 * 1000).toISOString();
+
 describe('selectOffer — kill switch', () => {
   it('returns null when history.disabled === true (no matter what scanners say)', () => {
     const r = selectOffer({
@@ -50,51 +56,59 @@ describe('selectOffer — kill switch', () => {
   });
 });
 
-describe('selectOffer — Tier 2 priority (continuity)', () => {
-  it('open-item beats decision beats welcome-back when all qualify', () => {
+describe('selectOffer — Tier 2 welcome (v4.14 merged: recall > time-gap)', () => {
+  it('recall prefers the open item over the decision when both qualify', () => {
     const r = selectOffer({
-      scan: mkScan({ hoursSinceLastSession: 50 }),
+      scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
+      lastSessionAt: hoursAgoIso(50),
       openItem: 'decide redis-vs-postgres',
       lastDecision: 'shipped v4.9.2',
     });
-    expect(r?.templateId).toBe('continuity-open-item');
+    expect(r?.templateId).toBe('welcome-back');
+    expect(r?.speech).toContain('decide redis-vs-postgres');
+    expect(r?.speech).not.toContain('shipped v4.9.2');
   });
 
-  it('falls through to decision when open-item missing', () => {
+  it('recall uses the decision when the open item is missing', () => {
     const r = selectOffer({
-      scan: mkScan({ hoursSinceLastSession: 50 }),
+      scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
+      lastSessionAt: hoursAgoIso(50),
       openItem: null,
       lastDecision: 'shipped v4.9.2',
     });
-    expect(r?.templateId).toBe('continuity-decision');
+    expect(r?.templateId).toBe('welcome-back');
+    expect(r?.speech).toContain('shipped v4.9.2');
   });
 
-  it('falls through to welcome-back when continuity missing AND hoursSinceLastSession >= 24', () => {
+  it('fires the time-gap welcome when no recall AND last session >= 24h ago', () => {
     const r = selectOffer({
-      scan: mkScan({ hoursSinceLastSession: 30 }),
+      scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
+      lastSessionAt: hoursAgoIso(30),
     });
     expect(r?.templateId).toBe('welcome-back');
+    expect(r?.speech).toContain('Welcome back');
   });
 
-  it('skips welcome-back when hoursSinceLastSession < 24', () => {
+  it('skips the time-gap welcome when the last session was < 24h ago', () => {
     const r = selectOffer({
-      scan: mkScan({ hoursSinceLastSession: 8 }),
+      scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
+      lastSessionAt: hoursAgoIso(8),
     });
     // No tier-2 candidate; with hour 19 (≥18) and no tier-2, time-of-day fires.
     expect(r?.templateId).toBe('time-of-day-evening');
   });
 
-  it('skips welcome-back when no prior session (hoursSinceLastSession === null)', () => {
+  it('skips the welcome when no prior session (lastSessionAt absent)', () => {
     const r = selectOffer({
-      scan: mkScan({ hoursSinceLastSession: null }),
+      scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
     });
@@ -233,23 +247,26 @@ describe('selectOffer — silence rule', () => {
   });
 });
 
-describe('selectOffer — Offer.speech is the templated text', () => {
-  it('continuity-open-item produces the expected speech string', () => {
+describe('selectOffer — Offer.speech is the welcome line', () => {
+  it('recall welcome produces the warm summary line', () => {
     const r = selectOffer({
       scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
+      lastSessionAt: hoursAgoIso(50),
       openItem: 'sql migration',
     });
-    expect(r?.speech).toBe('Last session left this open: <m>"sql migration"</m>.');
+    expect(r?.speech).toBe('Welcome back! Last time: <m>sql migration</m>. Continue, or something new?');
   });
 
-  it('welcome-back produces the expected speech string', () => {
+  it('time-gap welcome produces a human phrase, never raw hours', () => {
     const r = selectOffer({
-      scan: mkScan({ hoursSinceLastSession: 31 }),
+      scan: mkScan(),
       history: mkHistory(),
       now: NOW, ...paint,
+      lastSessionAt: hoursAgoIso(31),   // ~1.3 days → "yesterday"
     });
-    expect(r?.speech).toBe('Welcome back. Last session ended 31h ago.');
+    expect(r?.speech).toBe('Welcome back — last session was yesterday.');
+    expect(r?.speech).not.toMatch(/\d+\s*h\b/);
   });
 });

--- a/tests/v4/cli/greeter/selectOffer.test.ts
+++ b/tests/v4/cli/greeter/selectOffer.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { selectOffer } from '../../../../cli/v4/greeter/selectOffer';
+import { WELCOME_FALLBACKS } from '../../../../cli/v4/greeter/welcomeLine';
 import type {
   GreeterHistory, GreeterOfferRecord, ScanResult,
 } from '../../../../cli/v4/greeter/types';
@@ -127,14 +128,15 @@ describe('selectOffer — Tier 3 environment', () => {
     expect(r?.templateId).toBe('time-of-day-evening');
   });
 
-  it('time-of-day-evening does NOT fire when hour < 18', () => {
+  it('time-of-day-evening does NOT fire when hour < 18 (falls to the warm fallback)', () => {
     const NOON = new Date(2026, 4, 25, 12, 0, 0);
     const r = selectOffer({
       scan: mkScan({ hourOfDay: 12 }),
       history: mkHistory(),
       now: NOON, ...paint,
     });
-    expect(r).toBeNull();
+    expect(r?.templateId).not.toBe('time-of-day-evening');
+    expect(r?.id.startsWith('welcome-fallback-')).toBe(true);   // v4.14: no more cold silence
   });
 
   it('time-of-day-evening is suppressed by recent ignored entry (3-day decay)', () => {
@@ -148,8 +150,8 @@ describe('selectOffer — Tier 3 environment', () => {
       history: mkHistory({ offers: [offered] }),
       now: NOW, ...paint,
     });
-    // Suppressed → falls through to next tier; nothing else matches → null.
-    expect(r).toBeNull();
+    // Suppressed → falls through past every tier to the warm fallback.
+    expect(r?.id.startsWith('welcome-fallback-')).toBe(true);
   });
 
   it('cwd-changed fires when cwd differs AND no tier 2 AND no time-of-day (e.g. morning)', () => {
@@ -199,7 +201,9 @@ describe('selectOffer — Tier 4 update', () => {
       history: mkHistory({ offers: [offered] }),
       now: MORN, ...paint,
     });
-    expect(r).toBeNull();
+    // Update suppressed by decay → falls to the warm fallback (not the update line).
+    expect(r?.templateId).not.toBe('update-available');
+    expect(r?.id.startsWith('welcome-fallback-')).toBe(true);
   });
 
   it('update-available fires AGAIN after the 7-day decay window passes', () => {
@@ -235,13 +239,36 @@ describe('selectOffer — Tier 4 update', () => {
   });
 });
 
-describe('selectOffer — silence rule', () => {
-  it('returns null when nothing is observable', () => {
-    const MORN = new Date(2026, 4, 25, 9, 0, 0);
+describe('selectOffer — warm fallback (v4.14: no more cold silence)', () => {
+  const MORN = new Date(2026, 4, 25, 9, 0, 0);
+
+  it('shows a warm fallback greeting when nothing else is observable', () => {
     const r = selectOffer({
       scan: mkScan({ hourOfDay: 9 }),
       history: mkHistory(),
       now: MORN, ...paint,
+      fallbackIndex: 0,
+    });
+    expect(r?.id.startsWith('welcome-fallback-')).toBe(true);
+    expect(WELCOME_FALLBACKS).toContain(r?.speech);
+    expect(r?.speech).toBe(WELCOME_FALLBACKS[0]);
+  });
+
+  it('the fallback line tracks the supplied round-robin index', () => {
+    const at = (i: number) => selectOffer({
+      scan: mkScan({ hourOfDay: 9 }), history: mkHistory(), now: MORN, ...paint, fallbackIndex: i,
+    })?.speech;
+    expect(at(1)).toBe(WELCOME_FALLBACKS[1]);
+    expect(at(2)).toBe(WELCOME_FALLBACKS[2]);
+    expect(at(WELCOME_FALLBACKS.length)).toBe(WELCOME_FALLBACKS[0]);   // wraps
+  });
+
+  it('the kill switch still wins — /greeter off stays silent', () => {
+    const r = selectOffer({
+      scan: mkScan({ hourOfDay: 9 }),
+      history: mkHistory({ disabled: true }),
+      now: MORN, ...paint,
+      fallbackIndex: 0,
     });
     expect(r).toBeNull();
   });

--- a/tests/v4/cli/greeter/templates.test.ts
+++ b/tests/v4/cli/greeter/templates.test.ts
@@ -87,14 +87,14 @@ describe('TEMPLATES — Tier 3 (environment)', () => {
 });
 
 describe('TEMPLATES — Tier 4 (update)', () => {
-  it('update-available shows installed → latest with /update install in accent', () => {
+  it('update-available shows installed → latest in the warm advisory voice', () => {
     expect(TEMPLATES['update-available'](mkCtx({ installed: '4.9.3', latest: '4.9.4' })))
-      .toBe('aiden-runtime 4.9.3 → 4.9.4 available. <a>/update install</a> to ship.');
+      .toBe("There's a newer version of me available (4.9.3 → 4.9.4). Run <a>/update install</a> to upgrade — or just say the word.");
   });
 
   it('update-available falls back to "?" on missing versions (defensive)', () => {
     expect(TEMPLATES['update-available'](mkCtx()))
-      .toBe('aiden-runtime ? → ? available. <a>/update install</a> to ship.');
+      .toBe("There's a newer version of me available (? → ?). Run <a>/update install</a> to upgrade — or just say the word.");
   });
 });
 

--- a/tests/v4/cli/greeter/welcomeLine.test.ts
+++ b/tests/v4/cli/greeter/welcomeLine.test.ts
@@ -95,6 +95,26 @@ describe('buildWelcomeLine — time-gap tier (human words only)', () => {
   });
 });
 
+// ── Personality L1: greet by name (the USE half of the loop) ───────────────
+describe('buildWelcomeLine — greets by name when known', () => {
+  it('recall tier addresses the user by name', () => {
+    const line = buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(50), recallSummary: 'the parser', userName: 'Shiva' });
+    expect(line).toBe('Welcome back, Shiva! Last time: <m>the parser</m>. Continue, or something new?');
+  });
+  it('time-gap tier addresses the user by name', () => {
+    const line = buildWelcomeLine({ ...base, lastSessionAt: daysAgoIso(2), recallSummary: null, userName: 'Ada' });
+    expect(line).toContain('Welcome back, Ada —');
+  });
+  it('no name → the plain "Welcome back" (unchanged)', () => {
+    expect(buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(30), recallSummary: null })).toContain('Welcome back —');
+    expect(buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(30), recallSummary: null })).not.toContain(',');
+  });
+  it('blank / whitespace name is ignored (no dangling comma)', () => {
+    expect(buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(30), recallSummary: null, userName: '  ' }))
+      .not.toContain('Welcome back,');
+  });
+});
+
 // ── Tier 3: rotated fallback ───────────────────────────────────────────────
 describe('buildWelcomeLine — no-history fallback', () => {
   it('rotates a friendly line by seed (deterministic, not random)', () => {

--- a/tests/v4/cli/greeter/welcomeLine.test.ts
+++ b/tests/v4/cli/greeter/welcomeLine.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 UX polish (Bug 1) — buildWelcomeLine pure-function coverage.
+ *
+ * Three tiers: recall (summary known) → human time-gap (never raw hours) →
+ * rotated friendly fallback (no useful history). Pure: identical ctx ⇒
+ * identical string; the fallback rotation is a deterministic function of the
+ * seed, not randomness.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildWelcomeLine, humanGap, WELCOME_FALLBACKS,
+} from '../../../../cli/v4/greeter/welcomeLine';
+
+const NOW = new Date(2026, 6, 4, 12, 0, 0);   // local noon, 2026-07-04
+const paint = {
+  paintMuted:  (s: string) => `<m>${s}</m>`,
+  paintAccent: (s: string) => `<a>${s}</a>`,
+};
+const hoursAgoIso = (h: number): string => new Date(NOW.getTime() - h * 3600 * 1000).toISOString();
+const daysAgoIso  = (d: number): string => hoursAgoIso(d * 24);
+
+const base = { now: NOW, ...paint } as const;
+
+// ── Tier 1: recall ─────────────────────────────────────────────────────────
+describe('buildWelcomeLine — recall tier', () => {
+  it('renders the warm recall line when a summary is known', () => {
+    const line = buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(50), recallSummary: 'sql migration' });
+    expect(line).toBe('Welcome back! Last time: <m>sql migration</m>. Continue, or something new?');
+  });
+
+  it('recall wins over the time-gap even when both are available', () => {
+    const line = buildWelcomeLine({ ...base, lastSessionAt: daysAgoIso(40), recallSummary: 'ship the parser' });
+    expect(line).toContain('ship the parser');
+    expect(line).not.toContain('been a while');
+  });
+
+  it('clamps a very long summary so the line stays width-safe', () => {
+    const long = 'refactor the entire provider fallback chain and the retry budget accounting across every adapter';
+    const line = buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: long });
+    expect(line).toContain('…');
+    // the clamped summary (inside <m>…</m>) is bounded well under the raw length
+    expect(line.length).toBeLessThan(long.length + 60);
+  });
+
+  it('a whitespace-only summary is treated as no recall (falls to time-gap)', () => {
+    const line = buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(30), recallSummary: '   ' });
+    expect(line).toContain('Welcome back —');
+  });
+});
+
+// ── Tier 2: human time-gap (never raw hours) ───────────────────────────────
+describe('buildWelcomeLine — time-gap tier (human words only)', () => {
+  it('23h ago → "earlier today"', () => {
+    expect(humanGap(hoursAgoIso(23), NOW)).toBe('earlier today');
+    expect(buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(23), recallSummary: null }))
+      .toContain('earlier today');
+  });
+
+  it('30h ago → "yesterday"', () => {
+    expect(humanGap(hoursAgoIso(30), NOW)).toBe('yesterday');
+  });
+
+  it('3 days ago → "a few days ago"', () => {
+    expect(humanGap(daysAgoIso(3), NOW)).toBe('a few days ago');
+  });
+
+  it('10 days ago → "last week"', () => {
+    expect(humanGap(daysAgoIso(10), NOW)).toBe('last week');
+  });
+
+  it('40 days ago → "been a while"', () => {
+    expect(humanGap(daysAgoIso(40), NOW)).toBe('been a while');
+    expect(buildWelcomeLine({ ...base, lastSessionAt: daysAgoIso(40), recallSummary: null }))
+      .toContain("been a while");
+  });
+
+  it('NEVER shows raw hours in any bucket', () => {
+    for (const h of [23, 30, 72, 240, 960]) {
+      const line = buildWelcomeLine({ ...base, lastSessionAt: hoursAgoIso(h), recallSummary: null });
+      expect(line).not.toMatch(/\d+\s*h\b/);
+      expect(line).not.toMatch(/\d+\s*hours?/);
+    }
+  });
+
+  it('unparseable / missing timestamp → no gap (null), not a fake phrase', () => {
+    expect(humanGap('not-a-date', NOW)).toBeNull();
+    expect(humanGap(null, NOW)).toBeNull();
+  });
+});
+
+// ── Tier 3: rotated fallback ───────────────────────────────────────────────
+describe('buildWelcomeLine — no-history fallback', () => {
+  it('rotates a friendly line by seed (deterministic, not random)', () => {
+    const l0 = buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, rotateSeed: 0 });
+    const l1 = buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, rotateSeed: 1 });
+    expect(l0).toBe(WELCOME_FALLBACKS[0]);
+    expect(l1).toBe(WELCOME_FALLBACKS[1]);
+    expect(l0).not.toBe(l1);
+  });
+
+  it('wraps around the fallback list and is stable for a given seed', () => {
+    const n = WELCOME_FALLBACKS.length;
+    const a = buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, rotateSeed: n + 2 });
+    const b = buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, rotateSeed: 2 });
+    expect(a).toBe(b);                       // wrap-around
+    expect(a).toBe(buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, rotateSeed: n + 2 }));
+  });
+
+  it('defaults to the first line when no seed is supplied', () => {
+    expect(buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null })).toBe(WELCOME_FALLBACKS[0]);
+  });
+});

--- a/tests/v4/cli/greeter/welcomeLine.test.ts
+++ b/tests/v4/cli/greeter/welcomeLine.test.ts
@@ -136,4 +136,36 @@ describe('buildWelcomeLine — no-history fallback', () => {
   it('defaults to the first line when no seed is supplied', () => {
     expect(buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null })).toBe(WELCOME_FALLBACKS[0]);
   });
+
+  it('an explicit fallbackIndex selects that pool line and wins over rotateSeed', () => {
+    for (let i = 0; i < WELCOME_FALLBACKS.length; i++) {
+      expect(buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, fallbackIndex: i, rotateSeed: 0 }))
+        .toBe(WELCOME_FALLBACKS[i]);
+    }
+  });
+
+  it('fallbackIndex wraps (round-robin never goes out of range)', () => {
+    const n = WELCOME_FALLBACKS.length;
+    expect(buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, fallbackIndex: n })).toBe(WELCOME_FALLBACKS[0]);
+    expect(buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, fallbackIndex: n + 3 })).toBe(WELCOME_FALLBACKS[3]);
+  });
+
+  it('consecutive round-robin indices never repeat the same line twice running', () => {
+    let prev = '';
+    for (let i = 0; i < WELCOME_FALLBACKS.length * 2; i++) {
+      const line = buildWelcomeLine({ ...base, lastSessionAt: null, recallSummary: null, fallbackIndex: i });
+      expect(line).not.toBe(prev);
+      prev = line;
+    }
+  });
+
+  it('the pool is warm, one-line, width-safe (≤1 emoji, ≤72 chars)', () => {
+    const emoji = /\p{Extended_Pictographic}/gu;
+    for (const line of WELCOME_FALLBACKS) {
+      expect(line).not.toContain('\n');
+      expect(line.length).toBeLessThanOrEqual(72);
+      expect((line.match(emoji) ?? []).length).toBeLessThanOrEqual(1);
+    }
+    expect(WELCOME_FALLBACKS.length).toBeGreaterThanOrEqual(6);
+  });
 });

--- a/tests/v4/cli/onboarding/speakFirst.test.ts
+++ b/tests/v4/cli/onboarding/speakFirst.test.ts
@@ -21,8 +21,30 @@ import {
   renderOnboardingIntro,
   isOnboardingShown,
   resetOnboarding,
+  normalizeOnboardingName,
+  parseUserName,
+  readUserName,
+  type OnboardingMemory,
 } from '../../../../cli/v4/onboarding/speakFirst';
 import { resolveAidenPaths, type AidenPaths } from '../../../../core/v4/paths';
+
+/** In-memory MemoryManager stand-in that writes to the real USER.md path so
+ *  the ask→store→use loop can be asserted end-to-end against disk. */
+function fakeMemory(paths: AidenPaths): OnboardingMemory & { writes: string[] } {
+  const writes: string[] = [];
+  return {
+    writes,
+    async add(file: string, content: string) {
+      writes.push(`${file}:${content}`);
+      if (file === 'user') {
+        await fs.mkdir(path.dirname(paths.userMd), { recursive: true });
+        const prev = await fs.readFile(paths.userMd, 'utf8').catch(() => '');
+        await fs.writeFile(paths.userMd, prev ? `${prev}\n§\n${content}` : content, 'utf8');
+      }
+      return { ok: true };
+    },
+  };
+}
 
 let tmp: string;
 let paths: AidenPaths;
@@ -68,43 +90,106 @@ describe('shouldOnboard — trigger guard', () => {
 });
 
 describe('renderOnboardingIntro', () => {
-  it('brand-new + TTY: paints the utility-framed intro and writes the marker', async () => {
+  it('brand-new + TTY: paints the calm intro, asks ONE thing (the name)', async () => {
     const { out, text } = ttyOut(true);
-    const fired = await renderOnboardingIntro({ paths, out });
+    const fired = await renderOnboardingIntro({ paths, out, readAnswer: async () => null });
     expect(fired).toBe(true);
     const t = text();
-    expect(t).toMatch(/I'll work better if I know a bit about you/);
-    expect(t).toMatch(/What should I call you, and what are you working on\?/);
+    expect(t).toMatch(/Hi — I'm Aiden/);
+    expect(t).toMatch(/right here on your machine/);
+    expect(t).toMatch(/What should I call you\?/);
+    // One question only — no "what are you working on" survey this slice.
+    expect(t).not.toMatch(/what are you working on/i);
     // Personalization, not companionship — no feelings/intimacy framing.
-    expect(t).not.toMatch(/feel|miss you|love|lonely|friend/i);
+    expect(t).not.toMatch(/miss you|love|lonely|feelings/i);
     expect(await isOnboardingShown(paths)).toBe(true);
   });
 
+  // ★ the whole point — ask → STORE → (USE tested via the greeter elsewhere).
+  it('captures the name and STORES it to USER.md via the memory write path', async () => {
+    const mem = fakeMemory(paths);
+    const { out, text } = ttyOut(true);
+    const fired = await renderOnboardingIntro({ paths, out, memory: mem, readAnswer: async () => 'Shiva' });
+    expect(fired).toBe(true);
+    // Stored through the real namespace, exact durable format.
+    expect(mem.writes).toEqual(["user:User's name is Shiva. (source: onboarding)"]);
+    expect(await readUserName(paths.userMd)).toBe('Shiva');
+    expect(text()).toMatch(/Good to meet you, Shiva/);
+    expect(await isOnboardingShown(paths)).toBe(true);
+  });
+
+  it('normalizes a chatty answer to a clean call-name before storing', async () => {
+    const mem = fakeMemory(paths);
+    await renderOnboardingIntro({ paths, out: ttyOut(true).out, memory: mem, readAnswer: async () => "I'm Shiva" });
+    expect(await readUserName(paths.userMd)).toBe('Shiva');
+  });
+
+  it('empty answer → NO store, marker still set, graceful, never re-asks', async () => {
+    const mem = fakeMemory(paths);
+    const { out, text } = ttyOut(true);
+    const fired = await renderOnboardingIntro({ paths, out, memory: mem, readAnswer: async () => '   ' });
+    expect(fired).toBe(true);
+    expect(mem.writes).toEqual([]);                    // nothing stored
+    expect(await readUserName(paths.userMd)).toBeNull();
+    expect(text()).toMatch(/just say the word/i);      // graceful fallback
+    expect(await isOnboardingShown(paths)).toBe(true); // marker set → no re-ask
+    // Proof of no re-ask: a second run does not fire.
+    expect(await renderOnboardingIntro({ paths, out: ttyOut(true).out, memory: mem, readAnswer: async () => 'Late' })).toBe(false);
+    expect(await readUserName(paths.userMd)).toBeNull();
+  });
+
   it('idempotent: second call does not fire (marker written on first)', async () => {
-    const a = await renderOnboardingIntro({ paths, out: ttyOut().out });
-    const b = await renderOnboardingIntro({ paths, out: ttyOut().out });
+    const a = await renderOnboardingIntro({ paths, out: ttyOut().out, readAnswer: async () => 'Shiva', memory: fakeMemory(paths) });
+    const b = await renderOnboardingIntro({ paths, out: ttyOut().out, readAnswer: async () => 'Again', memory: fakeMemory(paths) });
     expect(a).toBe(true);
     expect(b).toBe(false);
   });
 
-  it('non-TTY: never paints (no interactive reply to extract)', async () => {
+  it('non-TTY out: never paints, no hang, marker not written', async () => {
     const { out, text } = ttyOut(false);
     expect(await renderOnboardingIntro({ paths, out })).toBe(false);
     expect(text()).toBe('');
-    // marker NOT written, so a later TTY boot can still onboard.
     expect(await isOnboardingShown(paths)).toBe(false);
+  });
+
+  it('non-interactive STDIN (piped): fires but reads nothing → no store, no hang', async () => {
+    const mem = fakeMemory(paths);
+    const { out } = ttyOut(true);                       // output IS a tty…
+    const pipedStdin = { isTTY: false } as unknown as NodeJS.ReadStream;   // …but stdin is piped
+    const fired = await renderOnboardingIntro({ paths, out, memory: mem, input: pipedStdin });
+    expect(fired).toBe(true);                           // intro shown
+    expect(mem.writes).toEqual([]);                     // default reader returned null → no store
+    expect(await isOnboardingShown(paths)).toBe(true);  // still marks (no re-ask)
   });
 
   it('existing user (non-empty USER.md): never paints', async () => {
     await fs.writeFile(paths.userMd, 'Name: Shiva\n', 'utf8');
     const { out, text } = ttyOut(true);
-    expect(await renderOnboardingIntro({ paths, out })).toBe(false);
+    expect(await renderOnboardingIntro({ paths, out, readAnswer: async () => 'X' })).toBe(false);
     expect(text()).toBe('');
   });
 
   it('resetOnboarding clears the marker so it can fire again', async () => {
-    await renderOnboardingIntro({ paths, out: ttyOut().out });
+    await renderOnboardingIntro({ paths, out: ttyOut().out, readAnswer: async () => null });
     expect(await resetOnboarding(paths)).toBe(true);
     expect(await shouldOnboard(paths)).toBe(true);
+  });
+});
+
+describe('name parsing helpers', () => {
+  it('normalizeOnboardingName strips lead-ins, quotes, punctuation; caps length', () => {
+    expect(normalizeOnboardingName('Shiva')).toBe('Shiva');
+    expect(normalizeOnboardingName("I'm Shiva")).toBe('Shiva');
+    expect(normalizeOnboardingName('my name is Shiva Deore')).toBe('Shiva Deore');
+    expect(normalizeOnboardingName('call me "Shiv".')).toBe('Shiv');
+    expect(normalizeOnboardingName('   ')).toBeNull();
+    expect(normalizeOnboardingName(null)).toBeNull();
+    expect(normalizeOnboardingName('x'.repeat(80))!.length).toBe(40);
+  });
+
+  it('parseUserName round-trips the stored line and tolerates other entries', () => {
+    expect(parseUserName("User's name is Shiva. (source: onboarding)")).toBe('Shiva');
+    expect(parseUserName("Likes dark mode\n§\nUser's name is Ada. (source: onboarding)")).toBe('Ada');
+    expect(parseUserName('no name here')).toBeNull();
   });
 });

--- a/tests/v4/core/mcpAuthRequired.test.ts
+++ b/tests/v4/core/mcpAuthRequired.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the typed `auth_required` anti-fake-success chain, end to end:
+ *   build → verifier flags failed → classifier marks NON-RECOVERABLE auth →
+ *   decideTaskVerdict blocks `completed` ("needs reauth for <provider>").
+ * Plus the regression contrast: a RAW auth string (no envelope) classifies as
+ * `other`/recoverable — the exact fake-success hole the typed result closes.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { buildMcpAuthRequiredResult, readAuthRequired } from '../../../core/v4/mcp/authRequired';
+import { defaultVerifier } from '../../../core/v4/verifier';
+import { buildDefaultClassifier } from '../../../core/v4/failureClassifier';
+import { decideTaskVerdict } from '../../../core/v4/taskVerification';
+import type { ToolCallResult } from '../../../providers/v4/types';
+import type { HonestyTraceEntry } from '../../../moat/honestyEnforcement';
+
+const TOOL = 'mcp_github_create_issue';
+const authRes = () => buildMcpAuthRequiredResult('github', 'token revoked', 'Run /mcp auth github');
+const asToolResult = (): ToolCallResult => ({ id: '1', name: TOOL, result: authRes() } as ToolCallResult);
+
+// ── the typed result ─────────────────────────────────────────────────────────
+describe('buildMcpAuthRequiredResult / readAuthRequired', () => {
+  it('builds a success:false result with a structured, non-retryable envelope', () => {
+    const r = authRes();
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/^auth_required: needs reauth for github/);
+    expect(r.auth_required).toEqual({
+      error: 'auth_required', provider: 'github', reason: 'token revoked',
+      retryable: false, reauth_hint: 'Run /mcp auth github',
+    });
+  });
+  it('reads the envelope back and returns null for non-auth results', () => {
+    expect(readAuthRequired(asToolResult())?.provider).toBe('github');
+    expect(readAuthRequired({ id: '2', name: 'x', result: { success: true } } as ToolCallResult)).toBeNull();
+    expect(readAuthRequired({ id: '3', name: 'x', result: 'plain string' } as ToolCallResult)).toBeNull();
+  });
+});
+
+// ── the chain: verifier → classifier ─────────────────────────────────────────
+describe('auth_required — verifier + classifier', () => {
+  it('the verifier flags the typed result as failed (success:false)', () => {
+    const v = defaultVerifier(TOOL, {}, asToolResult());
+    expect(v.ok).toBe(false);
+    expect(v.code).toBe('failed');
+  });
+
+  it('the classifier marks it NON-RECOVERABLE auth (never blind-retry an auth wall)', () => {
+    const v = defaultVerifier(TOOL, {}, asToolResult());
+    const c = buildDefaultClassifier().classify(v, TOOL, {}, asToolResult());
+    expect(c?.category).toBe('auth');
+    expect(c?.recoverable).toBe(false);
+    expect(c?.matchedPattern).toBe('auth_required');
+    expect(c?.reason).toContain('github');
+    expect(c?.recoveryHint?.action).toBe('request_user_action');
+  });
+
+  it('REGRESSION: a raw "needs re-authorization" string (no envelope) is NOT robustly caught → recoverable', () => {
+    // This is the pre-fix hole: the raw throw matched no AUTH_PATTERN and fell
+    // through to `other`/recoverable — a blind-retry-the-auth-wall / fake-success
+    // vector. The typed envelope above closes it.
+    const raw: ToolCallResult = { id: '9', name: TOOL, error: 'MCP server "github" needs re-authorization — run /mcp auth github' } as ToolCallResult;
+    const v = defaultVerifier(TOOL, {}, raw);
+    const c = buildDefaultClassifier().classify(v, TOOL, {}, raw);
+    expect(c?.category).not.toBe('auth');
+    expect(c?.recoverable).toBe(true);
+  });
+});
+
+// ── the guarantee: a task cannot complete on an auth-failed side effect ───────
+describe('auth_required — verify-before-done blocks completion', () => {
+  const mutatingEntry = (): HonestyTraceEntry => ({
+    name: TOOL,
+    handlerMutates: true, // MCP tools register mutates:true
+    result: authRes(),
+    verification: defaultVerifier(TOOL, {}, asToolResult()),
+  } as HonestyTraceEntry);
+
+  it('a mutating auth-failed side effect → verification_failed, NOT completed', () => {
+    const d = decideTaskVerdict([mutatingEntry()]);
+    expect(d.verdict).toBe('verification_failed');
+    expect(d.verdict).not.toBe('completed');
+    expect(d.failures[0].tool).toBe(TOOL);
+    expect(d.failures[0].reason).toContain('needs reauth for github');
+  });
+
+  it('surfaces the provider so the runtime can say "needs reauth for <provider>"', () => {
+    const d = decideTaskVerdict([mutatingEntry()]);
+    expect(d.failures.map((f) => f.reason).join(' ')).toMatch(/needs reauth for github/);
+  });
+
+  it('a successful mutating side effect still completes (no false blocking)', () => {
+    const okEntry: HonestyTraceEntry = {
+      name: TOOL, handlerMutates: true,
+      result: { success: true, id: 42 },
+      verification: { ok: true, confidence: 1, code: 'ok' },
+    } as HonestyTraceEntry;
+    expect(decideTaskVerdict([okEntry]).verdict).toBe('completed');
+  });
+});

--- a/tests/v4/core/mcpDeviceFlow.test.ts
+++ b/tests/v4/core/mcpDeviceFlow.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — RFC 8628 device-flow coverage. Generic (provider-agnostic): the
+ * request/parse, the §3.5 poll state machine (pending / slow_down / denied /
+ * expired / success), the GitHub 200-with-error quirk, and the end-to-end
+ * orchestration — all against a scripted fetch, no network.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  requestDeviceAuthorization,
+  pollDeviceTokenOnce,
+  runMcpDeviceFlow,
+  type DeviceFlowConfig,
+} from '../../../core/v4/mcp/deviceFlow';
+import type { FetchImpl, OAuthUserAgent } from '../../../core/v4/auth/oauthFlow';
+
+const DEVICE_EP = 'https://prov.example/device/code';
+const TOKEN_EP = 'https://prov.example/token';
+const CFG: DeviceFlowConfig = { deviceAuthorizationEndpoint: DEVICE_EP, tokenEndpoint: TOKEN_EP, clientId: 'cid', scope: 'repo' };
+
+type Resp = { status: number; body: unknown };
+const reply = (r: Resp) => ({ status: r.status, text: async () => (typeof r.body === 'string' ? r.body : JSON.stringify(r.body)) });
+
+/** Fetch stub: device endpoint returns `device`; token endpoint walks `tokens`. */
+function mkFetch(device: Resp, tokens: Resp[] = []): FetchImpl & { deviceCalls: number; tokenCalls: number } {
+  let ti = 0;
+  const fn = (async (url: string) => {
+    if (url === DEVICE_EP) { fn.deviceCalls++; return reply(device); }
+    fn.tokenCalls++;
+    return reply(tokens[Math.min(ti++, tokens.length - 1)]);
+  }) as FetchImpl & { deviceCalls: number; tokenCalls: number };
+  fn.deviceCalls = 0; fn.tokenCalls = 0;
+  return fn;
+}
+
+function mkUa(): { logs: string[]; opened: string[]; sleeps: number; ua: OAuthUserAgent } {
+  const logs: string[] = []; const opened: string[] = []; let sleeps = 0;
+  const ua: OAuthUserAgent = {
+    log: (l) => logs.push(l),
+    openBrowser: async (u) => { opened.push(u); },
+    prompt: async () => { throw new Error('device flow needs no prompt'); },
+    sleep: async () => { sleeps++; },
+  };
+  return { logs, opened, get sleeps() { return sleeps; }, ua };
+}
+
+const DEVICE_OK: Resp = { status: 200, body: {
+  device_code: 'DC', user_code: 'WXYZ-1234', verification_uri: 'https://prov.example/activate',
+  verification_uri_complete: 'https://prov.example/activate?code=WXYZ-1234', expires_in: 900, interval: 5,
+} };
+const TOKEN_OK: Resp = { status: 200, body: { access_token: 'at-123', refresh_token: 'rt-456', token_type: 'bearer', scope: 'repo', expires_in: 3600 } };
+
+// ── request device authorization ─────────────────────────────────────────────
+describe('requestDeviceAuthorization', () => {
+  it('parses device_code / user_code / verification_uri (+ complete, interval, expires)', async () => {
+    const auth = await requestDeviceAuthorization(CFG, mkFetch(DEVICE_OK));
+    expect(auth.deviceCode).toBe('DC');
+    expect(auth.userCode).toBe('WXYZ-1234');
+    expect(auth.verificationUri).toBe('https://prov.example/activate');
+    expect(auth.verificationUriComplete).toContain('code=WXYZ-1234');
+    expect(auth.intervalSeconds).toBe(5);
+    expect(auth.expiresInSeconds).toBe(900);
+  });
+
+  it('throws on a non-200 device-authorization response', async () => {
+    await expect(requestDeviceAuthorization(CFG, mkFetch({ status: 400, body: { error: 'invalid_client' } })))
+      .rejects.toThrow(/Device authorization request failed: HTTP 400/);
+  });
+
+  it('throws when required fields are missing', async () => {
+    await expect(requestDeviceAuthorization(CFG, mkFetch({ status: 200, body: { user_code: 'X' } })))
+      .rejects.toThrow(/missing device_code/);
+  });
+});
+
+// ── the §3.5 poll state machine ──────────────────────────────────────────────
+describe('pollDeviceTokenOnce — RFC 8628 §3.5 states', () => {
+  const poll = (t: Resp) => pollDeviceTokenOnce(CFG, 'DC', mkFetch(DEVICE_OK, [t]));
+
+  it('success → returns the parsed token', async () => {
+    const o = await poll(TOKEN_OK);
+    expect(o.kind).toBe('success');
+    if (o.kind === 'success') { expect(o.result.accessToken).toBe('at-123'); expect(o.result.refreshToken).toBe('rt-456'); }
+  });
+  it('authorization_pending → pending (400 body)', async () => {
+    expect((await poll({ status: 400, body: { error: 'authorization_pending' } })).kind).toBe('pending');
+  });
+  it('GitHub quirk: HTTP 200 with error=authorization_pending → pending', async () => {
+    expect((await poll({ status: 200, body: { error: 'authorization_pending' } })).kind).toBe('pending');
+  });
+  it('slow_down → slow_down', async () => {
+    expect((await poll({ status: 400, body: { error: 'slow_down' } })).kind).toBe('slow_down');
+  });
+  it('access_denied → denied', async () => {
+    expect((await poll({ status: 400, body: { error: 'access_denied' } })).kind).toBe('denied');
+  });
+  it('expired_token → expired', async () => {
+    expect((await poll({ status: 400, body: { error: 'expired_token' } })).kind).toBe('expired');
+  });
+  it('unknown error → error with message', async () => {
+    const o = await poll({ status: 400, body: { error: 'nope', error_description: 'bad' } });
+    expect(o.kind).toBe('error');
+    if (o.kind === 'error') expect(o.message).toMatch(/nope.*bad/);
+  });
+});
+
+// ── end-to-end orchestration ─────────────────────────────────────────────────
+describe('runMcpDeviceFlow', () => {
+  it('happy path: shows code, polls through pending, stores the token', async () => {
+    const fetchImpl = mkFetch(DEVICE_OK, [
+      { status: 400, body: { error: 'authorization_pending' } },
+      { status: 400, body: { error: 'authorization_pending' } },
+      TOKEN_OK,
+    ]);
+    const u = mkUa();
+    const result = await runMcpDeviceFlow({ config: CFG, server: 'github', ua: u.ua, fetchImpl, now: () => 0 });
+    expect(result.accessToken).toBe('at-123');
+    expect(u.logs.join('\n')).toMatch(/Enter code:\s+WXYZ-1234/);
+    expect(u.opened[0]).toContain('code=WXYZ-1234'); // opened the pre-filled URL
+    expect(fetchImpl.tokenCalls).toBe(3);            // pending, pending, success
+  });
+
+  it('slow_down keeps polling then succeeds (backs off, does not error)', async () => {
+    const fetchImpl = mkFetch(DEVICE_OK, [{ status: 400, body: { error: 'slow_down' } }, TOKEN_OK]);
+    const result = await runMcpDeviceFlow({ config: CFG, server: 's', ua: mkUa().ua, fetchImpl, now: () => 0 });
+    expect(result.accessToken).toBe('at-123');
+  });
+
+  it('access_denied → clean throw', async () => {
+    const fetchImpl = mkFetch(DEVICE_OK, [{ status: 400, body: { error: 'access_denied' } }]);
+    await expect(runMcpDeviceFlow({ config: CFG, server: 's', ua: mkUa().ua, fetchImpl, now: () => 0 }))
+      .rejects.toThrow(/denied/i);
+  });
+
+  it('expired_token → clean throw with retry hint', async () => {
+    const fetchImpl = mkFetch(DEVICE_OK, [{ status: 400, body: { error: 'expired_token' } }]);
+    await expect(runMcpDeviceFlow({ config: CFG, server: 's', ua: mkUa().ua, fetchImpl, now: () => 0 }))
+      .rejects.toThrow(/expired.*again/i);
+  });
+
+  it('deadline exceeded → times out (never polls forever)', async () => {
+    // Clock advances: 1st read sets the deadline (t=0 → deadline=900s), the next
+    // read is already past it → the while-loop is skipped → clean timeout.
+    let calls = 0;
+    const now = () => (calls++ === 0 ? 0 : 10_000_000);
+    const fetchImpl = mkFetch(DEVICE_OK, [{ status: 400, body: { error: 'authorization_pending' } }]);
+    await expect(runMcpDeviceFlow({ config: CFG, server: 's', ua: mkUa().ua, fetchImpl, now }))
+      .rejects.toThrow(/Timed out/);
+  });
+});

--- a/tests/v4/core/mcpDeviceFlow.test.ts
+++ b/tests/v4/core/mcpDeviceFlow.test.ts
@@ -121,7 +121,7 @@ describe('runMcpDeviceFlow', () => {
     const u = mkUa();
     const result = await runMcpDeviceFlow({ config: CFG, server: 'github', ua: u.ua, fetchImpl, now: () => 0 });
     expect(result.accessToken).toBe('at-123');
-    expect(u.logs.join('\n')).toMatch(/Enter code:\s+WXYZ-1234/);
+    expect(u.logs.join('\n')).toMatch(/Enter the code:\s+WXYZ-1234/);
     expect(u.opened[0]).toContain('code=WXYZ-1234'); // opened the pre-filled URL
     expect(fetchImpl.tokenCalls).toBe(3);            // pending, pending, success
   });
@@ -144,6 +144,24 @@ describe('runMcpDeviceFlow', () => {
       .rejects.toThrow(/expired.*again/i);
   });
 
+  it('shows the URL, code, expiry and cancel instruction (headless-safe UX)', async () => {
+    const u = mkUa();
+    await runMcpDeviceFlow({ config: CFG, server: 'gh', ua: u.ua, fetchImpl: mkFetch(DEVICE_OK, [TOKEN_OK]), now: () => 0 });
+    const out = u.logs.join('\n');
+    expect(out).toContain('https://prov.example/activate'); // URL ALWAYS printed (SSH/WSL safe)
+    expect(out).toContain('WXYZ-1234');                     // code
+    expect(out).toMatch(/expires in ~\d+ min/);             // expiry
+    expect(out).toMatch(/Ctrl\+C to cancel/);               // cancel instruction
+  });
+
+  it('an aborted signal cancels the poller cleanly (no hang, clear error)', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetchImpl = mkFetch(DEVICE_OK, [{ status: 400, body: { error: 'authorization_pending' } }]);
+    await expect(runMcpDeviceFlow({ config: CFG, server: 'gh', ua: mkUa().ua, fetchImpl, now: () => 0, signal: controller.signal }))
+      .rejects.toThrow(/Cancelled/);
+  });
+
   it('deadline exceeded → times out (never polls forever)', async () => {
     // Clock advances: 1st read sets the deadline (t=0 → deadline=900s), the next
     // read is already past it → the while-loop is skipped → clean timeout.
@@ -151,6 +169,6 @@ describe('runMcpDeviceFlow', () => {
     const now = () => (calls++ === 0 ? 0 : 10_000_000);
     const fetchImpl = mkFetch(DEVICE_OK, [{ status: 400, body: { error: 'authorization_pending' } }]);
     await expect(runMcpDeviceFlow({ config: CFG, server: 's', ua: mkUa().ua, fetchImpl, now }))
-      .rejects.toThrow(/Timed out/);
+      .rejects.toThrow(/code expired/);
   });
 });

--- a/tests/v4/core/mcpDeviceRouting.test.ts
+++ b/tests/v4/core/mcpDeviceRouting.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — ensureMcpOAuthConfig routing. The choice between DCR+loopback and the
+ * static device flow happens HERE. Three branches, all against a mocked
+ * discovery fetch + a real (temp) encrypted token store:
+ *   • no registration_endpoint + a static device client → device config
+ *   • no registration_endpoint + NO static client       → honest throw (unchanged)
+ *   • registration_endpoint present                      → DCR/loopback (unchanged)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { ensureMcpOAuthConfig } from '../../../core/v4/mcp/oauthDiscovery';
+import { resolveAidenPaths, type AidenPaths } from '../../../core/v4/paths';
+
+const SERVER_URL = 'https://srv.example/mcp/';
+const AS = 'https://as.example';
+
+type J = Record<string, unknown>;
+type FetchLike = (url: string, init?: { method?: string; headers?: Record<string, string>; body?: string }) =>
+  Promise<{ ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }>;
+
+/** Mock discovery: PRM → AS metadata → (optional) registration POST. */
+function mkFetch(prm: J | null, asMeta: J | null, regResponse?: J): FetchLike {
+  const ok = (j: J) => ({ ok: true, status: 200, json: async () => j, text: async () => JSON.stringify(j) });
+  const nf = () => ({ ok: false, status: 404, json: async () => ({}), text: async () => 'not found' });
+  return async (url, init) => {
+    if (url.includes('/.well-known/oauth-protected-resource')) return prm ? ok(prm) : nf();
+    if (url.includes('/.well-known/oauth-authorization-server') || url.includes('/.well-known/openid-configuration')) {
+      return asMeta ? ok(asMeta) : nf();
+    }
+    if (regResponse && init?.method === 'POST') return ok(regResponse); // registration_endpoint
+    return nf();
+  };
+}
+
+const PRM: J = { authorization_servers: [AS], resource: SERVER_URL };
+const AS_NO_DCR: J = { authorization_endpoint: `${AS}/authorize`, token_endpoint: `${AS}/token` };
+const AS_DCR: J = { ...AS_NO_DCR, registration_endpoint: `${AS}/register` };
+
+let tmp: string; let paths: AidenPaths;
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-mcp-route-'));
+  paths = resolveAidenPaths({ rootOverride: tmp });
+});
+afterEach(async () => { await fs.rm(tmp, { recursive: true, force: true }).catch(() => undefined); });
+
+describe('ensureMcpOAuthConfig — flow routing', () => {
+  it('no DCR + static device client → device-flow config (secret-free)', async () => {
+    const cfg = await ensureMcpOAuthConfig(paths, 'prov', SERVER_URL, {
+      fetchFn: mkFetch(PRM, AS_NO_DCR),
+      redirectUris: ['http://127.0.0.1:8765/callback'],
+      staticClient: { clientId: 'cid-123', deviceAuthorizationEndpoint: 'https://prov.example/device/code', scopes: ['repo', 'read:org'] },
+    });
+    expect(cfg.clientId).toBe('cid-123');
+    expect(cfg.endpoints.deviceAuthorizationEndpoint).toBe('https://prov.example/device/code');
+    expect(cfg.endpoints.tokenEndpoint).toBe(`${AS}/token`);
+    expect(cfg.redirectUris).toEqual([]);            // device flow has no redirect
+    expect(cfg.scopes).toEqual(['repo', 'read:org']);
+    expect(cfg.clientSecret).toBeUndefined();        // no secret
+  });
+
+  it('no DCR + NO static client → honest throw (unchanged behavior)', async () => {
+    await expect(ensureMcpOAuthConfig(paths, 'prov', SERVER_URL, {
+      fetchFn: mkFetch(PRM, AS_NO_DCR),
+      redirectUris: ['http://127.0.0.1:8765/callback'],
+    })).rejects.toThrow(/no registration_endpoint.*no device-flow client is configured/s);
+  });
+
+  it('DCR-capable server → loopback/DCR path (device endpoint absent, not regressed)', async () => {
+    const cfg = await ensureMcpOAuthConfig(paths, 'prov', SERVER_URL, {
+      fetchFn: mkFetch(PRM, AS_DCR, { client_id: 'dcr-client-999' }),
+      redirectUris: ['http://127.0.0.1:8765/callback'],
+      // a staticClient is present but MUST be ignored when DCR is available
+      staticClient: { clientId: 'should-not-be-used', deviceAuthorizationEndpoint: 'https://nope/device' },
+    });
+    expect(cfg.clientId).toBe('dcr-client-999');                     // from DCR, not the static client
+    expect(cfg.endpoints.deviceAuthorizationEndpoint).toBeUndefined(); // loopback path
+    expect(cfg.redirectUris).toEqual(['http://127.0.0.1:8765/callback']);
+  });
+
+  it('device-obtained config persists to the same encrypted store + is reused idempotently', async () => {
+    const deps = {
+      fetchFn: mkFetch(PRM, AS_NO_DCR),
+      redirectUris: [] as string[],
+      staticClient: { clientId: 'cid-persist', deviceAuthorizationEndpoint: 'https://prov.example/device/code' },
+    };
+    await ensureMcpOAuthConfig(paths, 'prov', SERVER_URL, deps);
+    // token file written under <home>/auth/mcp_prov.json (encrypted)
+    const authFile = path.join(tmp, 'auth', 'mcp_prov.json');
+    const raw = await fs.readFile(authFile, 'utf8');
+    expect(raw).not.toContain('cid-persist');          // encrypted at rest, not plaintext
+    // Second call is idempotent — returns the stored client without re-discovery.
+    const again = await ensureMcpOAuthConfig(paths, 'prov', SERVER_URL, {
+      ...deps, fetchFn: async () => { throw new Error('should not re-discover'); },
+    });
+    expect(again.clientId).toBe('cid-persist');
+  });
+});

--- a/tests/v4/core/mcpQuietBackground.test.ts
+++ b/tests/v4/core/mcpQuietBackground.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — stop bothering the human with background MCP housekeeping.
+ *   Fix 1: reconnect/retry/give-up chatter routes through the injected log
+ *          channel ONLY (boot points that at a file sink) — the client has no
+ *          chat/display dependency, so none of it can reach the conversation.
+ *   Fix 2: a server that DECLARES OAuth but has no token yet is marked
+ *          `needs-auth` QUIETLY — no establish, no reconnect-retry loop, no
+ *          "giving up" alarm. A previously-ready server that DROPS still retries.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createMcpClient } from '../../../core/v4/mcpClient';
+import { ToolRegistry } from '../../../core/v4/toolRegistry';
+import type { McpServerConfig } from '../../../core/v4/mcpClient';
+import type { McpExitInfo } from '../../../core/v4/mcp/transport';
+
+interface FakeTransport {
+  label: string;
+  request: (method: string) => Promise<unknown>;
+  notify: () => void;
+  onNotification: () => void;
+  onExit: (h: (info: McpExitInfo) => void) => void;
+  close: () => Promise<void>;
+  triggerExit: (info: McpExitInfo) => void;
+}
+function makeFake(opts: { initError?: Error; tools?: string[] } = {}): FakeTransport {
+  const exitHandlers: Array<(info: McpExitInfo) => void> = [];
+  let closed = false;
+  return {
+    label: 'fake',
+    request: async (method: string) => {
+      if (method === 'initialize') { if (opts.initError) throw opts.initError; return { capabilities: {} }; }
+      if (method === 'tools/list') return { tools: (opts.tools ?? ['a']).map((n) => ({ name: n, description: n, inputSchema: { type: 'object', properties: {} } })) };
+      return { content: [{ type: 'text', text: 'ok' }] };
+    },
+    notify: () => {}, onNotification: () => {},
+    onExit: (h) => { exitHandlers.push(h); },
+    close: async () => { closed = true; },
+    triggerExit: (info) => { if (!closed) for (const h of exitHandlers) h(info); },
+  };
+}
+
+// ── Fix 1 — chatter on the log channel only ──────────────────────────────────
+describe('Fix 1 — reconnect/give-up chatter routes to the log channel (chat-free)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('a dropped ready server reconnects+gives-up entirely via the injected log', async () => {
+    const logs: Array<[string, string]> = [];
+    const registry = new ToolRegistry();
+    const queue: FakeTransport[] = [makeFake({ tools: ['a'] })]; // first connects ready
+    const client = createMcpClient(registry, {
+      log: (lvl, msg) => logs.push([lvl, msg]),
+      // every RECONNECT transport fails the handshake → forces the give-up path
+      stdioFactory: (() => queue.shift() ?? makeFake({ initError: new Error('ECONNREFUSED') })) as never,
+      reconnect: { baseDelayMs: 10, maxDelayMs: 10, jitter: () => 0, maxPostReadyAttempts: 1 },
+    });
+    const server = await client.connect({ name: 'fs', type: 'stdio', stdio: { command: 'x', args: [] } });
+    (server.transport as unknown as FakeTransport).triggerExit({ code: 1, signal: null });
+    await vi.advanceTimersByTimeAsync(200);
+
+    const msgs = logs.map(([, m]) => m).join('\n');
+    expect(msgs).toMatch(/disconnected/);
+    expect(msgs).toMatch(/reconnecting \(attempt 1\/1\)/);
+    expect(msgs).toMatch(/failed after 1 retries/);
+    // The client exposes NO chat/display surface — its sole output is this log
+    // callback. Boot wires that to a file, so the conversation stays clean.
+  });
+});
+
+// ── Fix 2 — un-authorized OAuth server: quiet, no retry loop ──────────────────
+describe('Fix 2 — a token-less OAuth server is quietly needs-auth (no giving-up alarm)', () => {
+  const OAUTH_CFG: McpServerConfig = {
+    name: 'github', type: 'http',
+    http: { baseUrl: 'https://api.example/mcp/', oauth: { deviceAuthorizationEndpoint: 'https://example/device/code' } },
+  };
+
+  it("resolve 'none' + config declares OAuth → needs-auth, no establish, no reconnect", async () => {
+    const logs: Array<[string, string]> = [];
+    const registry = new ToolRegistry();
+    const client = createMcpClient(registry, {
+      log: (lvl, msg) => logs.push([lvl, msg]),
+      authProvider: { resolve: async () => ({ state: 'none' }) }, // nothing persisted yet
+      // If connect ever tried to establish, it would call this and throw.
+      streamableFactory: (() => { throw new Error('MUST NOT build a transport for an un-authorized server'); }) as never,
+    });
+    const server = await client.connect(OAUTH_CFG);
+    expect(server.status).toBe('needs-auth');
+    expect(client.get('github')?.status).toBe('needs-auth');
+
+    const msgs = logs.map(([, m]) => m).join('\n');
+    expect(msgs).not.toMatch(/reconnecting|failed after|giving up/); // NO alarm
+    expect(logs.filter(([, m]) => /needs auth/.test(m)).length).toBe(1); // calm hint, once
+  });
+
+  it("a plain (non-OAuth) http server with resolve 'none' still connects normally (unchanged)", async () => {
+    const registry = new ToolRegistry();
+    let built = 0;
+    const client = createMcpClient(registry, {
+      log: () => {},
+      authProvider: { resolve: async () => ({ state: 'none' }) },
+      streamableFactory: (() => { built += 1; return makeFake({ tools: ['x'] }); }) as never,
+    });
+    const server = await client.connect({ name: 'plain', type: 'http', http: { baseUrl: 'https://plain.example/mcp' } });
+    expect(built).toBe(1);               // DID establish (no oauth declared)
+    expect(server.status).toBe('ready');
+  });
+});

--- a/tests/v4/core/mcpRefresh.test.ts
+++ b/tests/v4/core/mcpRefresh.test.ts
@@ -159,8 +159,8 @@ class AuthFailTransport implements McpTransport {
   close(): Promise<void> { return Promise.resolve(); }
 }
 
-describe('McpClient.callTool — persistent auth error → needs-auth', () => {
-  it('transitions to needs-auth, unregisters tools, tells the model to re-auth', async () => {
+describe('McpClient.callTool — persistent auth error → typed auth_required (v4.14)', () => {
+  it('returns a TYPED auth_required result (not a raw throw), locks the server needs-auth', async () => {
     const registry = new ToolRegistry();
     const client = createMcpClient(registry, {
       log: () => {},
@@ -171,7 +171,19 @@ describe('McpClient.callTool — persistent auth error → needs-auth', () => {
     expect(server.status).toBe('ready');
     expect(registry.get('mcp_gm_t')).toBeDefined();
 
-    await expect(client.callTool('gm', 't', {})).rejects.toThrow(/re-authorization|run \/mcp auth/);
+    // v4.14 anti-fake-success — the auth failure comes back as a first-class
+    // typed result the runtime understands, never a raw exception the model
+    // could misread as transient.
+    const result = await client.callTool('gm', 't', {}) as {
+      success: boolean; error: string;
+      auth_required?: { provider: string; retryable: boolean; reauth_hint: string };
+    };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^auth_required:/);
+    expect(result.auth_required?.provider).toBe('gm');
+    expect(result.auth_required?.retryable).toBe(false);
+    expect(result.auth_required?.reauth_hint).toMatch(/\/mcp auth gm/);
+
     expect(client.get('gm')?.status).toBe('needs-auth');
     expect(client.get('gm')?.tools).toEqual([]);
     expect(registry.get('mcp_gm_t')).toBeUndefined();

--- a/tests/v4/moat/defaultAutonomyUx.test.ts
+++ b/tests/v4/moat/defaultAutonomyUx.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 UX polish (Bug 2) — the default trust level stops over-prompting on
+ * safe, reversible actions, WITHOUT weakening any floor.
+ *
+ *   • Default level is Partner: workspace-internal writes/moves auto-allow.
+ *   • FLOORS UNCHANGED: destructive / external-send / spend / out-of-scope
+ *     still ASK; the hard-block set still DENIES — at every level.
+ *   • Blanket grants (session/always) are recorded ONLY for safe classes; a
+ *     destructive/external/spend call asks every single time.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { ApprovalEngine, type ApprovalRequest } from '../../../moat/approvalEngine';
+import { resolveAutonomyPolicy, isNeverBlanketAllow } from '../../../moat/autonomy';
+import { resolveConfiguredAutonomyLevel } from '../../../core/v4/config';
+
+const WS = '/work/space';
+const cfg = (vals: Record<string, unknown>) => ({
+  getValue: (<T,>(k: string, fb?: T): T => (k in vals ? (vals[k] as T) : (fb as T))),
+});
+function wreq(over: Partial<ApprovalRequest> & { toolName?: string } = {}): ApprovalRequest {
+  return { toolName: 'file_write', category: 'write', args: { path: `${WS}/a.txt` }, ...over } as ApprovalRequest;
+}
+/** An engine at the DEFAULT level (Partner), workspace rooted at WS. */
+function defaultEngine(promptUser = vi.fn().mockResolvedValue('deny')) {
+  const level = resolveConfiguredAutonomyLevel(cfg({}));   // nothing configured → default
+  const e = new ApprovalEngine('smart', { promptUser });
+  e.setAutonomyPolicy(resolveAutonomyPolicy(level, { workspaceRoots: [WS] }));
+  return { e, promptUser };
+}
+
+// ── the default level ───────────────────────────────────────────────────────
+describe('resolveConfiguredAutonomyLevel — the sane default', () => {
+  it('nothing configured → Partner (auto-allows safe workspace writes)', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({}))).toBe('Partner');
+  });
+  it('explicit approval_mode: manual is respected → Assistant (cautious)', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'manual' }))).toBe('Assistant');
+  });
+  it('approval_mode smart / off → Partner', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'smart' }))).toBe('Partner');
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'off' }))).toBe('Partner');
+  });
+  it('explicit agent.autonomy always wins', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Observer' }))).toBe('Observer');
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Assistant', 'agent.approval_mode': 'smart' }))).toBe('Assistant');
+  });
+  it('a garbage agent.autonomy never RAISES — falls back to the default', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Superuser' }))).toBe('Partner');
+  });
+});
+
+// ── safe classes auto-allow at the default level (no prompt) ─────────────────
+describe('default level — safe/reversible classes auto-allow (zero prompt)', () => {
+  it('a workspace-internal write (absolute path) auto-allows', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ args: { path: `${WS}/src/x.ts` } }))).toBe(true);
+    expect(promptUser).not.toHaveBeenCalled();
+  });
+  it('a workspace-internal write with a RELATIVE path auto-allows', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ args: { path: 'notes/today.md' } }))).toBe(true);
+    expect(promptUser).not.toHaveBeenCalled();
+  });
+  it('a move WITHIN the workspace auto-allows', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ toolName: 'file_move', args: { from: `${WS}/a.txt`, to: `${WS}/b.txt` } }))).toBe(true);
+    expect(promptUser).not.toHaveBeenCalled();
+  });
+  it('reads always allow (category read short-circuits)', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ toolName: 'file_read', category: 'read', args: { path: '/anywhere/at/all' } }))).toBe(true);
+    expect(promptUser).not.toHaveBeenCalled();
+  });
+});
+
+// ── FLOORS unchanged — still ASK / DENY at the default level ─────────────────
+describe('default level — floors STILL gate (unchanged)', () => {
+  it('destructive (dangerous) still ASKS', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ toolName: 'file_delete', riskTier: 'dangerous' }))).toBe(false);
+    expect(promptUser).toHaveBeenCalledOnce();
+  });
+  it('an out-of-workspace write still ASKS', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ args: { path: '/etc/hosts' } }))).toBe(false);
+    expect(promptUser).toHaveBeenCalledOnce();
+  });
+  it('an ESCAPING relative path (../) resolves out-of-scope and ASKS', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ args: { path: '../../etc/passwd' } }))).toBe(false);
+    expect(promptUser).toHaveBeenCalledOnce();
+  });
+  it('an external send still ASKS', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ toolName: 'send_message', category: 'network', args: {} }))).toBe(false);
+    expect(promptUser).toHaveBeenCalledOnce();
+  });
+  it('an external SPEND still ASKS', async () => {
+    const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ toolName: 'api_call', effects: { externalSpend: true }, args: {} }))).toBe(false);
+    expect(promptUser).toHaveBeenCalledOnce();
+  });
+  it('the hard-block set is DENIED without a prompt (even if promptUser would allow)', async () => {
+    const { e, promptUser } = defaultEngine(vi.fn().mockResolvedValue('allow'));
+    expect(await e.checkApproval(wreq({ toolName: 'shell_exec', category: 'execute', args: { command: 'rm -rf /' } }))).toBe(false);
+    expect(promptUser).not.toHaveBeenCalled();
+  });
+});
+
+// ── session-allow: safe categories suppress re-prompt; floors never do ───────
+describe('blanket session-allow — safe suppresses, destructive/external/spend never', () => {
+  it('approving Session on a SAFE prompted write suppresses the re-prompt for the same category', async () => {
+    // Use Assistant so a workspace write actually prompts (Partner auto-allows).
+    const promptUser = vi.fn().mockResolvedValue('allow_session');
+    const e = new ApprovalEngine('smart', { promptUser });
+    e.setAutonomyPolicy(resolveAutonomyPolicy('Assistant', { workspaceRoots: [WS] }));
+    const req = wreq({ args: { path: `${WS}/report.txt` } });
+    expect(await e.checkApproval(req)).toBe(true);   // 1st: prompted → session-allowed
+    expect(await e.checkApproval(req)).toBe(true);   // 2nd: same signature → suppressed
+    expect(promptUser).toHaveBeenCalledOnce();        // only ONE prompt for the whole category
+  });
+
+  it('a DESTRUCTIVE call asks EVERY time even when the user picks Session', async () => {
+    const promptUser = vi.fn().mockResolvedValue('allow_session');
+    const e = new ApprovalEngine('smart', { promptUser });
+    e.setAutonomyPolicy(resolveAutonomyPolicy('Partner', { workspaceRoots: [WS] }));
+    const del = wreq({ toolName: 'file_delete', riskTier: 'dangerous', args: { path: `${WS}/a.txt` } });
+    expect(await e.checkApproval(del)).toBe(true);    // one-time allow (ran once)
+    expect(await e.checkApproval(del)).toBe(true);
+    expect(promptUser).toHaveBeenCalledTimes(2);      // NOT blanket — asked both times
+  });
+
+  it('an EXTERNAL send asks every time even when Session is picked', async () => {
+    const promptUser = vi.fn().mockResolvedValue('allow_session');
+    const e = new ApprovalEngine('smart', { promptUser });
+    e.setAutonomyPolicy(resolveAutonomyPolicy('Partner', { workspaceRoots: [WS] }));
+    const send = wreq({ toolName: 'send_message', category: 'network', args: { to: 'x' } });
+    await e.checkApproval(send);
+    await e.checkApproval(send);
+    expect(promptUser).toHaveBeenCalledTimes(2);
+  });
+
+  it('even allow_always does NOT persist a blanket for a destructive call', async () => {
+    const persistAllow = vi.fn();
+    const promptUser = vi.fn().mockResolvedValue('allow_always');
+    const e = new ApprovalEngine('smart', { promptUser, persistAllow });
+    e.setAutonomyPolicy(resolveAutonomyPolicy('Partner', { workspaceRoots: [WS] }));
+    const del = wreq({ toolName: 'file_delete', riskTier: 'dangerous', args: { path: `${WS}/a.txt` } });
+    await e.checkApproval(del);
+    expect(persistAllow).not.toHaveBeenCalled();       // never written to the permanent allowlist
+  });
+});
+
+// ── the never-blanket predicate ──────────────────────────────────────────────
+describe('isNeverBlanketAllow — the floor classifier', () => {
+  it('true for destructive / irreversible / external-send / spend', () => {
+    expect(isNeverBlanketAllow(wreq({ riskTier: 'dangerous' }))).toBe(true);
+    expect(isNeverBlanketAllow(wreq({ effects: { irreversible: true } }))).toBe(true);
+    expect(isNeverBlanketAllow(wreq({ toolName: 'send_message' }))).toBe(true);
+    expect(isNeverBlanketAllow(wreq({ effects: { externalSpend: true } }))).toBe(true);
+  });
+  it('false for an ordinary safe write', () => {
+    expect(isNeverBlanketAllow(wreq())).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

One-tap `/mcp connect <name>` — collapse the 3-step MCP connect (catalog add → auth → device code) into a single command. Add it (if needed) → authorize via the RFC 8628 device flow (verification URL + user code) → connected, tools registered. A missing public client id is prompted for once and persisted (never an env var). Honest catalog: one-tap connect is offered only for proven entries — github is flipped `oauthVerified` → true (device flow proven end-to-end against real GitHub); unverified entries stay on the manual path. The old `catalog add` / `auth` / `install` commands are untouched.

Since `origin/main` was still at v4.14.0, this also lands the foundation banked locally along the way:

- **Personality** — a durable last-session marker (fixes the stuck "943h" greeting), first-meeting name capture (ask → store → actually use it), warm rotating boot greetings + a self-update nudge, and less over-prompting on safe workspace actions.
- **MCP OAuth device flow (RFC 8628)** — secret-free login for static-client providers, plus a typed `auth_required` result so a token that dies mid-task can't fake-succeed (wired into the existing verify-before-done gate).
- **Connection housekeeping** — `--client-id` persists (no env var), MCP background chatter routes to a file log instead of the chat stream, and a token-less OAuth server boots quietly instead of alarming.

## Tests

- Full CI-mirrored suite green — **5779 passed / 0 failed**.
- Real-dist smoke (compiled dist): honest-catalog gate + add→auth orchestration + client-id persistence — 12/12.
- Clean-room verified; every commit authored **and** committed by Shiva Deore.

## Not in this PR

No version bump, no npm publish — banking to main only. The live GitHub OAuth connect is smoke-tested separately.
