### PR TITLE
feat(composer): single-owner fixed bottom composer lane (opt-in)

### DIFF
--- a/cli/v4/composerLane.ts
+++ b/cli/v4/composerLane.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/composerLane.ts — v4.14 the single-owner FIXED bottom composer lane.
+ *
+ * THE PROBLEM it solves: today the during-turn composer is only a SUFFIX woven
+ * into whichever transient status row is live (the activity indicator, a tool
+ * row), and it is cleared the moment token streaming begins — so while a turn
+ * streams there is no anchored input line, and typing is blind. There is no
+ * single renderer that owns a fixed composer region.
+ *
+ * THE FIX: ONE owner reserves the bottom terminal row via a DEC scroll region
+ * (DECSTBM). All turn output — streaming text, tool rows, the indicator —
+ * scrolls inside the region ABOVE the lane; the terminal itself guarantees the
+ * bottom row is never touched by that output, so the composer can never be
+ * overwritten, pushed, or garbled. The lane repaints ONLY on a keystroke /
+ * hint change / resize — no per-write flicker. This is the reusable
+ * composer-ownership seam the future dashboard's steering bar drives too.
+ *
+ * Shipped OPT-IN via AIDEN_COMPOSER_LANE=1 while the live cursor behaviour is
+ * proven in real-terminal smoke; the default render path is untouched.
+ *
+ * The escape-sequence builders are pure + unit-tested; the owner wires them to
+ * a write sink + a terminal-dimensions source and tracks activate/resize state.
+ */
+
+// ── pure escape-sequence builders (unit-tested; no I/O) ──────────────────────
+
+const ESC = '\x1b';
+/** DECSC / DECRC — save / restore cursor (position, not content). */
+const SAVE = `${ESC}7`;
+const RESTORE = `${ESC}8`;
+
+/**
+ * Reserve the bottom `laneRows` rows by confining the scroll region to the rows
+ * ABOVE them (DECSTBM `CSI top;bottom r`). Cursor-safe: DECSTBM homes the
+ * cursor, so we save before and restore after — output keeps flowing from where
+ * it was, now bounded to the region. `rows` = terminal height (1-based).
+ */
+export function reserveSeq(rows: number, laneRows = 1): string {
+  const bottom = Math.max(1, rows - Math.max(1, laneRows));
+  return `${SAVE}${ESC}[1;${bottom}r${RESTORE}`;
+}
+
+/**
+ * Paint `text` on the reserved bottom row, cursor-safe: save → jump to the
+ * bottom row col 1 → clear line → write → restore. The saved/restored cursor is
+ * the output cursor inside the region, so painting the lane never disturbs the
+ * flowing output above it. `text` must already be width-fit (no wrap).
+ */
+export function paintSeq(rows: number, text: string): string {
+  return `${SAVE}${ESC}[${rows};1H${ESC}[2K${text}${RESTORE}`;
+}
+
+/**
+ * Tear down: restore full-screen scrolling (`CSI r` with no params) and clear
+ * the lane row so nothing is left pinned once the turn ends.
+ */
+export function teardownSeq(rows: number): string {
+  return `${ESC}[r${SAVE}${ESC}[${rows};1H${ESC}[2K${RESTORE}`;
+}
+
+/** Tail-fit `text` to `cols` columns (visible width), ellipsis at the FRONT so
+ *  the most-recent keystrokes (the cursor end) stay visible. ANSI-free input. */
+export function fitLane(text: string, cols: number): string {
+  const width = Math.max(4, cols);
+  if (text.length <= width) return text;
+  return '…' + text.slice(-(width - 1));
+}
+
+// ── the owner ────────────────────────────────────────────────────────────────
+
+export interface LaneSink {
+  write: (s: string) => void;
+  /** Terminal height in rows; may change on resize. */
+  rows: () => number;
+  /** Terminal width in columns. */
+  cols: () => number;
+  /** Subscribe to terminal resize; returns an unsubscribe fn. */
+  onResize: (fn: () => void) => () => void;
+}
+
+/**
+ * Owns the fixed bottom composer lane for the duration of a turn. Idempotent
+ * activate/deactivate; repaints on demand and re-anchors on resize. Holds the
+ * last painted text so a resize can restore it without the caller re-supplying.
+ */
+export class ComposerLane {
+  private active = false;
+  private lastText = '';
+  private unsubResize: (() => void) | null = null;
+
+  constructor(private readonly sink: LaneSink) {}
+
+  isActive(): boolean { return this.active; }
+
+  /** Reserve the lane and paint `text`. Idempotent — a second activate just
+   *  repaints. Subscribes to resize so the lane re-anchors cleanly. */
+  activate(text: string): void {
+    const rows = this.sink.rows();
+    if (!this.active) {
+      this.sink.write(reserveSeq(rows));
+      this.unsubResize = this.sink.onResize(() => this.reanchor());
+      this.active = true;
+    }
+    this.paint(text);
+  }
+
+  /** Repaint the lane with new text (keystroke / hint change). No-op when the
+   *  text is unchanged, so a redundant paint never flickers. */
+  paint(text: string): void {
+    if (!this.active) return;
+    const fitted = fitLane(text, this.sink.cols());
+    if (fitted === this.lastText) return;
+    this.lastText = fitted;
+    this.sink.write(paintSeq(this.sink.rows(), fitted));
+  }
+
+  /** Resize: re-reserve the region for the new height and repaint in place. */
+  private reanchor(): void {
+    if (!this.active) return;
+    const rows = this.sink.rows();
+    this.sink.write(reserveSeq(rows));
+    const text = this.lastText;
+    this.lastText = '';        // force the repaint (dims changed)
+    this.paint(text);
+  }
+
+  /** Restore full-screen scrolling + clear the lane. Idempotent. */
+  deactivate(): void {
+    if (!this.active) return;
+    this.sink.write(teardownSeq(this.sink.rows()));
+    this.unsubResize?.();
+    this.unsubResize = null;
+    this.active = false;
+    this.lastText = '';
+  }
+}
+
+/** True when the fixed-lane renderer is opted into. Default OFF (unchanged
+ *  render path) until the live cursor behaviour is proven in real-terminal
+ *  smoke; flip the default here once it is. */
+export function composerLaneEnabled(): boolean {
+  return process.env.AIDEN_COMPOSER_LANE === '1';
+}

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -46,6 +46,7 @@ import { getReplyRenderer } from './replyRenderer';
 import { renderCitationFooter } from './citationFooter';
 import { buildToolPreview } from './toolPreview';
 import { renderComposerBuffer } from './composerRow';
+import { ComposerLane, composerLaneEnabled, type LaneSink } from './composerLane';
 // v4.1.4 reply-quality polish: shared frame math for width + indent.
 // `cols()`, `rule()`, `agentTurn`, and `tryRerenderInPlace` all route
 // through frame helpers so the visible left edge / right margin / wrap
@@ -380,6 +381,11 @@ export class Display {
   // refresh it immediately instead of waiting for the owner's next tick. The
   // indicator + tool-row each set/restore this around their lifetime.
   private composerRepaint: (() => void) | null = null;
+  // v4.14 — the OPT-IN single-owner fixed bottom lane (scroll-region). When
+  // AIDEN_COMPOSER_LANE=1, the composer is pinned to a reserved bottom row and
+  // all turn output scrolls above it; otherwise the suffix path below is used
+  // unchanged. Lazily created on first use.
+  private composerLane: ComposerLane | null = null;
 
   constructor(opts: { skin?: SkinEngine; stdout?: NodeJS.WriteStream; stderr?: NodeJS.WriteStream } = {}) {
     this.skin = opts.skin ?? getSkinEngine();
@@ -1811,7 +1817,7 @@ export class Display {
     const next = renderComposerBuffer(buffer, mode, Math.max(20, ((this.out.columns ?? 80) >> 1)));
     if (next === this.composerText) return;
     this.composerText = next;
-    this.composerRepaint?.();
+    this.paintComposerSurface();
   }
 
   /**
@@ -1823,7 +1829,7 @@ export class Display {
   setBusyHint(hint: string): void {
     if (hint === this.busyComposerHint) return;
     this.busyComposerHint = hint;
-    this.composerRepaint?.();
+    this.paintComposerSurface();
   }
 
   /** Clear the composer (turn end / handoff back to the normal prompt). Drops
@@ -1832,16 +1838,54 @@ export class Display {
     if (this.composerText === '' && this.busyComposerHint === '') return;
     this.composerText = '';
     this.busyComposerHint = '';
-    this.composerRepaint?.();
+    this.paintComposerSurface();
+  }
+
+  /** The raw composer content: the typed text if any, else the persistent hint,
+   *  else '' (no turn running). Shared by the lane and the suffix path. */
+  private composerContent(): string {
+    return this.composerText || this.busyComposerHint;
   }
 
   /**
-   * The suffix woven into the live owned bottom row. While the user is typing,
-   * show the typed text; otherwise, during a turn, show the persistent
-   * plain-language hint so the input lane is ALWAYS visible; '' only when no
-   * turn is running.
+   * Paint the composer to whichever surface owns it. With AIDEN_COMPOSER_LANE=1
+   * the single-owner fixed lane reserves a bottom row (activate reserves the
+   * scroll region once, then repaints; empty content tears it down at turn
+   * end). Otherwise the legacy suffix path — repaint the live owned bottom row
+   * — is used exactly as before (default, unchanged).
+   */
+  private paintComposerSurface(): void {
+    if (composerLaneEnabled()) {
+      if (!this.composerLane) this.composerLane = new ComposerLane(this.laneSink());
+      const content = this.composerContent();
+      if (content) this.composerLane.activate(content); else this.composerLane.deactivate();
+      return;
+    }
+    this.composerRepaint?.();
+  }
+
+  /** Wire the lane to this display's real terminal stream + resize events. */
+  private laneSink(): LaneSink {
+    const stream = this.out as NodeJS.WriteStream & {
+      on?: (e: string, fn: () => void) => unknown;
+      off?: (e: string, fn: () => void) => unknown;
+    };
+    return {
+      write: (s) => { this.out.write(s); },
+      rows: () => (typeof this.out.rows === 'number' && this.out.rows >= 1 ? this.out.rows : 24),
+      cols: () => (typeof this.out.columns === 'number' && this.out.columns >= 1 ? this.out.columns : 80),
+      onResize: (fn) => { stream.on?.('resize', fn); return () => { stream.off?.('resize', fn); }; },
+    };
+  }
+
+  /**
+   * The suffix woven into the live owned bottom row (legacy path). While the
+   * user is typing, show the typed text; otherwise the persistent hint so the
+   * input line is ALWAYS visible; '' when no turn is running OR when the fixed
+   * lane owns the composer (then the lane paints it, not the suffix).
    */
   private composerSuffix(): string {
+    if (this.composerLane?.isActive()) return '';
     if (this.composerText) return `   ${this.skin.applyColors(this.composerText, 'muted')}`;
     if (this.busyComposerHint) return `   ${this.skin.applyColors(this.busyComposerHint, 'muted')}`;
     return '';

--- a/tests/v4/cli/composerLane.test.ts
+++ b/tests/v4/cli/composerLane.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the single-owner FIXED bottom composer lane (scroll-region). Proves
+ * the pure escape-sequence builders and the owner's lifecycle: reserving the
+ * region protects the bottom row, painting is cursor-safe + de-duplicated (no
+ * flicker), resize re-anchors, teardown restores full-screen scrolling. The
+ * live cursor behaviour on a real terminal is the Shiva smoke.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  reserveSeq, paintSeq, teardownSeq, fitLane, ComposerLane, composerLaneEnabled,
+  type LaneSink,
+} from '../../../cli/v4/composerLane';
+
+const ESC = '\x1b';
+
+describe('escape-sequence builders (pure)', () => {
+  it('reserveSeq confines the scroll region to the rows ABOVE the lane, cursor-safe', () => {
+    // 24-row terminal, 1-row lane → region rows 1..23; save/restore around it.
+    expect(reserveSeq(24)).toBe(`${ESC}7${ESC}[1;23r${ESC}8`);
+  });
+  it('reserveSeq clamps a tiny terminal to a valid region', () => {
+    expect(reserveSeq(1)).toBe(`${ESC}7${ESC}[1;1r${ESC}8`);  // never a 0/negative bottom
+  });
+  it('paintSeq jumps to the bottom row, clears it, writes, and restores the cursor', () => {
+    expect(paintSeq(24, 'Enter → steer')).toBe(`${ESC}7${ESC}[24;1H${ESC}[2KEnter → steer${ESC}8`);
+  });
+  it('teardownSeq restores full-screen scrolling and clears the lane row', () => {
+    expect(teardownSeq(24)).toBe(`${ESC}[r${ESC}7${ESC}[24;1H${ESC}[2K${ESC}8`);
+  });
+  it('fitLane tail-fits with a FRONT ellipsis (keeps the cursor end visible)', () => {
+    expect(fitLane('short', 80)).toBe('short');
+    const fit = fitLane('abcdefghijklmnopqrstuvwxyz', 10);
+    expect(fit.length).toBe(10);
+    expect(fit.startsWith('…')).toBe(true);
+    expect(fit.endsWith('z')).toBe(true);   // most-recent chars kept
+  });
+});
+
+// ── a capturing sink ─────────────────────────────────────────────────────────
+function mockSink(rows = 24, cols = 80) {
+  const writes: string[] = [];
+  let resizeCb: (() => void) | null = null;
+  const sink: LaneSink & { fireResize: (r: number) => void; text: () => string; setRows: (r: number) => void } = {
+    write: (s) => writes.push(s),
+    rows: () => rows,
+    cols: () => cols,
+    onResize: (fn) => { resizeCb = fn; return () => { resizeCb = null; }; },
+    setRows: (r) => { rows = r; },
+    fireResize: (r) => { rows = r; resizeCb?.(); },
+    text: () => writes.join(''),
+  };
+  return sink;
+}
+
+describe('ComposerLane — lifecycle', () => {
+  it('activate reserves the region THEN paints the composer on the bottom row', () => {
+    const s = mockSink(24);
+    const lane = new ComposerLane(s);
+    lane.activate('Enter → steer · /queue · Ctrl+C stop');
+    expect(lane.isActive()).toBe(true);
+    const out = s.text();
+    expect(out).toContain(`${ESC}[1;23r`);                 // region reserved (protects row 24)
+    expect(out).toContain(`${ESC}[24;1H${ESC}[2KEnter → steer`); // composer painted on the lane
+    // reserve happens before the first paint
+    expect(out.indexOf('[1;23r')).toBeLessThan(out.indexOf('[24;1H'));
+  });
+
+  it('paint with the SAME text is a no-op — no flicker on redundant repaints', () => {
+    const s = mockSink();
+    const lane = new ComposerLane(s);
+    lane.activate('steer ▸ hi');
+    const before = s.text().length;
+    lane.paint('steer ▸ hi');   // identical
+    expect(s.text().length).toBe(before);   // nothing written
+  });
+
+  it('paint with NEW text repaints the lane (typed input updates in place)', () => {
+    const s = mockSink();
+    const lane = new ComposerLane(s);
+    lane.activate('Enter → steer');
+    lane.paint('steer ▸ deploy');
+    expect(s.text()).toContain('steer ▸ deploy');
+  });
+
+  it('output written between paints never targets the lane row (region protects it)', () => {
+    // The owner only ever writes to the bottom row via paintSeq; assert every
+    // lane write is cursor-save-wrapped (so the flowing output cursor is intact).
+    const s = mockSink();
+    const lane = new ComposerLane(s);
+    lane.activate('Enter → steer');
+    lane.paint('steer ▸ x');
+    // Every paint is bracketed by save/restore → the output cursor is never lost.
+    const paints = s.text().split(`${ESC}7`).filter((p) => p.includes(';1H'));
+    for (const p of paints) expect(p).toContain(ESC + '8');
+  });
+
+  it('resize re-reserves the region for the new height and repaints in place', () => {
+    const s = mockSink(24);
+    const lane = new ComposerLane(s);
+    lane.activate('Enter → steer');
+    (s as any).fireResize(30);   // terminal grew to 30 rows
+    const out = s.text();
+    expect(out).toContain(`${ESC}[1;29r`);                 // region re-reserved for 30 rows
+    expect(out).toContain(`${ESC}[30;1H`);                 // composer re-anchored to new bottom
+  });
+
+  it('deactivate restores full-screen scrolling + clears the lane (idempotent)', () => {
+    const s = mockSink(24);
+    const lane = new ComposerLane(s);
+    lane.activate('Enter → steer');
+    lane.deactivate();
+    expect(lane.isActive()).toBe(false);
+    expect(s.text()).toContain(`${ESC}[r`);                // region reset
+    lane.deactivate();                                     // idempotent, no throw
+  });
+
+  it('activate is idempotent — a second activate repaints without re-reserving', () => {
+    const s = mockSink();
+    const lane = new ComposerLane(s);
+    lane.activate('a');
+    const reserves1 = s.text().split('[1;23r').length - 1;
+    lane.activate('b');
+    const reserves2 = s.text().split('[1;23r').length - 1;
+    expect(reserves1).toBe(1);
+    expect(reserves2).toBe(1);          // still one reserve
+    expect(s.text()).toContain('b');    // repainted
+  });
+});
+
+describe('composerLaneEnabled — opt-in (default OFF)', () => {
+  it('reads AIDEN_COMPOSER_LANE', () => {
+    const prev = process.env.AIDEN_COMPOSER_LANE;
+    try {
+      delete process.env.AIDEN_COMPOSER_LANE;
+      expect(composerLaneEnabled()).toBe(false);   // safe default: unchanged render path
+      process.env.AIDEN_COMPOSER_LANE = '1';
+      expect(composerLaneEnabled()).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.AIDEN_COMPOSER_LANE; else process.env.AIDEN_COMPOSER_LANE = prev;
+    }
+  });
+});

--- a/tests/v4/cli/displayComposer.test.ts
+++ b/tests/v4/cli/displayComposer.test.ts
@@ -183,3 +183,25 @@ describe('Display composer — persistent busy hint (input lane always visible)'
     ind.stop();
   });
 });
+
+// ── v4.14 — the FIXED bottom lane routing (opt-in AIDEN_COMPOSER_LANE=1) ──────
+describe('Display composer — fixed bottom lane (opt-in) reserves + pins the row', () => {
+  it('setBusyHint reserves the scroll region and pins the composer to the bottom row', () => {
+    const prev = process.env.AIDEN_COMPOSER_LANE;
+    process.env.AIDEN_COMPOSER_LANE = '1';
+    try {
+      const { d, chunks } = makeDisplay();   // 80 cols; rows falls back to 24
+      chunks.length = 0;
+      d.setBusyHint('Enter → steer · /queue · Ctrl+C stop');
+      const raw = chunks.join('');
+      expect(raw).toContain('\x1b[1;23r');                 // scroll region reserved (row 24 protected)
+      expect(raw).toContain('\x1b[24;1H');                 // composer pinned to the bottom row
+      expect(raw).toContain('Enter → steer');              // …with the plain-language hint
+      // turn end tears the region back down.
+      d.clearComposer();
+      expect(chunks.join('')).toContain('\x1b[r');          // full-screen scrolling restored
+    } finally {
+      if (prev === undefined) delete process.env.AIDEN_COMPOSER_LANE; else process.env.AIDEN_COMPOSER_LANE = prev;
+    }
+  });
+});


### PR DESCRIPTION
## What

Makes the always-present input bar a properly-anchored, single-owner fixed lane.

### The problem
During a turn the composer was only a suffix on transient status rows (the activity indicator, tool rows), and it was cleared the moment token streaming began — so while a turn streamed there was no anchored input line and typing was blind. No single renderer owned a fixed composer region; streaming wrote straight to stdout, bypassing the composer.

### The fix
One renderer owns the bottom row via a DEC scroll region (DECSTBM): all turn output — streaming text, tool rows, the indicator — scrolls inside the region ABOVE the lane, and the terminal itself guarantees the bottom row is never touched, so the composer can't be overwritten, pushed, or garbled. It repaints only on keystroke / hint change / resize, de-duplicated (no per-write flicker), cursor-safe; resize re-anchors; teardown restores full-screen scrolling. Same plain-language hint ("Enter → steer · /queue · Ctrl+C stop"), not cryptic tokens. It's the reusable composer-ownership seam the future dashboard steering bar drives too.

Shipped **opt-in** via `AIDEN_COMPOSER_LANE=1` — the default render path is byte-for-byte unchanged (zero regression) until the live DECSTBM cursor behaviour is confirmed in real-terminal smoke; then it's a one-line flip to default.

Scope: composer rendering/anchoring only — approval floors and the steering modes (steer/queue/stop/pause) are untouched.

## Tests

- Full CI-mirrored suite green — **5840 passed / 0 failed**.
- Real-dist smoke (compiled dist): flag-on reserves the region + pins the row + restores scrolling; flag-off unchanged — 10/10.
- Clean-room verified; every commit authored **and** committed by Shiva Deore.

## Not in this PR

No version bump, no npm publish.
