### PR TITLE
feat(control): /mode command + always-present steering bar (Bug 1 + Bug 2)

### DIFF
--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -114,7 +114,7 @@ import { installResizeGuard } from './resizeGuard';
 import { categorizeEvent } from '../../core/v4/daemon/eventCategories';
 import { captureArtifactFromTrace } from '../../core/v4/daemon/artifactStore';
 // v4.12.1 Pillar 4 Slice 2a — type-next-while-busy.
-import { DuringTurnInput, type BusyEnterMode } from './duringTurnInput';
+import { DuringTurnInput, resolveConfiguredBusyMode, type BusyEnterMode } from './duringTurnInput';
 import { attachTurnInputListener } from './turnInputListener';
 import { requestTurnCancel } from './frame/interruptControls';
 
@@ -658,6 +658,9 @@ export class ChatSession implements ChatSessionLike {
     // still applies after the engine is frozen at boot.
     if (opts.yoloMode) opts.approvalEngine.setMode('off', { userInitiated: true });
     if (opts.resumeHistory) this.history = [...opts.resumeHistory];
+    // v4.14 — restore the persisted preferred busy-mode (agent.busyMode) so a
+    // /busy choice survives a restart. Default 'queue' when unset/garbage.
+    try { this.duringTurnInput.setMode(resolveConfiguredBusyMode(opts.config)); } catch { /* safe */ }
     // v4.14 Pillar 5 Slice C — emit autonomy_changed when the dial is set. The
     // dial changes at the prompt (no active run), so runId is null here: the
     // live subscriber sees it and durable persistence is skipped.
@@ -1651,6 +1654,20 @@ export class ChatSession implements ChatSessionLike {
     const detachTurnInput = attachTurnInputListener({
       cb: {
         onLine: (text) => {
+          // v4.14 — during-turn control words act IMMEDIATELY (never queued).
+          // Pause/resume are only meaningful mid-turn, so they live here (like
+          // the Enter-modes), not as prompt-level slash commands.
+          const word = text.trim().toLowerCase();
+          if (word === '/pause') {
+            const ok = this.duringTurnInput.requestPause();
+            try { this.opts.display.dim(ok ? '  ‖ paused — /resume to continue (Ctrl+C still stops)' : '  ‖ already paused'); } catch { /* defensive */ }
+            return;
+          }
+          if (word === '/resume') {
+            const ok = this.duringTurnInput.resume();
+            try { this.opts.display.dim(ok ? '  ▸ resumed' : '  ▸ not paused'); } catch { /* defensive */ }
+            return;
+          }
           const act = this.duringTurnInput.onBusyEnter(text);
           if (act.action === 'queued') {
             try { this.opts.display.dim(`  ✓ queued (${act.count} pending) — runs after this turn`); } catch { /* defensive */ }
@@ -2055,6 +2072,9 @@ export class ChatSession implements ChatSessionLike {
         // safe boundary and injects the nudge as tool-stream context. The
         // controller owns the buffer; an interrupt clears it (below).
         drainSteer: () => this.duringTurnInput.drainSteer(),
+        // v4.14 — PAUSE gate. The loop awaits this at the SAME safe boundary;
+        // /pause freezes the turn, /resume (or a Ctrl+C abort) unblocks it.
+        waitForResumeIfPaused: (sig) => this.duringTurnInput.waitWhilePaused(sig),
         // v4.11 Slice 4 — expose the per-turn runtime context to
         // tools via `agent.getCurrentTurnContext()`. The spawn /
         // fanout facades read it to thread parent signal + cost

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -115,6 +115,7 @@ import { categorizeEvent } from '../../core/v4/daemon/eventCategories';
 import { captureArtifactFromTrace } from '../../core/v4/daemon/artifactStore';
 // v4.12.1 Pillar 4 Slice 2a — type-next-while-busy.
 import { DuringTurnInput, resolveConfiguredBusyMode, type BusyEnterMode } from './duringTurnInput';
+import { modeStatusLine } from './commands/mode';
 import { attachTurnInputListener } from './turnInputListener';
 import { requestTurnCancel } from './frame/interruptControls';
 
@@ -1660,12 +1661,18 @@ export class ChatSession implements ChatSessionLike {
           const word = text.trim().toLowerCase();
           if (word === '/pause') {
             const ok = this.duringTurnInput.requestPause();
-            try { this.opts.display.dim(ok ? '  ‖ paused — /resume to continue (Ctrl+C still stops)' : '  ‖ already paused'); } catch { /* defensive */ }
+            try {
+              this.opts.display.dim(ok ? '  ‖ paused — /resume to continue (Ctrl+C still stops)' : '  ‖ already paused');
+              this.opts.display.setBusyHint(this.duringTurnInput.busyHint()); // reflect paused state in the bar
+            } catch { /* defensive */ }
             return;
           }
           if (word === '/resume') {
             const ok = this.duringTurnInput.resume();
-            try { this.opts.display.dim(ok ? '  ▸ resumed' : '  ▸ not paused'); } catch { /* defensive */ }
+            try {
+              this.opts.display.dim(ok ? '  ▸ resumed' : '  ▸ not paused');
+              this.opts.display.setBusyHint(this.duringTurnInput.busyHint());
+            } catch { /* defensive */ }
             return;
           }
           const act = this.duringTurnInput.onBusyEnter(text);
@@ -1691,6 +1698,11 @@ export class ChatSession implements ChatSessionLike {
         },
       },
     });
+    // v4.14 BUG 2 — show the input lane the MOMENT the turn starts (a persistent
+    // plain-language hint), so the user sees they can type/steer/queue without
+    // having to type first. It rides the same owned bottom row (indicator / tool
+    // row) that already survives streaming, and is cleared at turn end below.
+    try { this.opts.display.setBusyHint(this.duringTurnInput.busyHint()); } catch { /* defensive */ }
     // Helper: wrap a callback so it only fires for the live turn.
     // R1 guard — late events from a cancelled turn early-return.
     // `wrapTurnId` accepts (callback, undefined) and returns
@@ -2943,6 +2955,13 @@ export class ChatSession implements ChatSessionLike {
         });
       }
     } catch { /* never let the greeter crash boot */ }
+
+    // v4.14 BUG 1 — show the trust level calmly at boot so the user always knows
+    // how autonomous Aiden is right now, and that /mode changes it. One dim line.
+    try {
+      const lvl = this.opts.approvalEngine?.getAutonomyPolicy()?.level;
+      if (lvl) display.dim(`  ${modeStatusLine(lvl)}  ·  /mode to change`);
+    } catch { /* never break boot */ }
 
     // v4.9.0 pre-ship UI: hint moved BEFORE the closing rule so the
     // rule sits adjacent to the active prompt (it becomes the visual

--- a/cli/v4/commands/auto.ts
+++ b/cli/v4/commands/auto.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/commands/auto.ts — v4.14 the one-command autonomy opt-in.
+ *
+ * The SHIPPED default is the safe level (Assistant — asks at each write
+ * boundary). `/auto` is the single, memorable opt-in to Partner ("auto"):
+ * workspace-internal writes act WITHOUT asking, while every floor still gates
+ * (destructive / external-send / spend / shell / out-of-workspace all still
+ * ASK; the hard-block set still DENIES). `/auto off` (or `safe`) returns to
+ * the safe default.
+ *
+ * Both directions PERSIST via `applyAndPersistAutonomy` (writes
+ * `agent.autonomy` to config.yaml), so the choice survives a restart — the
+ * boot path re-reads it through `resolveConfiguredAutonomyLevel`.
+ *
+ * This is a thin, friendly alias over `/autonomy Partner|Assistant`; it shares
+ * the SAME apply+persist helper so the two can never drift, and it uses the
+ * SAME `userInitiated` raise path (never bypasses the SH.1 freeze or any floor).
+ */
+import type { SlashCommand } from '../commandRegistry';
+import type { AutonomyLevel } from '../../../moat/autonomy';
+import { applyAndPersistAutonomy } from './autonomy';
+
+const OFF_WORDS = new Set(['off', 'safe', 'stop', 'no', 'disable']);
+
+export const auto: SlashCommand = {
+  name: 'auto',
+  description: 'Toggle Auto mode (Partner): workspace writes auto-apply; floors still ask.',
+  category: 'system',
+  icon: '⚡',
+  handler: async (ctx) => {
+    if (!ctx.approvalEngine) {
+      ctx.display.warn('Approval engine not wired in this context.');
+      return {};
+    }
+    const arg = (ctx.args[0] ?? '').trim().toLowerCase();
+    const turnOff = OFF_WORDS.has(arg);
+    const target: AutonomyLevel = turnOff ? 'Assistant' : 'Partner';
+
+    const { applied, persisted } = await applyAndPersistAutonomy(ctx, target);
+    if (!applied) {
+      ctx.display.warn('Auto change was not applied (blocked by the approval floor).');
+      return {};
+    }
+
+    const durability = persisted
+      ? (turnOff ? ' Persisted across restarts.' : ' Persisted — stays on across restarts (/auto off to disable).')
+      : ' Session only (config not writable here).';
+
+    if (target === 'Partner') {
+      ctx.display.success(
+        `⚡ Auto ON (Partner) — acts freely under ${process.cwd()}; ` +
+        `destructive / external / spend / out-of-scope still ask.${durability}`,
+      );
+    } else {
+      ctx.display.success(
+        `Auto OFF — safe mode (Assistant): asks at each write boundary.${durability}`,
+      );
+    }
+    return {};
+  },
+};

--- a/cli/v4/commands/autonomy.ts
+++ b/cli/v4/commands/autonomy.ts
@@ -19,12 +19,57 @@
  * in-process / prompt-injected code (no userInitiated) can NEVER raise the
  * level. `--yolo` stays a separate dev bypass, not a dial level.
  */
-import type { SlashCommand } from '../commandRegistry';
-import { isAutonomyLevel, resolveAutonomyPolicy, AUTONOMY_LEVELS } from '../../../moat/autonomy';
+import type { SlashCommand, SlashCommandContext } from '../commandRegistry';
+import {
+  type AutonomyLevel,
+  isAutonomyLevel,
+  resolveAutonomyPolicy,
+  AUTONOMY_LEVELS,
+} from '../../../moat/autonomy';
+
+/**
+ * Apply an autonomy level to the LIVE session AND persist it so the choice
+ * SURVIVES A RESTART. The engine change uses `userInitiated: true` — the ONLY
+ * sanctioned raise path (respects the SH.1 freeze; in-process / prompt-injected
+ * code can never raise the level). Persistence writes `agent.autonomy` to
+ * config.yaml, which `resolveConfiguredAutonomyLevel` reads back at the next
+ * boot (aidenCLI wires the boot default from it).
+ *
+ * Returns `{ applied, persisted }`:
+ *   • applied=false   → no engine, or the approval floor blocked the change.
+ *   • persisted=false → no ConfigManager wired (session-only switch); the
+ *     caller MUST surface this so a change is never silently non-durable.
+ *
+ * Shared by `/autonomy <level>` and `/auto` so the two can never drift.
+ */
+export async function applyAndPersistAutonomy(
+  ctx: SlashCommandContext,
+  level: AutonomyLevel,
+): Promise<{ applied: boolean; persisted: boolean }> {
+  const engine = ctx.approvalEngine;
+  if (!engine) return { applied: false, persisted: false };
+  const policy = resolveAutonomyPolicy(level, { workspaceRoots: [process.cwd()] });
+  const applied = engine.setAutonomyPolicy(policy, { userInitiated: true });
+  if (!applied) return { applied: false, persisted: false };
+  let persisted = false;
+  if (ctx.config) {
+    ctx.config.set('agent.autonomy', level);
+    await ctx.config.save();
+    persisted = true;
+  }
+  return { applied: true, persisted };
+}
+
+/** Human note for a level, appended to the confirmation line. */
+function levelNote(level: AutonomyLevel): string {
+  return level === 'Observer'  ? 'read-only — no mutations will run.'
+    : level === 'Partner' ? `acts freely under ${process.cwd()} — destructive / external / spend / out-of-scope still ask.`
+    : 'acts, asks at each risk boundary.';
+}
 
 export const autonomy: SlashCommand = {
   name: 'autonomy',
-  description: 'Set the autonomy dial: Observer | Assistant | Partner.',
+  description: 'Set the autonomy dial: Observer | Assistant | Partner (persisted).',
   category: 'system',
   icon: '🎚️',
   handler: async (ctx) => {
@@ -39,7 +84,7 @@ export const autonomy: SlashCommand = {
     if (!arg) {
       ctx.display.info(
         `Autonomy: ${current}. Levels: ${AUTONOMY_LEVELS.join(' | ')}. ` +
-        `Usage: /autonomy <level>.`,
+        `Usage: /autonomy <level>  (or /auto to toggle Partner).`,
       );
       return {};
     }
@@ -52,18 +97,15 @@ export const autonomy: SlashCommand = {
       return {};
     }
 
-    const policy = resolveAutonomyPolicy(level, { workspaceRoots: [process.cwd()] });
-    // ★ userInitiated — the ONLY sanctioned raise path; respects SH.1 freeze.
-    const applied = engine.setAutonomyPolicy(policy, { userInitiated: true });
+    const { applied, persisted } = await applyAndPersistAutonomy(ctx, level);
     if (!applied) {
       ctx.display.warn('Autonomy change was not applied (blocked by the approval floor).');
       return {};
     }
-    const note =
-      level === 'Observer'  ? 'read-only — no mutations will run.'
-      : level === 'Partner' ? `acts freely under ${process.cwd()} — destructive / external / out-of-scope still ask.`
-      : 'acts, asks at each risk boundary.';
-    ctx.display.success(`Autonomy set to ${level} — ${note}`);
+    const durability = persisted
+      ? ' Persisted — survives restart.'
+      : ' Session only (config not writable here).';
+    ctx.display.success(`Autonomy set to ${level} — ${levelNote(level)}${durability}`);
     return {};
   },
 };

--- a/cli/v4/commands/busy.ts
+++ b/cli/v4/commands/busy.ts
@@ -42,7 +42,13 @@ export const busy: SlashCommand = {
       return {};
     }
     session.setBusyMode(arg);
-    ctx.display.success(NOTE[arg]);
+    // v4.14 — persist the preferred mode so it survives a restart. Boot re-reads
+    // it via resolveConfiguredBusyMode(agent.busyMode). Session-only if no config.
+    let persisted = false;
+    if (ctx.config) {
+      try { ctx.config.set('agent.busyMode', arg); await ctx.config.save(); persisted = true; } catch { /* best-effort */ }
+    }
+    ctx.display.success(`${NOTE[arg]}${persisted ? ' — persisted across restarts.' : ''}`);
     return {};
   },
 };

--- a/cli/v4/commands/help.ts
+++ b/cli/v4/commands/help.ts
@@ -81,6 +81,8 @@ export const SUBSECTION_MAP: Readonly<Record<string, Subsection>> = {
   autonomy: 'System',
   // v4.14 — one-command opt-in to Partner ("auto"), persisted across restarts.
   auto: 'System',
+  // v4.14 — friendly trust-level viewer/switcher (safe | auto | observer).
+  mode: 'System',
   // v4.12.1 Pillar 4 Slice 2a — type-next-while-busy.
   busy: 'System',
   queue: 'System',

--- a/cli/v4/commands/help.ts
+++ b/cli/v4/commands/help.ts
@@ -79,6 +79,8 @@ export const SUBSECTION_MAP: Readonly<Record<string, Subsection>> = {
   yolo: 'System',
   // v4.12.1 Pillar 2 — the autonomy dial (Observer | Assistant | Partner).
   autonomy: 'System',
+  // v4.14 — one-command opt-in to Partner ("auto"), persisted across restarts.
+  auto: 'System',
   // v4.12.1 Pillar 4 Slice 2a — type-next-while-busy.
   busy: 'System',
   queue: 'System',

--- a/cli/v4/commands/index.ts
+++ b/cli/v4/commands/index.ts
@@ -25,6 +25,7 @@ import { retry } from './retry';
 import { yolo } from './yolo';
 import { autonomy } from './autonomy';
 import { auto } from './auto';
+import { mode } from './mode';
 import { busy } from './busy';
 import { queue } from './queue';
 import { redirect } from './redirect';
@@ -95,6 +96,7 @@ export {
   yolo,
   autonomy,
   auto,
+  mode,
   busy,
   queue,
   redirect,
@@ -166,6 +168,7 @@ export const allCommands: SlashCommand[] = [
   yolo,
   autonomy,
   auto,
+  mode,
   busy,
   queue,
   redirect,

--- a/cli/v4/commands/index.ts
+++ b/cli/v4/commands/index.ts
@@ -24,6 +24,7 @@ import { undo } from './undo';
 import { retry } from './retry';
 import { yolo } from './yolo';
 import { autonomy } from './autonomy';
+import { auto } from './auto';
 import { busy } from './busy';
 import { queue } from './queue';
 import { redirect } from './redirect';
@@ -93,6 +94,7 @@ export {
   retry,
   yolo,
   autonomy,
+  auto,
   busy,
   queue,
   redirect,
@@ -163,6 +165,7 @@ export const allCommands: SlashCommand[] = [
   retry,
   yolo,
   autonomy,
+  auto,
   busy,
   queue,
   redirect,

--- a/cli/v4/commands/mode.ts
+++ b/cli/v4/commands/mode.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/commands/mode.ts — v4.14 the friendly trust-level surface.
+ *
+ * `/mode` (no args) shows the current level + all options in PLAIN language.
+ * `/mode <level>` switches and PERSISTS (survives restart). Accepts friendly
+ * aliases (safe / auto / observer) as well as the canonical dial names. This is
+ * a viewer/switcher over the same autonomy dial `/autonomy` and `/auto` drive —
+ * they share `applyAndPersistAutonomy`, so a level set here is durable and the
+ * three can never drift.
+ *
+ * FLOORS ARE ABSOLUTE AT EVERY LEVEL and are NOT touched here: destructive,
+ * spend, external-send, shell, and out-of-workspace writes still ASK — even in
+ * `auto` (Partner) — and the hard-block set still DENIES. `/mode` only moves the
+ * dial between Observer < Assistant (safe, default) < Partner (auto).
+ */
+import type { SlashCommand } from '../commandRegistry';
+import { type AutonomyLevel, AUTONOMY_LEVELS } from '../../../moat/autonomy';
+import { applyAndPersistAutonomy } from './autonomy';
+
+/** Friendly aliases → the canonical dial level. */
+const ALIASES: Readonly<Record<string, AutonomyLevel>> = {
+  observer: 'Observer', 'read-only': 'Observer', readonly: 'Observer', ro: 'Observer', look: 'Observer',
+  assistant: 'Assistant', safe: 'Assistant', ask: 'Assistant', cautious: 'Assistant',
+  partner: 'Partner', auto: 'Partner', autopilot: 'Partner', full: 'Partner',
+};
+
+/** Plain-language, one-line description of what each level does. */
+const PLAIN: Readonly<Record<AutonomyLevel, string>> = {
+  Observer:  'read-only — looks, never changes anything.',
+  Assistant: 'safe — acts, but asks before each write (the default).',
+  Partner:   'auto — acts freely in this folder; still asks for destructive / spend / send / out-of-folder.',
+};
+
+/** The persistent, plain-language current-mode line (also used at boot/status). */
+export function modeStatusLine(level: AutonomyLevel): string {
+  const short = level === 'Partner' ? 'auto' : level === 'Assistant' ? 'safe' : 'observer';
+  return `Trust: ${short} — ${PLAIN[level]}`;
+}
+
+export const mode: SlashCommand = {
+  name: 'mode',
+  description: 'Show or set the trust level: safe (default) | auto | observer. Persists.',
+  category: 'system',
+  icon: '🎚️',
+  handler: async (ctx) => {
+    const engine = ctx.approvalEngine;
+    if (!engine) { ctx.display.warn('Approval engine not wired in this context.'); return {}; }
+    const current = engine.getAutonomyPolicy()?.level ?? 'Assistant';
+
+    const arg = (ctx.args[0] ?? '').trim().toLowerCase();
+    if (!arg) {
+      // View: current + all options, active one marked, in plain language.
+      ctx.display.info(modeStatusLine(current));
+      for (const lvl of AUTONOMY_LEVELS) {
+        ctx.display.dim(`  ${lvl === current ? '●' : '○'} ${lvl} — ${PLAIN[lvl]}`);
+      }
+      ctx.display.dim('Switch: /mode safe · /mode auto · /mode observer  (/auto is the same as /mode auto). Floors — destructive / spend / send / out-of-folder — always ask, even in auto.');
+      return {};
+    }
+
+    const level = ALIASES[arg] ?? AUTONOMY_LEVELS.find((l) => l.toLowerCase() === arg);
+    if (!level) {
+      ctx.display.warn(`Unknown mode "${arg}". Try: safe | auto | observer.`);
+      return {};
+    }
+
+    const { applied, persisted } = await applyAndPersistAutonomy(ctx, level);
+    if (!applied) {
+      ctx.display.warn('Mode change was not applied (blocked by the approval floor).');
+      return {};
+    }
+    ctx.display.success(
+      `${modeStatusLine(level)}${persisted ? ' · persisted across restarts.' : ' · session only.'}`,
+    );
+    return {};
+  },
+};

--- a/cli/v4/composerRow.ts
+++ b/cli/v4/composerRow.ts
@@ -20,9 +20,13 @@
 
 export type ComposerMode = 'queue' | 'interrupt' | 'redirect';
 
-/** Human label for the mode's Enter action. */
+/** Plain-language verb for what Enter does in this mode (v4.14 — was the raw
+ *  mode name; users read "steer ▸ …" more clearly than "redirect ▸ …"). */
+const PLAIN_LABEL: Readonly<Record<ComposerMode, string>> = {
+  queue: 'queue', interrupt: 'stop', redirect: 'steer',
+};
 export function modeLabel(mode: ComposerMode): string {
-  return mode;   // 'queue' | 'interrupt' | 'redirect' — verb reads as "queue ▸ …"
+  return PLAIN_LABEL[mode];
 }
 
 /**

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -371,6 +371,11 @@ export class Display {
   // whichever owned bottom row is live (activity indicator OR tool row) so it
   // survives long tool calls. Empty string = nothing appended (not noisy).
   private composerText = '';
+  // v4.14 BUG 2 — the PERSISTENT plain-language busy hint ("Enter → steer ·
+  // …"). Set at turn start so the input lane is ALWAYS visible during a turn
+  // (not only after the user types); shown when `composerText` is empty. Empty
+  // = no turn running (or handed back to the normal prompt).
+  private busyComposerHint = '';
   // The active bottom-owner registers a repaint fn here so a keystroke can
   // refresh it immediately instead of waiting for the owner's next tick. The
   // indicator + tool-row each set/restore this around their lifetime.
@@ -1809,16 +1814,37 @@ export class Display {
     this.composerRepaint?.();
   }
 
-  /** Clear the composer (turn end / handoff back to the normal prompt). */
-  clearComposer(): void {
-    if (this.composerText === '') return;
-    this.composerText = '';
+  /**
+   * v4.14 BUG 2 — set the PERSISTENT plain-language busy hint so the input lane
+   * is visible the moment a turn starts (before any keystroke). Called at turn
+   * start and whenever the hint changes (e.g. pause/resume). Repaints the live
+   * owned bottom row so it shows immediately.
+   */
+  setBusyHint(hint: string): void {
+    if (hint === this.busyComposerHint) return;
+    this.busyComposerHint = hint;
     this.composerRepaint?.();
   }
 
-  /** The suffix woven into the live owned bottom row. '' when inactive. */
+  /** Clear the composer (turn end / handoff back to the normal prompt). Drops
+   *  BOTH the typed text and the persistent busy hint. */
+  clearComposer(): void {
+    if (this.composerText === '' && this.busyComposerHint === '') return;
+    this.composerText = '';
+    this.busyComposerHint = '';
+    this.composerRepaint?.();
+  }
+
+  /**
+   * The suffix woven into the live owned bottom row. While the user is typing,
+   * show the typed text; otherwise, during a turn, show the persistent
+   * plain-language hint so the input lane is ALWAYS visible; '' only when no
+   * turn is running.
+   */
   private composerSuffix(): string {
-    return this.composerText ? `   ${this.skin.applyColors(this.composerText, 'muted')}` : '';
+    if (this.composerText) return `   ${this.skin.applyColors(this.composerText, 'muted')}`;
+    if (this.busyComposerHint) return `   ${this.skin.applyColors(this.busyComposerHint, 'muted')}`;
+    return '';
   }
 
   /** An owned bottom-row painter registers its repaint fn for the duration it

--- a/cli/v4/duringTurnInput.ts
+++ b/cli/v4/duringTurnInput.ts
@@ -5,18 +5,30 @@
  * Aiden — local-first agent.
  */
 /**
- * cli/v4/duringTurnInput.ts — v4.12.1 Pillar 4 Slice 2a.
+ * cli/v4/duringTurnInput.ts — v4.12.1 Pillar 4 Slice 2a; extended v4.14.
  *
- * The pure, renderer-agnostic controller for "type to Aiden while a turn is
- * running." It owns the type-next QUEUE and the busy-Enter MODE — no stdin, no
- * render, so it's fully unit-testable headlessly. Both the frame and legacy
- * keypress sources feed this one controller.
+ * The pure, renderer-agnostic ENGINE for "type to Aiden while a turn is
+ * running." It owns the type-next QUEUE, the busy-Enter MODE, the PAUSE gate,
+ * the BACKGROUND-handoff intent, and the plain-language indicator text — no
+ * stdin, no render, no timers, so it's fully unit-testable headlessly. Every
+ * live-input surface drives this ONE engine: the terminal steering bar AND the
+ * future dashboard are just adapters over it (this is the reusable-engine seam
+ * — nothing terminal-specific lives here).
  *
- * Modes: 'queue' (Enter-while-busy queues the message for after the turn — the
- * safe default), 'interrupt' (Enter cancels the turn), and 'redirect' (v4.12.1
- * Slice 2b — Enter injects a mid-turn nudge as tool-stream context at the safe
- * loop boundary; user-facing command is `/redirect`). `esc` is a distinct
+ * Enter-modes (what Enter does mid-turn): 'queue' (queue the message for after
+ * the turn — the safe default), 'interrupt' (cancel the turn), and 'redirect'
+ * (v4.12.1 Slice 2b — inject a mid-turn nudge as tool-stream context at the
+ * safe loop boundary; user-facing command is `/redirect`). `esc` is a distinct
  * always-live interrupt key handled by the keypress source, NOT a mode.
+ *
+ * Orthogonal controls (v4.14, driven by commands, not Enter-modes):
+ *   • PAUSE — freeze the loop at its next safe boundary; resume on command. The
+ *     engine holds only the flag + a waiter list; the loop awaits
+ *     `waitWhilePaused` at the SAME boundary steer injects at.
+ *   • BACKGROUND — a one-shot intent the session reads to hand the running turn
+ *     to the durable-run substrate; the engine never touches the daemon.
+ *   • Steer SALVAGE — if a turn ends with a steer still buffered (no safe
+ *     boundary was reached), it's moved to the queue, never silently dropped.
  *
  * Internal identifiers (pendingSteer / drainSteer / clearSteer / the 'steered'
  * action) keep the original verb — only the user-facing surface says redirect.
@@ -39,7 +51,7 @@ export type BusyEnterAction =
 
 export class DuringTurnInput {
   private queue: string[] = [];
-  private mode: BusyEnterMode = 'queue';
+  private mode: BusyEnterMode;
   /**
    * v4.12.1 Slice 2b — the pending mid-turn steer. Buffered here (a member of
    * chatSession's controller, so "on the session" per the design) and drained
@@ -47,6 +59,16 @@ export class DuringTurnInput {
    * Multiple nudges before the boundary accumulate (newline-joined).
    */
   private pendingSteer: string | null = null;
+
+  // v4.14 — orthogonal controls (pause gate + background handoff intent).
+  private paused = false;
+  private resumeWaiters: Array<() => void> = [];
+  private backgroundRequested = false;
+
+  /** `initialMode` restores a persisted preferred busy-mode at session boot. */
+  constructor(initialMode: BusyEnterMode = 'queue') {
+    this.mode = isBusyEnterMode(initialMode) ? initialMode : 'queue';
+  }
 
   // ── Mode ─────────────────────────────────────────────────────────────────
   setMode(mode: BusyEnterMode): void { this.mode = mode; }
@@ -119,5 +141,90 @@ export class DuringTurnInput {
     }
     const count = this.enqueue(text);
     return { action: 'queued', count, text: text.trim() };
+  }
+
+  // ── Pause / Resume (v4.14) ────────────────────────────────────────────────
+  /** Request a freeze. The loop, at its next safe boundary, awaits
+   *  `waitWhilePaused`. Returns false if already paused (idempotent). */
+  requestPause(): boolean {
+    if (this.paused) return false;
+    this.paused = true;
+    return true;
+  }
+
+  isPaused(): boolean { return this.paused; }
+
+  /** Resume from a pause; wakes every boundary awaiting `waitWhilePaused`.
+   *  Returns true if it was actually paused. */
+  resume(): boolean {
+    if (!this.paused) return false;
+    this.paused = false;
+    const waiters = this.resumeWaiters;
+    this.resumeWaiters = [];
+    for (const w of waiters) w();
+    return true;
+  }
+
+  /**
+   * Await here at a safe loop boundary while paused. Resolves immediately when
+   * not paused; otherwise when `resume()` fires — or when the turn's abort
+   * signal aborts, so Ctrl+C during a pause still cancels cleanly (the loop
+   * then sees `signal.aborted`). Renderer-agnostic: only a flag + waiter list,
+   * no timers, no stdin.
+   */
+  waitWhilePaused(signal?: AbortSignal): Promise<void> {
+    if (!this.paused || signal?.aborted) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.resumeWaiters.push(resolve);
+      signal?.addEventListener('abort', () => resolve(), { once: true });
+    });
+  }
+
+  // ── Background handoff (v4.14) ────────────────────────────────────────────
+  /** Flag the running turn to be handed to the durable-run substrate. The
+   *  session reads this via `takeBackgroundRequest` and does the handoff — the
+   *  engine never touches the daemon. */
+  requestBackground(): void { this.backgroundRequested = true; }
+
+  /** Read + clear the background-handoff intent (one-shot). */
+  takeBackgroundRequest(): boolean {
+    const b = this.backgroundRequested;
+    this.backgroundRequested = false;
+    return b;
+  }
+
+  hasBackgroundRequest(): boolean { return this.backgroundRequested; }
+
+  // ── Steer salvage (v4.14) ─────────────────────────────────────────────────
+  /**
+   * Called when a turn ENDS with a steer still buffered — the loop never
+   * reached a safe injection boundary (e.g. a text-only turn that finished
+   * before any tool batch). Rather than silently dropping the nudge, move it to
+   * the type-next queue so it runs next, and return it so the UI can show a
+   * visible "couldn't steer mid-turn — queued instead" note. Null when there
+   * was nothing pending.
+   */
+  salvageSteerToQueue(): string | null {
+    const s = this.drainSteer();
+    if (s === null) return null;
+    this.enqueue(s);
+    return s;
+  }
+
+  // ── Indicator text (v4.14) — shared by the terminal bar AND the dashboard ──
+  /** ONE clear current action for the busy bar, in plain language. */
+  enterActionLabel(): string {
+    if (this.paused) return 'paused';
+    switch (this.mode) {
+      case 'interrupt': return 'Enter → stop turn';
+      case 'redirect':  return 'Enter → steer';
+      default:          return 'Enter → queue';
+    }
+  }
+
+  /** The compact one-line busy hint: current action + how to switch + stop. */
+  busyHint(): string {
+    if (this.paused) return 'Paused · /resume to continue · Ctrl+C stop';
+    return `${this.enterActionLabel()} · /busy to change · Ctrl+C stop`;
   }
 }

--- a/cli/v4/duringTurnInput.ts
+++ b/cli/v4/duringTurnInput.ts
@@ -42,6 +42,20 @@ export function isBusyEnterMode(s: unknown): s is BusyEnterMode {
   return s === 'queue' || s === 'interrupt' || s === 'redirect';
 }
 
+/**
+ * Read the persisted preferred busy-mode from config (`agent.busyMode`) so the
+ * user's choice survives a restart — the boot path seeds `DuringTurnInput` with
+ * it. A missing/garbage value coerces to the safe default 'queue' and never
+ * RAISES to interrupt/redirect. Kept cli-side (config only needs `getValue`) so
+ * core never depends on this module.
+ */
+export function resolveConfiguredBusyMode(
+  config?: { getValue<T = unknown>(key: string, fallback?: T): T },
+): BusyEnterMode {
+  const raw = config?.getValue<string | undefined>('agent.busyMode', undefined);
+  return isBusyEnterMode(raw) ? raw : 'queue';
+}
+
 /** What the keypress source should DO with an Enter pressed during a turn. */
 export type BusyEnterAction =
   | { action: 'queued';  count: number; text: string }

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -436,6 +436,15 @@ export interface RunConversationOptions {
    */
   drainSteer?:       () => string | null;
   /**
+   * v4.14 — PAUSE gate. Called by the loop at the SAME safe boundary as
+   * `drainSteer` (history balanced, before the next provider call). Awaits
+   * while the user has paused the turn and resolves on /resume — or on abort,
+   * so a Ctrl+C during a pause unblocks and the top-of-loop signal check
+   * cancels cleanly. Omitted by daemon agents + unit tests (no interactive
+   * pause) — a missing hook means "never pauses".
+   */
+  waitForResumeIfPaused?: (signal?: AbortSignal) => Promise<void>;
+  /**
    * v4.11 Slice 4 — optional per-turn `TurnRuntimeContext`. When
    * provided, the loop exposes it via `agent.getCurrentTurnContext()`
    * so the spawn / fanout tool facades can route through the
@@ -2037,6 +2046,14 @@ export class AidenAgent {
       }
 
       messages.push(...turnToolMessages);
+
+      // ── v4.14 — PAUSE gate at the SAME safe boundary ─────────────────
+      // If the user paused mid-turn, freeze HERE (history balanced, before the
+      // next provider call fires). Resumes on /resume; an abort during a pause
+      // unblocks the waiter so the top-of-loop signal check stops the turn.
+      if (runOptions.waitForResumeIfPaused) {
+        await runOptions.waitForResumeIfPaused(runOptions.signal);
+      }
       // Loop continues — provider gets the tool results next iteration.
     }
 

--- a/core/v4/config.ts
+++ b/core/v4/config.ts
@@ -210,31 +210,32 @@ function setDotted(obj: Record<string, unknown>, key: string, value: unknown): v
  * `agent.autonomy` wins; a typo must never silently RAISE autonomy, so an
  * invalid value falls through to the default rather than throwing.
  *
- * v4.14 UX (Bug 2) — the DEFAULT is now `Partner`, not `Assistant`.
+ * v4.14 — the SHIPPED default is the SAFE, documented level: `Assistant`
+ * (acts, asks at each write boundary). Shipping the most-autonomous level by
+ * default is the wrong risk posture, so the brief Partner-as-default
+ * experiment is REVERTED. `Partner` ("auto") is now an explicit, one-command
+ * OPT-IN (`/auto`), persisted as `agent.autonomy: Partner` and read back here
+ * on the next boot — so the opt-in survives a restart.
  *
- * Why: the old default (Assistant, `allowWrite: 'ask'`) prompted on EVERY
- * write, including routine safe/reversible workspace-internal writes and
- * moves — the "asks too often" nag that trains blind-yes. `Partner` is the
- * level the dial already defines as "acts freely INSIDE the workspace;
- * destructive + external-send + out-of-scope still ask." It auto-allows only
- * the genuinely-safe class and KEEPS EVERY FLOOR intact (destructive,
- * external send, spend, shell, out-of-workspace all still ask; the hard-block
- * set still denies). Choosing Partner-as-default — rather than loosening
- * Assistant (which would collapse two distinct levels into one) — keeps all
- * three levels meaningful: Observer (read-only) < Assistant (asks at every
- * write) < Partner (workspace writes auto). No floor is touched.
+ * The three levels stay meaningful: Observer (read-only) < Assistant (asks at
+ * every write) < Partner (workspace writes auto). NO floor moves at any level:
+ * destructive, external-send, spend, shell, and out-of-workspace writes still
+ * ASK, and the hard-block set still DENIES — including under `/auto` (Partner).
  *
- * A user who explicitly opted into the cautious `approval_mode: manual` is
- * respected → Assistant (asks at every write boundary). Everything else
- * (smart / off / unset) → Partner.
+ * `approval_mode` no longer RAISES the level. Nothing configured — or any
+ * `approval_mode` value — resolves to the safe `Assistant` default; only an
+ * explicit, valid `agent.autonomy` (e.g. the persisted `/auto` opt-in, or a
+ * hand-set `Observer`) selects another level. A typo never silently raises
+ * autonomy: an invalid value falls through to `Assistant`.
  */
 export function resolveConfiguredAutonomyLevel(config: {
   getValue<T = unknown>(key: string, fallback?: T): T;
 }): AutonomyLevel {
   const raw = config.getValue<string | undefined>('agent.autonomy', undefined);
   if (isAutonomyLevel(raw)) return raw;
-  const mode = config.getValue<'manual' | 'smart' | 'off' | undefined>('agent.approval_mode', undefined);
-  return mode === 'manual' ? 'Assistant' : 'Partner';
+  // Nothing valid configured → the safe default. Partner is an explicit
+  // opt-in only (persisted `agent.autonomy`); no `approval_mode` value raises.
+  return 'Assistant';
 }
 
 export class ConfigManager implements ConfigProvider {

--- a/tests/v4/cli/commands.test.ts
+++ b/tests/v4/cli/commands.test.ts
@@ -59,7 +59,7 @@ function makeCtx(over: Record<string, unknown> = {}) {
 }
 
 describe('barrel exports', () => {
-  it('allCommands has 57 entries with unique names', () => {
+  it('allCommands has 58 entries with unique names', () => {
     // Phase 16b.3 added /identity (17 → 18).
     // Phase 16b.4 added /debug-prompt (18 → 19).
     // Phase 16c added /streaming (19 → 20).
@@ -95,9 +95,10 @@ describe('barrel exports', () => {
     // v4.12.1 Pillar 4 Slice 2a added /busy + /queue (53 → 55).
     // v4.12.1 Pillar 4 Slice 2b added /redirect (55 → 56).
     // v4.14 added /auto (one-command Partner opt-in) (56 → 57).
-    expect(allCommands.length).toBe(57);
+    // v4.14 added /mode (friendly trust-level viewer/switcher) (57 → 58).
+    expect(allCommands.length).toBe(58);
     const names = new Set(allCommands.map((c) => c.name));
-    expect(names.size).toBe(57);
+    expect(names.size).toBe(58);
   });
 
   it('every command exposes name, description, category', () => {

--- a/tests/v4/cli/commands.test.ts
+++ b/tests/v4/cli/commands.test.ts
@@ -59,7 +59,7 @@ function makeCtx(over: Record<string, unknown> = {}) {
 }
 
 describe('barrel exports', () => {
-  it('allCommands has 46 entries with unique names', () => {
+  it('allCommands has 57 entries with unique names', () => {
     // Phase 16b.3 added /identity (17 → 18).
     // Phase 16b.4 added /debug-prompt (18 → 19).
     // Phase 16c added /streaming (19 → 20).
@@ -94,9 +94,10 @@ describe('barrel exports', () => {
     // v4.12.1 Pillar 2 added /autonomy (52 → 53).
     // v4.12.1 Pillar 4 Slice 2a added /busy + /queue (53 → 55).
     // v4.12.1 Pillar 4 Slice 2b added /redirect (55 → 56).
-    expect(allCommands.length).toBe(56);
+    // v4.14 added /auto (one-command Partner opt-in) (56 → 57).
+    expect(allCommands.length).toBe(57);
     const names = new Set(allCommands.map((c) => c.name));
-    expect(names.size).toBe(56);
+    expect(names.size).toBe(57);
   });
 
   it('every command exposes name, description, category', () => {

--- a/tests/v4/cli/commands/autoOptIn.test.ts
+++ b/tests/v4/cli/commands/autoOptIn.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — `/auto` is the one-command opt-in to Partner ("auto"), and the
+ * choice PERSISTS across restarts. This proves the round-trip:
+ *   1. `/auto` sets the live engine level to Partner AND writes
+ *      `agent.autonomy: Partner` to config (set + save).
+ *   2. On the "next boot", `resolveConfiguredAutonomyLevel` reads that back
+ *      → Partner. So the opt-in survives a restart.
+ *   3. `/auto off` returns to the safe default (Assistant), also persisted.
+ *   4. No ConfigManager wired → session-only switch with a visible note
+ *      (never silently non-durable).
+ *   5. `/autonomy <level>` shares the SAME apply+persist helper.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { auto } from '../../../../cli/v4/commands/auto';
+import { autonomy } from '../../../../cli/v4/commands/autonomy';
+import { ApprovalEngine } from '../../../../moat/approvalEngine';
+import { resolveConfiguredAutonomyLevel } from '../../../../core/v4/config';
+import type { SlashCommandContext } from '../../../../cli/v4/commandRegistry';
+
+/** A config double that records dotted writes and reads them back (as boot would). */
+function fakeConfig() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    set: (k: string, v: unknown) => { store[k] = v; },
+    save: vi.fn(async () => {}),
+    getValue: <T,>(k: string, fb?: T): T => (k in store ? (store[k] as T) : (fb as T)),
+  };
+}
+function captured() {
+  const out: string[] = [];
+  return {
+    out,
+    info: (m: string) => out.push(`info:${m}`),
+    warn: (m: string) => out.push(`warn:${m}`),
+    success: (m: string) => out.push(`ok:${m}`),
+    dim: (m: string) => out.push(`dim:${m}`),
+    write: (m: string) => out.push(m),
+    printError: (m: string) => out.push(`err:${m}`),
+  };
+}
+function buildCtx(
+  args: string[],
+  opts: { engine?: ApprovalEngine; config?: ReturnType<typeof fakeConfig> } = {},
+) {
+  const display = captured();
+  const ctx = {
+    args,
+    rawArgs: args.join(' '),
+    display,
+    approvalEngine: opts.engine,
+    config: opts.config,
+  } as unknown as SlashCommandContext;
+  return { ctx, display };
+}
+const text = (d: ReturnType<typeof captured>) => d.out.join('\n');
+
+describe('/auto — one-command opt-in to Partner, persisted', () => {
+  it('/auto sets the live level to Partner AND persists agent.autonomy=Partner', async () => {
+    const engine = new ApprovalEngine('smart');
+    const config = fakeConfig();
+    const { ctx, display } = buildCtx([], { engine, config });
+
+    await auto.handler(ctx);
+
+    expect(engine.getAutonomyPolicy()?.level).toBe('Partner');   // live session flipped
+    expect(config.store['agent.autonomy']).toBe('Partner');       // written to config
+    expect(config.save).toHaveBeenCalledOnce();                   // flushed to disk
+    expect(text(display)).toMatch(/Auto ON \(Partner\)/);
+    expect(text(display)).toMatch(/Persisted/);
+  });
+
+  it('the persisted opt-in SURVIVES A RESTART (boot re-reads it → Partner)', async () => {
+    const engine = new ApprovalEngine('smart');
+    const config = fakeConfig();
+    const { ctx } = buildCtx([], { engine, config });
+    await auto.handler(ctx);
+
+    // Simulate the next boot: a fresh resolver reading the persisted config.
+    expect(resolveConfiguredAutonomyLevel(config)).toBe('Partner');
+  });
+
+  it('/auto off returns to the safe default (Assistant), also persisted', async () => {
+    const engine = new ApprovalEngine('smart');
+    const config = fakeConfig();
+    config.set('agent.autonomy', 'Partner');                      // start opted-in
+
+    const { ctx, display } = buildCtx(['off'], { engine, config });
+    await auto.handler(ctx);
+
+    expect(engine.getAutonomyPolicy()?.level).toBe('Assistant');
+    expect(config.store['agent.autonomy']).toBe('Assistant');     // opt-in cleared
+    expect(resolveConfiguredAutonomyLevel(config)).toBe('Assistant'); // safe on next boot
+    expect(text(display)).toMatch(/Auto OFF/);
+  });
+
+  it('no ConfigManager wired → session-only switch, with a visible note (not silent)', async () => {
+    const engine = new ApprovalEngine('smart');
+    const { ctx, display } = buildCtx([], { engine });            // no config
+    await auto.handler(ctx);
+
+    expect(engine.getAutonomyPolicy()?.level).toBe('Partner');    // live switch still works
+    expect(text(display)).toMatch(/Session only/);                // durability surfaced
+  });
+
+  it('no approval engine → a clear warning, no crash', async () => {
+    const { ctx, display } = buildCtx([]);                        // nothing wired
+    await auto.handler(ctx);
+    expect(text(display)).toMatch(/Approval engine not wired/);
+  });
+});
+
+describe('/autonomy <level> — shares the same persist helper', () => {
+  it('/autonomy Partner persists agent.autonomy=Partner (survives restart)', async () => {
+    const engine = new ApprovalEngine('smart');
+    const config = fakeConfig();
+    const { ctx, display } = buildCtx(['Partner'], { engine, config });
+
+    await autonomy.handler(ctx);
+
+    expect(engine.getAutonomyPolicy()?.level).toBe('Partner');
+    expect(config.store['agent.autonomy']).toBe('Partner');
+    expect(resolveConfiguredAutonomyLevel(config)).toBe('Partner');
+    expect(text(display)).toMatch(/Persisted/);
+  });
+
+  it('/autonomy Observer persists too (any explicit level is durable)', async () => {
+    const engine = new ApprovalEngine('smart');
+    const config = fakeConfig();
+    const { ctx } = buildCtx(['observer'], { engine, config });   // case-insensitive
+    await autonomy.handler(ctx);
+    expect(config.store['agent.autonomy']).toBe('Observer');
+  });
+});

--- a/tests/v4/cli/commands/busyPersistence.test.ts
+++ b/tests/v4/cli/commands/busyPersistence.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — /busy persists the preferred Enter-while-busy mode so it survives a
+ * restart: it writes `agent.busyMode` to config, and boot re-reads it via
+ * resolveConfiguredBusyMode. A garbage stored value never RAISES to a more
+ * autonomous mode — it coerces to the safe 'queue'.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { busy } from '../../../../cli/v4/commands/busy';
+import { resolveConfiguredBusyMode } from '../../../../cli/v4/duringTurnInput';
+import type { SlashCommandContext } from '../../../../cli/v4/commandRegistry';
+
+function fakeConfig() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    set: (k: string, v: unknown) => { store[k] = v; },
+    save: vi.fn(async () => {}),
+    getValue: <T,>(k: string, fb?: T): T => (k in store ? (store[k] as T) : (fb as T)),
+  };
+}
+function fakeSession() {
+  let mode = 'queue';
+  return { setBusyMode: (m: string) => { mode = m; }, getBusyMode: () => mode };
+}
+function buildCtx(args: string[], opts: { session?: unknown; config?: ReturnType<typeof fakeConfig> }) {
+  const out: string[] = [];
+  const display = {
+    info: (m: string) => out.push(`info:${m}`),
+    warn: (m: string) => out.push(`warn:${m}`),
+    success: (m: string) => out.push(`ok:${m}`),
+  };
+  const ctx = { args, rawArgs: args.join(' '), display, session: opts.session, config: opts.config } as unknown as SlashCommandContext;
+  return { ctx, out };
+}
+const text = (o: string[]) => o.join('\n');
+
+describe('resolveConfiguredBusyMode', () => {
+  it('reads a valid persisted mode', () => {
+    expect(resolveConfiguredBusyMode({ getValue: (<T,>(_k: string, _fb?: T) => 'redirect' as unknown as T) })).toBe('redirect');
+  });
+  it('defaults to queue when unset, and coerces garbage to queue (never RAISES)', () => {
+    expect(resolveConfiguredBusyMode()).toBe('queue');
+    expect(resolveConfiguredBusyMode({ getValue: (<T,>(_k: string, fb?: T) => fb as T) })).toBe('queue');
+    expect(resolveConfiguredBusyMode({ getValue: (<T,>() => 'interrupt-ish' as unknown as T) })).toBe('queue');
+  });
+});
+
+describe('/busy — persists the preferred mode across restarts', () => {
+  it('sets the live mode AND writes agent.busyMode (survives a simulated restart)', async () => {
+    const config = fakeConfig();
+    const session = fakeSession();
+    const { ctx, out } = buildCtx(['redirect'], { session, config });
+
+    await busy.handler(ctx);
+
+    expect(session.getBusyMode()).toBe('redirect');        // live session flipped
+    expect(config.store['agent.busyMode']).toBe('redirect'); // written to config
+    expect(config.save).toHaveBeenCalledOnce();
+    expect(resolveConfiguredBusyMode(config)).toBe('redirect'); // boot re-reads it
+    expect(text(out)).toMatch(/persisted/i);
+  });
+
+  it('an unknown mode is rejected — no write, no persist', async () => {
+    const config = fakeConfig();
+    const session = fakeSession();
+    const { ctx, out } = buildCtx(['nonsense'], { session, config });
+    await busy.handler(ctx);
+    expect(config.store['agent.busyMode']).toBeUndefined();
+    expect(config.save).not.toHaveBeenCalled();
+    expect(text(out)).toMatch(/Unknown mode/);
+  });
+
+  it('no config wired → session-only switch, no crash, no "persisted" claim', async () => {
+    const session = fakeSession();
+    const { ctx, out } = buildCtx(['interrupt'], { session });
+    await busy.handler(ctx);
+    expect(session.getBusyMode()).toBe('interrupt');
+    expect(text(out)).not.toMatch(/persisted/i);
+  });
+});

--- a/tests/v4/cli/commands/mode.test.ts
+++ b/tests/v4/cli/commands/mode.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 BUG 1 — `/mode`: the friendly trust-level viewer/switcher. No args shows
+ * the current level + options in plain language; an arg switches and persists
+ * (agent.autonomy in config); friendly aliases (safe/auto/observer) map to the
+ * dial; an unknown arg is a calm error. Floors are NOT touched here.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { mode } from '../../../../cli/v4/commands/mode';
+import { ApprovalEngine } from '../../../../moat/approvalEngine';
+import { resolveConfiguredAutonomyLevel } from '../../../../core/v4/config';
+import { resolveAutonomyPolicy } from '../../../../moat/autonomy';
+import type { SlashCommandContext } from '../../../../cli/v4/commandRegistry';
+
+function fakeConfig() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    set: (k: string, v: unknown) => { store[k] = v; },
+    save: vi.fn(async () => {}),
+    getValue: <T,>(k: string, fb?: T): T => (k in store ? (store[k] as T) : (fb as T)),
+  };
+}
+function captured() {
+  const out: string[] = [];
+  return {
+    out,
+    info: (m: string) => out.push(`info:${m}`),
+    warn: (m: string) => out.push(`warn:${m}`),
+    success: (m: string) => out.push(`ok:${m}`),
+    dim: (m: string) => out.push(`dim:${m}`),
+  };
+}
+function buildCtx(args: string[], opts: { engine?: ApprovalEngine; config?: ReturnType<typeof fakeConfig> } = {}) {
+  const display = captured();
+  const ctx = { args, rawArgs: args.join(' '), display, approvalEngine: opts.engine, config: opts.config } as unknown as SlashCommandContext;
+  return { ctx, display };
+}
+const text = (d: ReturnType<typeof captured>) => d.out.join('\n');
+/** An engine seeded at a level. */
+function engineAt(level: 'Observer' | 'Assistant' | 'Partner') {
+  const e = new ApprovalEngine('smart');
+  e.setAutonomyPolicy(resolveAutonomyPolicy(level, { workspaceRoots: ['/ws'] }));
+  return e;
+}
+
+describe('/mode — view', () => {
+  it('no args shows the current level + all options in plain language', async () => {
+    const { ctx, display } = buildCtx([], { engine: engineAt('Assistant'), config: fakeConfig() });
+    await mode.handler(ctx);
+    const out = text(display);
+    expect(out).toMatch(/Trust: safe/);           // current, plain-language
+    expect(out).toMatch(/Observer/);
+    expect(out).toMatch(/Assistant/);
+    expect(out).toMatch(/Partner/);
+    expect(out).toMatch(/● Assistant/);            // active one marked
+    expect(out).toMatch(/always ask, even in auto/); // floors reassurance
+  });
+});
+
+describe('/mode — switch + persist', () => {
+  it('/mode auto switches to Partner and PERSISTS (survives restart)', async () => {
+    const engine = engineAt('Assistant');
+    const config = fakeConfig();
+    const { ctx, display } = buildCtx(['auto'], { engine, config });
+    await mode.handler(ctx);
+    expect(engine.getAutonomyPolicy()?.level).toBe('Partner');   // live change
+    expect(config.store['agent.autonomy']).toBe('Partner');       // written
+    expect(resolveConfiguredAutonomyLevel(config)).toBe('Partner'); // next boot reads it
+    expect(text(display)).toMatch(/persisted across restarts/);
+  });
+
+  it('/mode safe switches back to Assistant, persisted', async () => {
+    const engine = engineAt('Partner');
+    const config = fakeConfig();
+    config.set('agent.autonomy', 'Partner');
+    const { ctx } = buildCtx(['safe'], { engine, config });
+    await mode.handler(ctx);
+    expect(engine.getAutonomyPolicy()?.level).toBe('Assistant');
+    expect(config.store['agent.autonomy']).toBe('Assistant');
+    expect(resolveConfiguredAutonomyLevel(config)).toBe('Assistant');
+  });
+
+  it('/mode observer → Observer (read-only)', async () => {
+    const engine = engineAt('Assistant');
+    const config = fakeConfig();
+    const { ctx } = buildCtx(['observer'], { engine, config });
+    await mode.handler(ctx);
+    expect(engine.getAutonomyPolicy()?.level).toBe('Observer');
+    expect(config.store['agent.autonomy']).toBe('Observer');
+  });
+
+  it('canonical dial names still work (case-insensitive)', async () => {
+    const engine = engineAt('Assistant');
+    const { ctx } = buildCtx(['partner'], { engine, config: fakeConfig() });
+    await mode.handler(ctx);
+    expect(engine.getAutonomyPolicy()?.level).toBe('Partner');
+  });
+
+  it('unknown arg → friendly error, no change', async () => {
+    const engine = engineAt('Assistant');
+    const { ctx, display } = buildCtx(['turbo'], { engine, config: fakeConfig() });
+    await mode.handler(ctx);
+    expect(engine.getAutonomyPolicy()?.level).toBe('Assistant');  // unchanged
+    expect(text(display)).toMatch(/Unknown mode "turbo"/);
+    expect(text(display)).toMatch(/safe \| auto \| observer/);
+  });
+
+  it('no approval engine → clear warning, no crash', async () => {
+    const { ctx, display } = buildCtx(['auto']);
+    await mode.handler(ctx);
+    expect(text(display)).toMatch(/Approval engine not wired/);
+  });
+});

--- a/tests/v4/cli/composerRow.test.ts
+++ b/tests/v4/cli/composerRow.test.ts
@@ -11,11 +11,11 @@
 import { describe, it, expect } from 'vitest';
 import { renderComposerBuffer, modeLabel } from '../../../cli/v4/composerRow';
 
-describe('modeLabel — the Enter-action verb', () => {
-  it('maps each busy mode to its label', () => {
+describe('modeLabel — the plain-language Enter-action verb', () => {
+  it('maps each busy mode to a plain-language verb', () => {
     expect(modeLabel('queue')).toBe('queue');
-    expect(modeLabel('interrupt')).toBe('interrupt');
-    expect(modeLabel('redirect')).toBe('redirect');
+    expect(modeLabel('interrupt')).toBe('stop');     // v4.14 — was 'interrupt'
+    expect(modeLabel('redirect')).toBe('steer');     // v4.14 — was 'redirect'
   });
 });
 
@@ -27,8 +27,8 @@ describe('renderComposerBuffer — mode label + live text', () => {
 
   it('prefixes the typed text with the mode label + ▸', () => {
     expect(renderComposerBuffer('hello', 'queue')).toBe('queue ▸ hello');
-    expect(renderComposerBuffer('do X', 'redirect')).toBe('redirect ▸ do X');
-    expect(renderComposerBuffer('stop', 'interrupt')).toBe('interrupt ▸ stop');
+    expect(renderComposerBuffer('do X', 'redirect')).toBe('steer ▸ do X');
+    expect(renderComposerBuffer('stop', 'interrupt')).toBe('stop ▸ stop');
   });
 
   it('tail-truncates a long line (keeps the cursor end, ellipsis at the front)', () => {

--- a/tests/v4/cli/displayComposer.test.ts
+++ b/tests/v4/cli/displayComposer.test.ts
@@ -38,7 +38,7 @@ describe('Display composer — live during-turn paint', () => {
     chunks.length = 0;
     d.setComposer('deploy now', 'redirect');
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('redirect ▸ deploy now');
+    expect(painted).toContain('steer ▸ deploy now');
     ind.stop();
   });
 
@@ -89,7 +89,7 @@ describe('Display composer — live during-turn paint', () => {
     ind.resume();          // indicator reclaims the bottom
     chunks.length = 0;
     d.setComposer('back', 'redirect');
-    expect(stripAnsi(chunks.join(''))).toContain('redirect ▸ back');
+    expect(stripAnsi(chunks.join(''))).toContain('steer ▸ back');
     ind.stop();
   });
 
@@ -130,9 +130,56 @@ describe('Display composer — live during-turn paint', () => {
     // chatSession passes an already-stripped buffer; the row shows it verbatim.
     d.setComposer('npm run build', 'redirect');
     const painted = stripAnsi(chunks.join(''));
-    expect(painted).toContain('redirect ▸ npm run build');
+    expect(painted).toContain('steer ▸ npm run build');
     expect(painted).not.toContain('[200~');
     expect(painted).not.toContain('[201~');
+    ind.stop();
+  });
+});
+
+// ── v4.14 BUG 2 — the ALWAYS-visible input lane (persistent hint) ────────────
+describe('Display composer — persistent busy hint (input lane always visible)', () => {
+  it('setBusyHint shows the plain-language hint in the row BEFORE any keystroke', () => {
+    const { d, chunks } = makeDisplay();
+    const ind = d.activityIndicator('thinking');
+    chunks.length = 0;
+    d.setBusyHint('Enter → steer · /busy to change · Ctrl+C stop');   // turn start, nothing typed
+    const painted = stripAnsi(chunks.join(''));
+    expect(painted).toContain('Enter → steer');   // input lane visible with zero typing
+    ind.stop();
+  });
+
+  it('typing OVERRIDES the hint with the live buffer; clearing the buffer falls BACK to the hint', () => {
+    const { d, chunks } = makeDisplay();
+    const ind = d.activityIndicator('thinking');
+    d.setBusyHint('Enter → queue · /busy to change · Ctrl+C stop');
+    d.setComposer('hello', 'queue');
+    expect(stripAnsi(chunks.join(''))).toContain('queue ▸ hello');   // typed text wins
+    chunks.length = 0;
+    d.setComposer('', 'queue');                                       // user cleared their line
+    expect(stripAnsi(chunks.join(''))).toContain('Enter → queue');   // hint returns (lane stays visible)
+    ind.stop();
+  });
+
+  it('the hint SURVIVES a tool call (rides the tool row, like the typed composer)', () => {
+    const { d, chunks } = makeDisplay();
+    const ind = d.activityIndicator('thinking');
+    d.setBusyHint('Enter → steer · /busy to change · Ctrl+C stop');
+    ind.pause();
+    const row = d.toolRow('web_research', { query: 'q' });
+    const painted = stripAnsi(chunks.join(''));
+    expect(painted).toContain('Enter → steer');   // visible + typeable during a long tool call
+    row.ok(120);
+    ind.stop();
+  });
+
+  it('clearComposer drops the hint too (turn end hands back to the normal prompt)', () => {
+    const { d, chunks } = makeDisplay();
+    const ind = d.activityIndicator('thinking');
+    d.setBusyHint('Enter → steer · /busy to change · Ctrl+C stop');
+    chunks.length = 0;
+    d.clearComposer();
+    expect(stripAnsi(chunks.join(''))).not.toContain('Enter → steer');
     ind.stop();
   });
 });

--- a/tests/v4/cli/duringTurnInputEngine.test.ts
+++ b/tests/v4/cli/duringTurnInputEngine.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the reusable busy-input ENGINE additions on DuringTurnInput:
+ * pause/resume gate, background-handoff intent, steer salvage, persisted
+ * initial mode, and the plain-language indicator text. All pure and
+ * renderer-agnostic (no stdin, no render, no timers) — the same engine the
+ * terminal steering bar and the future dashboard both drive.
+ */
+import { describe, it, expect } from 'vitest';
+import { DuringTurnInput } from '../../../cli/v4/duringTurnInput';
+
+describe('DuringTurnInput — persisted initial mode', () => {
+  it('restores a valid persisted mode', () => {
+    expect(new DuringTurnInput('redirect').getMode()).toBe('redirect');
+    expect(new DuringTurnInput('interrupt').getMode()).toBe('interrupt');
+  });
+  it('defaults to queue, and coerces a garbage persisted value to queue (never RAISES)', () => {
+    expect(new DuringTurnInput().getMode()).toBe('queue');
+    expect(new DuringTurnInput('nonsense' as never).getMode()).toBe('queue');
+  });
+});
+
+describe('DuringTurnInput — pause / resume gate', () => {
+  it('requestPause is idempotent; isPaused reflects it', () => {
+    const d = new DuringTurnInput();
+    expect(d.isPaused()).toBe(false);
+    expect(d.requestPause()).toBe(true);
+    expect(d.isPaused()).toBe(true);
+    expect(d.requestPause()).toBe(false); // already paused
+  });
+
+  it('resume returns false when not paused, true when it was', () => {
+    const d = new DuringTurnInput();
+    expect(d.resume()).toBe(false);
+    d.requestPause();
+    expect(d.resume()).toBe(true);
+    expect(d.isPaused()).toBe(false);
+  });
+
+  it('waitWhilePaused resolves IMMEDIATELY when not paused', async () => {
+    const d = new DuringTurnInput();
+    await expect(d.waitWhilePaused()).resolves.toBeUndefined();
+  });
+
+  it('waitWhilePaused BLOCKS while paused and wakes on resume', async () => {
+    const d = new DuringTurnInput();
+    d.requestPause();
+    let resolved = false;
+    const p = d.waitWhilePaused().then(() => { resolved = true; });
+    await Promise.resolve();               // let microtasks flush
+    expect(resolved).toBe(false);          // still frozen
+    d.resume();
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('resume wakes MULTIPLE boundary waiters at once', async () => {
+    const d = new DuringTurnInput();
+    d.requestPause();
+    const flags = [false, false, false];
+    const ps = flags.map((_, i) => d.waitWhilePaused().then(() => { flags[i] = true; }));
+    await Promise.resolve();
+    expect(flags).toEqual([false, false, false]);
+    d.resume();
+    await Promise.all(ps);
+    expect(flags).toEqual([true, true, true]);
+  });
+
+  it('an abort during a pause unblocks the boundary (Ctrl+C still cancels), pause flag untouched', async () => {
+    const d = new DuringTurnInput();
+    d.requestPause();
+    const ac = new AbortController();
+    let resolved = false;
+    const p = d.waitWhilePaused(ac.signal).then(() => { resolved = true; });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    ac.abort();
+    await p;
+    expect(resolved).toBe(true);
+    expect(d.isPaused()).toBe(true);        // abort resolves the waiter but does not un-pause
+  });
+
+  it('an already-aborted signal resolves immediately even while paused', async () => {
+    const d = new DuringTurnInput();
+    d.requestPause();
+    const ac = new AbortController();
+    ac.abort();
+    await expect(d.waitWhilePaused(ac.signal)).resolves.toBeUndefined();
+  });
+});
+
+describe('DuringTurnInput — background handoff intent', () => {
+  it('is a one-shot: request → take(true) → take(false)', () => {
+    const d = new DuringTurnInput();
+    expect(d.hasBackgroundRequest()).toBe(false);
+    expect(d.takeBackgroundRequest()).toBe(false);
+    d.requestBackground();
+    expect(d.hasBackgroundRequest()).toBe(true);
+    expect(d.takeBackgroundRequest()).toBe(true);   // consumed
+    expect(d.takeBackgroundRequest()).toBe(false);  // and cleared
+    expect(d.hasBackgroundRequest()).toBe(false);
+  });
+});
+
+describe('DuringTurnInput — steer salvage (never silently drop a nudge)', () => {
+  it('moves a buffered steer into the queue and returns it', () => {
+    const d = new DuringTurnInput();
+    d.setPendingSteer('focus on the tests');
+    const salvaged = d.salvageSteerToQueue();
+    expect(salvaged).toBe('focus on the tests');
+    expect(d.peek()).toEqual(['focus on the tests']); // now runs next
+    expect(d.hasPendingSteer()).toBe(false);          // drained
+  });
+  it('accumulated nudges salvage as one queued message', () => {
+    const d = new DuringTurnInput();
+    d.setPendingSteer('a');
+    d.setPendingSteer('b');
+    expect(d.salvageSteerToQueue()).toBe('a\nb');
+    expect(d.peek()).toEqual(['a\nb']);
+  });
+  it('returns null and leaves the queue untouched when nothing is pending', () => {
+    const d = new DuringTurnInput();
+    expect(d.salvageSteerToQueue()).toBeNull();
+    expect(d.count()).toBe(0);
+  });
+});
+
+describe('DuringTurnInput — plain-language indicator (shared with the dashboard)', () => {
+  it('enterActionLabel names ONE clear action per mode', () => {
+    const d = new DuringTurnInput();
+    expect(d.enterActionLabel()).toBe('Enter → queue');
+    d.setMode('interrupt');
+    expect(d.enterActionLabel()).toBe('Enter → stop turn');
+    d.setMode('redirect');
+    expect(d.enterActionLabel()).toBe('Enter → steer');
+  });
+  it('busyHint shows the action + how to switch + how to stop', () => {
+    const d = new DuringTurnInput();
+    d.setMode('redirect');
+    expect(d.busyHint()).toBe('Enter → steer · /busy to change · Ctrl+C stop');
+  });
+  it('a pause overrides the indicator with a resume hint', () => {
+    const d = new DuringTurnInput();
+    d.setMode('redirect');
+    d.requestPause();
+    expect(d.enterActionLabel()).toBe('paused');
+    expect(d.busyHint()).toBe('Paused · /resume to continue · Ctrl+C stop');
+  });
+});

--- a/tests/v4/core/aidenPause.test.ts
+++ b/tests/v4/core/aidenPause.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the mid-turn PAUSE gate at the safe loop boundary. Proves the loop
+ * awaits `waitForResumeIfPaused` at the SAME point steer drains (history
+ * balanced, before the next provider call): /pause freezes the turn there, and
+ * either /resume continues it or a Ctrl+C abort stops it cleanly. Uses the REAL
+ * DuringTurnInput engine wired through the loop hook — end-to-end, deterministic
+ * (no timers): the boundary signals itself so there is no wall-clock race.
+ */
+import { describe, it, expect } from 'vitest';
+import { AidenAgent, type ToolExecutor } from '../../../core/v4/aidenAgent';
+import { MockProviderAdapter } from '../../../core/v4/__mocks__/mockProvider';
+import { DuringTurnInput } from '../../../cli/v4/duringTurnInput';
+import type { Message } from '../../../providers/v4/types';
+
+const userMsg = (c: string): Message => ({ role: 'user', content: c });
+const execOk: ToolExecutor = async (call) => ({ id: call.id, name: call.name, result: `ran ${call.name}` });
+
+describe('mid-turn pause gate', () => {
+  it('freezes the loop at the safe boundary and resumes on /resume', async () => {
+    // iter 1 → a tool call; loop hits the boundary and (paused) freezes; on
+    // resume, iter 2 fires and stops.
+    const provider = new MockProviderAdapter([
+      MockProviderAdapter.toolUse([{ id: 'c1', name: 'file_read', arguments: {} }]),
+      MockProviderAdapter.stop('done'),
+    ]);
+    const engine = new DuringTurnInput();
+    engine.requestPause();
+    let atBoundary!: () => void;
+    const reached = new Promise<void>((r) => { atBoundary = r; });
+
+    const agent = new AidenAgent({ provider, tools: [], toolExecutor: execOk });
+    const run = agent.runConversation([userMsg('go')], {
+      waitForResumeIfPaused: async (sig) => { atBoundary(); await engine.waitWhilePaused(sig); },
+    });
+
+    await reached;                                    // loop reached the boundary + is frozen
+    expect(provider.capturedInputs).toHaveLength(1);  // the 2nd provider call has NOT fired
+    engine.resume();
+    await run;
+    expect(provider.capturedInputs).toHaveLength(2);  // resumed → 2nd provider call fired
+  });
+
+  it('a Ctrl+C abort DURING a pause stops the turn (no further provider call)', async () => {
+    const provider = new MockProviderAdapter([
+      MockProviderAdapter.toolUse([{ id: 'c1', name: 'file_read', arguments: {} }]),
+      MockProviderAdapter.stop('must not run'),
+    ]);
+    const engine = new DuringTurnInput();
+    engine.requestPause();
+    const ac = new AbortController();
+    let atBoundary!: () => void;
+    const reached = new Promise<void>((r) => { atBoundary = r; });
+
+    const agent = new AidenAgent({ provider, tools: [], toolExecutor: execOk });
+    const run = agent.runConversation([userMsg('go')], {
+      signal: ac.signal,
+      waitForResumeIfPaused: async (sig) => { atBoundary(); await engine.waitWhilePaused(sig); },
+    });
+
+    await reached;
+    expect(provider.capturedInputs).toHaveLength(1);
+    ac.abort();                                       // Ctrl+C while paused
+    await run;
+    expect(provider.capturedInputs).toHaveLength(1);  // 2nd provider call NEVER fired — turn stopped
+  });
+
+  it('a turn that is NOT paused runs straight through (hook resolves immediately)', async () => {
+    const provider = new MockProviderAdapter([
+      MockProviderAdapter.toolUse([{ id: 'c1', name: 'file_read', arguments: {} }]),
+      MockProviderAdapter.stop('done'),
+    ]);
+    const engine = new DuringTurnInput();                 // never paused
+    const agent = new AidenAgent({ provider, tools: [], toolExecutor: execOk });
+    await agent.runConversation([userMsg('go')], {
+      waitForResumeIfPaused: (sig) => engine.waitWhilePaused(sig),
+    });
+    expect(provider.capturedInputs).toHaveLength(2);      // no freeze
+  });
+});

--- a/tests/v4/moat/defaultAutonomyUx.test.ts
+++ b/tests/v4/moat/defaultAutonomyUx.test.ts
@@ -5,19 +5,26 @@
  * Aiden — local-first agent.
  */
 /**
- * v4.14 UX polish (Bug 2) — the default trust level stops over-prompting on
- * safe, reversible actions, WITHOUT weakening any floor.
+ * v4.14 — the SHIPPED default is the SAFE level, and "auto" is an explicit
+ * opt-in. (Reverts the brief Partner-as-default experiment: shipping the
+ * most-autonomous level by default is the wrong risk posture.)
  *
- *   • Default level is Partner: workspace-internal writes/moves auto-allow.
- *   • FLOORS UNCHANGED: destructive / external-send / spend / out-of-scope
- *     still ASK; the hard-block set still DENIES — at every level.
+ *   • Default level is Assistant: acts, but ASKS at each write boundary.
+ *   • Partner ("auto") is an OPT-IN: workspace-internal writes auto-allow.
+ *   • FLOORS UNCHANGED AT EVERY LEVEL (Assistant AND Partner/auto):
+ *     destructive / external-send / spend / out-of-scope still ASK; the
+ *     hard-block set still DENIES.
  *   • Blanket grants (session/always) are recorded ONLY for safe classes; a
  *     destructive/external/spend call asks every single time.
  */
 import { describe, it, expect, vi } from 'vitest';
 
 import { ApprovalEngine, type ApprovalRequest } from '../../../moat/approvalEngine';
-import { resolveAutonomyPolicy, isNeverBlanketAllow } from '../../../moat/autonomy';
+import {
+  resolveAutonomyPolicy,
+  isNeverBlanketAllow,
+  type AutonomyLevel,
+} from '../../../moat/autonomy';
 import { resolveConfiguredAutonomyLevel } from '../../../core/v4/config';
 
 const WS = '/work/space';
@@ -27,88 +34,93 @@ const cfg = (vals: Record<string, unknown>) => ({
 function wreq(over: Partial<ApprovalRequest> & { toolName?: string } = {}): ApprovalRequest {
   return { toolName: 'file_write', category: 'write', args: { path: `${WS}/a.txt` }, ...over } as ApprovalRequest;
 }
-/** An engine at the DEFAULT level (Partner), workspace rooted at WS. */
-function defaultEngine(promptUser = vi.fn().mockResolvedValue('deny')) {
-  const level = resolveConfiguredAutonomyLevel(cfg({}));   // nothing configured → default
+/** An engine at a given level, workspace rooted at WS. */
+function engineAt(level: AutonomyLevel, promptUser = vi.fn().mockResolvedValue('deny')) {
   const e = new ApprovalEngine('smart', { promptUser });
   e.setAutonomyPolicy(resolveAutonomyPolicy(level, { workspaceRoots: [WS] }));
   return { e, promptUser };
 }
+/** An engine at whatever the DEFAULT resolves to (nothing configured). */
+function defaultEngine(promptUser = vi.fn().mockResolvedValue('deny')) {
+  const level = resolveConfiguredAutonomyLevel(cfg({}));
+  return engineAt(level, promptUser);
+}
 
 // ── the default level ───────────────────────────────────────────────────────
-describe('resolveConfiguredAutonomyLevel — the sane default', () => {
-  it('nothing configured → Partner (auto-allows safe workspace writes)', () => {
-    expect(resolveConfiguredAutonomyLevel(cfg({}))).toBe('Partner');
+describe('resolveConfiguredAutonomyLevel — the SAFE default', () => {
+  it('nothing configured → Assistant (asks at each write boundary)', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({}))).toBe('Assistant');
   });
-  it('explicit approval_mode: manual is respected → Assistant (cautious)', () => {
+  it('approval_mode NEVER raises the level: manual / smart / off all → Assistant', () => {
     expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'manual' }))).toBe('Assistant');
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'smart' }))).toBe('Assistant');
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'off' }))).toBe('Assistant');
   });
-  it('approval_mode smart / off → Partner', () => {
-    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'smart' }))).toBe('Partner');
-    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.approval_mode': 'off' }))).toBe('Partner');
-  });
-  it('explicit agent.autonomy always wins', () => {
+  it('explicit agent.autonomy always wins (incl. the persisted /auto opt-in)', () => {
     expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Observer' }))).toBe('Observer');
-    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Assistant', 'agent.approval_mode': 'smart' }))).toBe('Assistant');
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Partner' }))).toBe('Partner');
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Assistant', 'agent.approval_mode': 'off' }))).toBe('Assistant');
   });
-  it('a garbage agent.autonomy never RAISES — falls back to the default', () => {
-    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Superuser' }))).toBe('Partner');
+  it('a garbage agent.autonomy never RAISES — falls back to the safe default', () => {
+    expect(resolveConfiguredAutonomyLevel(cfg({ 'agent.autonomy': 'Superuser' }))).toBe('Assistant');
   });
 });
 
-// ── safe classes auto-allow at the default level (no prompt) ─────────────────
-describe('default level — safe/reversible classes auto-allow (zero prompt)', () => {
-  it('a workspace-internal write (absolute path) auto-allows', async () => {
+// ── default (Assistant) ASKS on writes; auto (Partner) is quiet ──────────────
+describe('safe default asks on writes; auto opt-in is quiet on safe workspace writes', () => {
+  it('DEFAULT (Assistant): a workspace-internal write ASKS (safe-by-default)', async () => {
     const { e, promptUser } = defaultEngine();
+    expect(await e.checkApproval(wreq({ args: { path: `${WS}/src/x.ts` } }))).toBe(false);
+    expect(promptUser).toHaveBeenCalledOnce();
+  });
+  it('AUTO (Partner opt-in): a workspace-internal write auto-allows (zero prompt)', async () => {
+    const { e, promptUser } = engineAt('Partner');
     expect(await e.checkApproval(wreq({ args: { path: `${WS}/src/x.ts` } }))).toBe(true);
     expect(promptUser).not.toHaveBeenCalled();
   });
-  it('a workspace-internal write with a RELATIVE path auto-allows', async () => {
-    const { e, promptUser } = defaultEngine();
+  it('AUTO (Partner): a RELATIVE-path workspace write auto-allows', async () => {
+    const { e, promptUser } = engineAt('Partner');
     expect(await e.checkApproval(wreq({ args: { path: 'notes/today.md' } }))).toBe(true);
     expect(promptUser).not.toHaveBeenCalled();
   });
-  it('a move WITHIN the workspace auto-allows', async () => {
-    const { e, promptUser } = defaultEngine();
-    expect(await e.checkApproval(wreq({ toolName: 'file_move', args: { from: `${WS}/a.txt`, to: `${WS}/b.txt` } }))).toBe(true);
-    expect(promptUser).not.toHaveBeenCalled();
-  });
-  it('reads always allow (category read short-circuits)', async () => {
-    const { e, promptUser } = defaultEngine();
-    expect(await e.checkApproval(wreq({ toolName: 'file_read', category: 'read', args: { path: '/anywhere/at/all' } }))).toBe(true);
-    expect(promptUser).not.toHaveBeenCalled();
+  it('reads always allow at BOTH levels (category read short-circuits)', async () => {
+    for (const level of ['Assistant', 'Partner'] as const) {
+      const { e, promptUser } = engineAt(level);
+      expect(await e.checkApproval(wreq({ toolName: 'file_read', category: 'read', args: { path: '/anywhere/at/all' } }))).toBe(true);
+      expect(promptUser).not.toHaveBeenCalled();
+    }
   });
 });
 
-// ── FLOORS unchanged — still ASK / DENY at the default level ─────────────────
-describe('default level — floors STILL gate (unchanged)', () => {
+// ── FLOORS unchanged — still ASK / DENY at EVERY level, incl. auto ───────────
+describe.each(['Assistant', 'Partner'] as const)('floors STILL gate at level %s', (level) => {
   it('destructive (dangerous) still ASKS', async () => {
-    const { e, promptUser } = defaultEngine();
+    const { e, promptUser } = engineAt(level);
     expect(await e.checkApproval(wreq({ toolName: 'file_delete', riskTier: 'dangerous' }))).toBe(false);
     expect(promptUser).toHaveBeenCalledOnce();
   });
   it('an out-of-workspace write still ASKS', async () => {
-    const { e, promptUser } = defaultEngine();
+    const { e, promptUser } = engineAt(level);
     expect(await e.checkApproval(wreq({ args: { path: '/etc/hosts' } }))).toBe(false);
     expect(promptUser).toHaveBeenCalledOnce();
   });
   it('an ESCAPING relative path (../) resolves out-of-scope and ASKS', async () => {
-    const { e, promptUser } = defaultEngine();
+    const { e, promptUser } = engineAt(level);
     expect(await e.checkApproval(wreq({ args: { path: '../../etc/passwd' } }))).toBe(false);
     expect(promptUser).toHaveBeenCalledOnce();
   });
   it('an external send still ASKS', async () => {
-    const { e, promptUser } = defaultEngine();
+    const { e, promptUser } = engineAt(level);
     expect(await e.checkApproval(wreq({ toolName: 'send_message', category: 'network', args: {} }))).toBe(false);
     expect(promptUser).toHaveBeenCalledOnce();
   });
   it('an external SPEND still ASKS', async () => {
-    const { e, promptUser } = defaultEngine();
+    const { e, promptUser } = engineAt(level);
     expect(await e.checkApproval(wreq({ toolName: 'api_call', effects: { externalSpend: true }, args: {} }))).toBe(false);
     expect(promptUser).toHaveBeenCalledOnce();
   });
   it('the hard-block set is DENIED without a prompt (even if promptUser would allow)', async () => {
-    const { e, promptUser } = defaultEngine(vi.fn().mockResolvedValue('allow'));
+    const { e, promptUser } = engineAt(level, vi.fn().mockResolvedValue('allow'));
     expect(await e.checkApproval(wreq({ toolName: 'shell_exec', category: 'execute', args: { command: 'rm -rf /' } }))).toBe(false);
     expect(promptUser).not.toHaveBeenCalled();
   });
@@ -117,7 +129,6 @@ describe('default level — floors STILL gate (unchanged)', () => {
 // ── session-allow: safe categories suppress re-prompt; floors never do ───────
 describe('blanket session-allow — safe suppresses, destructive/external/spend never', () => {
   it('approving Session on a SAFE prompted write suppresses the re-prompt for the same category', async () => {
-    // Use Assistant so a workspace write actually prompts (Partner auto-allows).
     const promptUser = vi.fn().mockResolvedValue('allow_session');
     const e = new ApprovalEngine('smart', { promptUser });
     e.setAutonomyPolicy(resolveAutonomyPolicy('Assistant', { workspaceRoots: [WS] }));


### PR DESCRIPTION
## What

Two control bugs from live smoke — "the user can't control Aiden as promised" — fixed at root, plus bringing forward the safe-default + busy-input engine that an earlier banking had left behind.

### Bug 1 — `/mode` was missing
The trust dial existed, but there was no friendly view/change command and it didn't persist. Adds `/mode`:
- No args → the current level + all options (safe / auto / observer) in plain language, active one marked.
- Arg → switch + persist (survives restart); shares the persist path with `/auto` so they can't drift.
- Boot shows the level calmly ("Trust: safe — … · /mode to change").
- Floors untouched — destructive / spend / send / out-of-workspace still ask at every level, incl. auto.

### Bug 2 — the input bar wasn't visible while a turn ran
Root cause: the during-turn composer rendered nothing when empty, so before you typed there was no lane inviting you to steer/queue. Now a persistent plain-language hint ("Enter → steer · /busy to change · Ctrl+C stop") is always visible in the live bottom row (it rides streaming untouched — the sticky owned-row seam already handled the two-writers problem), overridden by your live buffer while typing. Controls wired to it: steer, queue, stop (Ctrl+C), pause/resume. Labels are plain verbs now (steer / queue / stop).

Also brings forward (cherry-picked from feat/live-input, left behind before): the safe-default (Assistant) + `/auto` + persistence, and the busy-input engine (pause/resume/salvage + loop wiring + mode persistence).

`/bg` (background handoff to the daemon) is not in this PR — it needs the durable-run handoff the REPL isn't wired for; the engine intent is in place.

## Tests

- Full CI-mirrored suite green — **5826 passed / 0 failed**.
- Real-dist smoke (compiled dist): `/mode` view/switch/persist + always-visible plain-language lane — 8/8.
- Clean-room verified; every commit authored **and** committed by Shiva Deore.

## Not in this PR

No version bump, no npm publish — banking to main only.
