### PR TITLE
Aiden v4.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v4.14.1 — 2026-07-05
+
+The input bar is always there, and connecting a server is one command.
+
+(The v4.11 → v4.14.0 line shipped via GitHub Releases; this entry resumes the changelog at the v4.14.x point release.)
+
+- **One-tap MCP connect.** `/mcp connect <name>` adds the server, authorizes it, and connects — one command, no env vars, no three-step dance.
+- **Always-present steering bar.** The input line stays live while Aiden works. Steer it mid-task, queue your next message, or stop with Ctrl+C — in both idle and busy.
+- **`/mode` — pick your trust level.** Safe by default: Aiden asks before risky, spendy, or out-of-folder actions. `/mode auto` opts into hands-off; the floors always hold.
+- **Warm intro + greeting.** Aiden asks your name once and actually uses it, and the boot greeting knows how long you've been away.
+
+Fixes: no more "[compress] refused" noise on a fresh chat; the busy-hint text is width-safe.
+
+---
+
 ## v4.10.0 — 2026-05-26
 
 Aiden becomes inspectable, durable, and finally streams properly.

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -67,9 +67,21 @@ export interface AidenPromptConfig {
   theme?: Partial<Theme>;
   /** Max dropdown rows visible at once. Default 8. */
   dropdownLimit?: number;
+  /** v4.14 — persistent plain-language idle hint shown in the footer when no
+   *  ghost/dropdown is active (e.g. "Type your message · /help · /mode"). */
+  hint?: string;
 }
 
 const DEFAULT_DROPDOWN_LIMIT = 8;
+
+/**
+ * v4.14 — show the persistent idle hint ONLY when nothing else owns the footer
+ * (no ghost preview, no slash dropdown) and the prompt is idle. Pure so the
+ * idle-bar behaviour is unit-testable without driving inquirer/a PTY.
+ */
+export function shouldShowIdleHint(hasFooterContent: boolean, hint: string | undefined, status: string): boolean {
+  return !hasFooterContent && typeof hint === 'string' && hint.length > 0 && status === 'idle';
+}
 
 /** Strip ANSI for width math. */
 function stripAnsi(s: string): string {
@@ -416,6 +428,15 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
   }
 
   const footerParts = [ghostLine, dropdownLines].filter((s): s is string => typeof s === 'string' && s.length > 0);
+
+  // v4.14 — persistent plain-language IDLE hint. When nothing else owns the
+  // footer (no ghost preview, no slash dropdown), show the calm hint so the
+  // idle bar is neat + informative every prompt, not a bare `▲`. Mirrors the
+  // busy bar's always-visible hint — one consistent, plain-language surface.
+  if (shouldShowIdleHint(footerParts.length > 0, config.hint, status)) {
+    footerParts.push(`  ${dim(config.hint as string)}`);
+  }
+
   const footer = footerParts.length > 0 ? footerParts.join('\n') : undefined;
 
   return footer ? [line, footer] : line;

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -686,9 +686,11 @@ Reply with ONE word: safe, caution, or dangerous.`;
     //   - error + invariantViolation    → warn with the specific cause
     //   - error (auxiliary throw)       → warn with the wrapped message
     //   - success                       → verbose-only dim line
+    // v4.14 — a refusal (too short / aux unavailable) is internal housekeeping,
+    // NOT something to surface in the user's chat. The auto path no longer even
+    // attempts below threshold (see aidenAgent), so this is belt-and-braces:
+    // stay SILENT in chat. (Genuine errors below still explain a degradation.)
     if (result.refused && !result.error) {
-      const detail = result.errorMessage ?? 'conversation too short';
-      this.display.dim(`[compress] refused — ${detail}`);
       return;
     }
     if (result.error) {

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -3482,6 +3482,10 @@ function createDefaultPromptApi(opts: DefaultPromptOpts = {}): ChatPromptApi {
           commands: opts.commands ?? [],
           history,
           theme:    promptTheme as never,
+          // v4.14 — persistent plain-language idle hint on the MAIN prompt (the
+          // "▲" line), so idle shows a neat bar with a hint, not a bare glyph.
+          // Skipped on the "… " multi-line continuation.
+          hint:     prompt.includes('▲') ? 'Type your message · /help · /mode' : undefined,
         });
         const trimmed = (value ?? '').trim();
         // Append to disk history. Awaited so the write flushes before

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -1814,7 +1814,7 @@ export class Display {
    * live (not blind). Empty buffer → the suffix disappears (never noisy).
    */
   setComposer(buffer: string, mode: 'queue' | 'interrupt' | 'redirect'): void {
-    const next = renderComposerBuffer(buffer, mode, Math.max(20, ((this.out.columns ?? 80) >> 1)));
+    const next = renderComposerBuffer(buffer, mode, this.composerAvail());
     if (next === this.composerText) return;
     this.composerText = next;
     this.paintComposerSurface();
@@ -1884,10 +1884,30 @@ export class Display {
    * input line is ALWAYS visible; '' when no turn is running OR when the fixed
    * lane owns the composer (then the lane paints it, not the suffix).
    */
+  /**
+   * Columns available for the composer suffix, reserving room for the owned
+   * row's indicator/tool prefix ("  ⋯ thinking… Ns   ") so the WHOLE row fits
+   * one line. Without this the busy hint overflowed → the terminal wrapped it →
+   * the single-line erase-repaint could only show the wrapped TAIL
+   * ("…change · Ctrl+C stop"). v4.14 fix.
+   */
+  private composerAvail(): number {
+    return Math.max(12, (this.out.columns ?? 80) - 30);
+  }
+
   private composerSuffix(): string {
     if (this.composerLane?.isActive()) return '';
-    if (this.composerText) return `   ${this.skin.applyColors(this.composerText, 'muted')}`;
-    if (this.busyComposerHint) return `   ${this.skin.applyColors(this.busyComposerHint, 'muted')}`;
+    const a = this.composerAvail();
+    // Typed text keeps the CURSOR END; the hint keeps the FRONT ("Enter → …")
+    // with a trailing ellipsis — never the wrapped tail, never mid-word garbage.
+    if (this.composerText) {
+      const t = this.composerText.length <= a ? this.composerText : '…' + this.composerText.slice(-(a - 1));
+      return `   ${this.skin.applyColors(t, 'muted')}`;
+    }
+    if (this.busyComposerHint) {
+      const h = this.busyComposerHint.length <= a ? this.busyComposerHint : this.busyComposerHint.slice(0, a - 1) + '…';
+      return `   ${this.skin.applyColors(h, 'muted')}`;
+    }
     return '';
   }
 

--- a/cli/v4/frame/coalescer.ts
+++ b/cli/v4/frame/coalescer.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/frame/coalescer.ts — render coalescing for the Ink frame.
+ *
+ * Fast model streams emit many tiny deltas; repainting the whole frame on each
+ * one thrashes the reconciler. This batches deltas and signals a flush at most
+ * once per `intervalMs` (~16–33ms = 30–60fps). It NEVER drops content — only
+ * FRAMES: on flush the whole accumulated text is returned. The clock is
+ * injected so it's deterministic + headless-testable.
+ */
+export interface DeltaCoalescer {
+  /** Accumulate a delta (content is never lost). */
+  push(text: string): void;
+  /** True when there's buffered content AND enough time has passed to paint. */
+  shouldFlush(nowMs: number): boolean;
+  /** Drain the accumulated text and stamp the flush time. */
+  flush(nowMs: number): string;
+  /** True when any content is buffered (e.g. flush the tail at turn end). */
+  pending(): boolean;
+}
+
+export function makeCoalescer(intervalMs = 24): DeltaCoalescer {
+  let buf = '';
+  let lastFlush = -Infinity;
+  return {
+    push(text) { if (text) buf += text; },
+    shouldFlush(nowMs) { return buf.length > 0 && nowMs - lastFlush >= intervalMs; },
+    flush(nowMs) { const out = buf; buf = ''; lastFlush = nowMs; return out; },
+    pending() { return buf.length > 0; },
+  };
+}

--- a/cli/v4/frame/composerModel.ts
+++ b/cli/v4/frame/composerModel.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/frame/composerModel.ts — the ONE composer's state → view mapping.
+ *
+ * Idle and busy use the SAME composer component; only the SUBMIT POLICY and the
+ * plain-language HINT differ. This pure function derives both from the frame
+ * state, so the Ink component just renders what it returns — no idle-vs-busy
+ * branching in the view. Reusable by the future dashboard's composer too.
+ */
+
+/** What pressing Enter does right now. */
+export type SubmitPolicy = 'send' | 'queue' | 'steer' | 'stop';
+
+export interface ComposerView {
+  /** The plain-language hint line under the input (never cryptic tokens). */
+  hint:   string;
+  /** What Enter does now — the caller wires it to the real action. */
+  submit: SubmitPolicy;
+}
+
+const ENTER_ACTION: Record<'queue' | 'interrupt' | 'redirect', SubmitPolicy> = {
+  queue: 'queue', interrupt: 'stop', redirect: 'steer',
+};
+
+/**
+ * Derive the composer view. IDLE → send + calm hint. BUSY → the active mode's
+ * Enter action + steering hint (Ctrl+Enter always queues; Ctrl+C always stops).
+ * PAUSED (busy) → a resume-first hint, Enter still does the mode action.
+ */
+export function composerView(opts: {
+  phase:    'idle' | 'busy';
+  busyMode: 'queue' | 'interrupt' | 'redirect';
+  paused:   boolean;
+}): ComposerView {
+  if (opts.phase === 'idle') {
+    return { submit: 'send', hint: 'Type your message · /help · /mode to change' };
+  }
+  const submit = ENTER_ACTION[opts.busyMode];
+  if (opts.paused) {
+    return { submit, hint: 'Paused · /resume to continue · Ctrl+C stop' };
+  }
+  return { submit, hint: `Enter → ${submit} · Ctrl+Enter queue · Ctrl+C stop` };
+}

--- a/cli/v4/frame/frameReducer.ts
+++ b/cli/v4/frame/frameReducer.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/frame/frameReducer.ts — the single UI store for the Ink frame owner.
+ *
+ * THE CORE PRINCIPLE: one renderer owns the terminal frame. The model stream,
+ * tool rows, spinner, status, and keystrokes are all EVENTS into this ONE pure
+ * reducer → FrameState → Ink renders it. Nothing writes to stdout directly
+ * while Ink owns the screen. Raw content (the transcript items) is CANONICAL;
+ * the painted frame is disposable and re-derivable from state.
+ *
+ * turnId discipline: every turn-scoped event carries the turn's id. An event
+ * whose id doesn't match the active turn is a LATE event from a finished or
+ * interrupted turn — it is IGNORED, never resurrected. Non-turn events
+ * (composer keystrokes, overlays) apply in any state, including idle.
+ *
+ * Pure + headless-testable: no I/O, no Ink, no timers.
+ */
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+export type ToolStatus = 'running' | 'ok' | 'error';
+
+/** One canonical transcript item. Assistant items accumulate stream deltas. */
+export type TranscriptItem =
+  | { kind: 'user';      id: string; text: string }
+  | { kind: 'assistant'; id: string; text: string }
+  | { kind: 'tool';      id: string; name: string; status: ToolStatus; detail: string }
+  | { kind: 'note';      id: string; text: string };   // queued/steer confirmations, etc.
+
+export interface StatusLane {
+  verb:          string;   // "thinking" | "researching" | …
+  elapsedS:      number;
+  model:         string;
+  contextTokens: number;
+  contextMax:    number | null;
+}
+
+export interface ComposerLaneState {
+  buffer: string;
+  cursor: number;
+}
+
+export type Overlay =
+  | null
+  | { kind: 'slash';    items: string[]; selected: number }
+  | { kind: 'approval'; message: string }
+  | { kind: 'queue';    items: string[] };
+
+export interface FrameState {
+  /** Active turn id, or null when idle. Drives phase + late-event filtering. */
+  turnId:     number | null;
+  phase:      'idle' | 'busy';
+  transcript: TranscriptItem[];
+  status:     StatusLane;
+  composer:   ComposerLaneState;
+  busyMode:   'queue' | 'interrupt' | 'redirect';
+  paused:     boolean;
+  overlay:    Overlay;
+}
+
+export function initialFrameState(): FrameState {
+  return {
+    turnId: null,
+    phase: 'idle',
+    transcript: [],
+    status: { verb: 'thinking', elapsedS: 0, model: '', contextTokens: 0, contextMax: null },
+    composer: { buffer: '', cursor: 0 },
+    busyMode: 'queue',
+    paused: false,
+    overlay: null,
+  };
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+export type FrameEvent =
+  // ── turn lifecycle ──
+  | { type: 'turn/start';     turnId: number }
+  | { type: 'turn/end';       turnId: number }
+  | { type: 'turn/interrupt'; turnId: number }
+  // ── turn-scoped render events (carry turnId; late ones ignored) ──
+  | { type: 'stream/delta';   turnId: number; text: string }
+  | { type: 'tool/start';     turnId: number; id: string; name: string; detail?: string }
+  | { type: 'tool/progress';  turnId: number; id: string; detail: string }
+  | { type: 'tool/complete';  turnId: number; id: string; status: 'ok' | 'error'; detail?: string }
+  | { type: 'status/set';     turnId: number; patch: Partial<StatusLane> }
+  | { type: 'note';           turnId: number; text: string }
+  // ── non-turn events (apply any time, incl. idle) ──
+  | { type: 'user/message';   text: string }
+  | { type: 'composer/set';   buffer: string; cursor: number }
+  | { type: 'busyMode/set';   mode: 'queue' | 'interrupt' | 'redirect' }
+  | { type: 'pause/set';      paused: boolean }
+  | { type: 'overlay/set';    overlay: Overlay };
+
+/** Turn-scoped event types — gated by the turnId guard. */
+const TURN_SCOPED = new Set<FrameEvent['type']>([
+  'stream/delta', 'tool/start', 'tool/progress', 'tool/complete', 'status/set', 'note',
+]);
+
+let seq = 0;
+/** Monotonic id for transcript items (pure: derived from a module counter, not
+ *  a clock, so tests are deterministic across a process run). */
+function nextId(prefix: string): string { seq += 1; return `${prefix}${seq}`; }
+
+// ── Reducer ──────────────────────────────────────────────────────────────────
+
+export function frameReducer(prev: FrameState, ev: FrameEvent): FrameState {
+  // ── turnId guard: a turn-scoped event whose id isn't the ACTIVE turn is a
+  //    late/foreign event (from a finished/interrupted turn) → drop it. ──
+  if (TURN_SCOPED.has(ev.type)) {
+    const turnId = (ev as { turnId: number }).turnId;
+    if (prev.turnId === null || turnId !== prev.turnId) return prev;
+  }
+
+  switch (ev.type) {
+    case 'turn/start':
+      return { ...prev, turnId: ev.turnId, phase: 'busy', paused: false,
+        status: { ...prev.status, elapsedS: 0 } };
+
+    case 'turn/end':
+    case 'turn/interrupt': {
+      if (prev.turnId !== ev.turnId) return prev;   // stale end/interrupt → ignore
+      // Any still-running tool is closed (interrupt) so it never lingers.
+      const transcript = ev.type === 'turn/interrupt'
+        ? prev.transcript.map((t) => t.kind === 'tool' && t.status === 'running'
+            ? { ...t, status: 'error' as const, detail: 'interrupted' } : t)
+        : prev.transcript;
+      return { ...prev, turnId: null, phase: 'idle', paused: false, overlay: null, transcript };
+    }
+
+    case 'stream/delta': {
+      const last = prev.transcript[prev.transcript.length - 1];
+      if (last && last.kind === 'assistant') {
+        const transcript = prev.transcript.slice(0, -1).concat({ ...last, text: last.text + ev.text });
+        return { ...prev, transcript };
+      }
+      return { ...prev, transcript: prev.transcript.concat({ kind: 'assistant', id: nextId('a'), text: ev.text }) };
+    }
+
+    case 'tool/start':
+      return { ...prev, transcript: prev.transcript.concat({
+        kind: 'tool', id: ev.id, name: ev.name, status: 'running', detail: ev.detail ?? '' }) };
+
+    case 'tool/progress':
+      return { ...prev, transcript: prev.transcript.map((t) =>
+        t.kind === 'tool' && t.id === ev.id ? { ...t, detail: ev.detail } : t) };
+
+    case 'tool/complete':
+      return { ...prev, transcript: prev.transcript.map((t) =>
+        t.kind === 'tool' && t.id === ev.id
+          ? { ...t, status: ev.status, detail: ev.detail ?? t.detail } : t) };
+
+    case 'status/set':
+      return { ...prev, status: { ...prev.status, ...ev.patch } };
+
+    case 'note':
+      return { ...prev, transcript: prev.transcript.concat({ kind: 'note', id: nextId('n'), text: ev.text }) };
+
+    case 'user/message':
+      return { ...prev, transcript: prev.transcript.concat({ kind: 'user', id: nextId('u'), text: ev.text }) };
+
+    case 'composer/set':
+      return { ...prev, composer: { buffer: ev.buffer, cursor: ev.cursor } };
+
+    case 'busyMode/set':
+      return { ...prev, busyMode: ev.mode };
+
+    case 'pause/set':
+      return { ...prev, paused: ev.paused };
+
+    case 'overlay/set':
+      return { ...prev, overlay: ev.overlay };
+
+    default:
+      return prev;
+  }
+}
+
+/** Test-only — reset the item-id counter so ids are stable across test files. */
+export function _resetFrameIds(): void { seq = 0; }

--- a/cli/v4/frame/inkApp.ts
+++ b/cli/v4/frame/inkApp.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/frame/inkApp.ts — the Ink render tree for the single-owner frame.
+ *
+ * Renders a FrameState (nothing else): SETTLED transcript items flow into Ink's
+ * <Static> (printed once, scrolled up into real scrollback ABOVE the live
+ * frame); the LIVE tail (the still-streaming assistant + any running tool) + the
+ * busy/status row + the ONE composer + overlays render in the live frame that
+ * Ink owns at the bottom. Output can never overwrite the composer because ONE
+ * renderer owns the whole frame + the final cursor.
+ *
+ * Pure view: no state, no I/O — props in, elements out. Built with
+ * React.createElement (no JSX) to avoid flipping the project tsconfig, matching
+ * cli/v4/frame/composer.ts.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const React = require('react') as typeof import('react');
+
+import type { FrameState, TranscriptItem } from './frameReducer';
+import { composerView } from './composerModel';
+
+export interface InkAppComponents {
+  Box:    React.ComponentType<{ children?: React.ReactNode; flexDirection?: 'row' | 'column'; marginTop?: number }>;
+  Text:   React.ComponentType<{ children?: React.ReactNode; color?: string; dimColor?: boolean; inverse?: boolean; bold?: boolean }>;
+  Static: React.ComponentType<{ items: TranscriptItem[]; children: (item: TranscriptItem, index: number) => React.ReactNode }>;
+}
+
+/** Split the transcript into a SETTLED prefix (→ Static/scrollback) and a LIVE
+ *  suffix (still-changing tail). Live = trailing run of a running tool or the
+ *  streaming assistant at the tail while busy. Tools run sequentially + the
+ *  assistant streams at the tail, so the live items are always a suffix. */
+export function splitTranscript(t: TranscriptItem[], phase: 'idle' | 'busy'): { settled: TranscriptItem[]; live: TranscriptItem[] } {
+  let liveStart = t.length;
+  for (let i = t.length - 1; i >= 0; i -= 1) {
+    const it = t[i];
+    const isLive = (it.kind === 'tool' && it.status === 'running')
+      || (it.kind === 'assistant' && i === t.length - 1 && phase === 'busy');
+    if (isLive) liveStart = i; else break;
+  }
+  return { settled: t.slice(0, liveStart), live: t.slice(liveStart) };
+}
+
+/** One transcript row → its element. Kept pure + exported for view tests. */
+export function itemLine(it: TranscriptItem): string {
+  switch (it.kind) {
+    case 'user':      return `▲ ${it.text}`;
+    case 'assistant': return `┃ ${it.text}`;
+    case 'note':      return `  ${it.text}`;
+    case 'tool': {
+      const glyph = it.status === 'running' ? '⋯' : it.status === 'ok' ? '✓' : '✗';
+      return `  ${glyph} ${it.name}${it.detail ? ` — ${it.detail}` : ''}`;
+    }
+  }
+}
+
+export function makeInkApp(ink: InkAppComponents): React.ComponentType<{ state: FrameState }> {
+  const { Box, Text, Static } = ink;
+
+  function Row({ item }: { item: TranscriptItem }): React.ReactElement {
+    const color = item.kind === 'user' ? 'cyan'
+      : item.kind === 'tool' ? (item.status === 'error' ? 'red' : item.status === 'ok' ? 'green' : 'yellow')
+      : undefined;
+    return React.createElement(Text, { color, dimColor: item.kind === 'note' }, itemLine(item));
+  }
+
+  function StatusRow({ state }: { state: FrameState }): React.ReactElement | null {
+    if (state.phase !== 'busy') return null;
+    const s = state.status;
+    const paused = state.paused ? ' · paused' : '';
+    return React.createElement(Text, { dimColor: true },
+      `  ${s.verb}… ${s.elapsedS}s${paused}`);
+  }
+
+  function Composer({ state }: { state: FrameState }): React.ReactElement {
+    const view = composerView({ phase: state.phase, busyMode: state.busyMode, paused: state.paused });
+    const { buffer, cursor } = state.composer;
+    const before = buffer.slice(0, cursor);
+    const at     = cursor < buffer.length ? buffer[cursor] : ' ';
+    const after  = cursor < buffer.length ? buffer.slice(cursor + 1) : '';
+    return React.createElement(Box, { flexDirection: 'column', marginTop: 1 },
+      // The input line: prompt + before-cursor + inverse cursor cell + after.
+      React.createElement(Box, { flexDirection: 'row' },
+        React.createElement(Text, { color: 'cyan' }, '▲ '),
+        React.createElement(Text, null, before),
+        React.createElement(Text, { inverse: true }, at),
+        React.createElement(Text, null, after),
+      ),
+      // The plain-language hint line.
+      React.createElement(Text, { dimColor: true }, `  ${view.hint}`),
+    );
+  }
+
+  function Overlay({ state }: { state: FrameState }): React.ReactElement | null {
+    const o = state.overlay;
+    if (!o) return null;
+    if (o.kind === 'slash') {
+      return React.createElement(Box, { flexDirection: 'column' },
+        ...o.items.map((cmd, i) => React.createElement(Text,
+          { key: cmd, inverse: i === o.selected }, `  ${cmd}`)));
+    }
+    if (o.kind === 'approval') return React.createElement(Text, { color: 'yellow' }, `  ⚠ ${o.message}`);
+    if (o.kind === 'queue') {
+      return React.createElement(Box, { flexDirection: 'column' },
+        React.createElement(Text, { dimColor: true }, `  queued (${o.items.length}):`),
+        ...o.items.map((q, i) => React.createElement(Text, { key: String(i), dimColor: true }, `    • ${q}`)));
+    }
+    return null;
+  }
+
+  return function InkApp({ state }: { state: FrameState }): React.ReactElement {
+    const { settled, live } = splitTranscript(state.transcript, state.phase);
+    return React.createElement(Box, { flexDirection: 'column' },
+      // SETTLED history → Static → real scrollback above the live frame.
+      React.createElement(Static as React.ComponentType<{ items: TranscriptItem[]; children: (i: TranscriptItem, n: number) => React.ReactNode }>,
+        { items: settled, children: (item: TranscriptItem) => React.createElement(Row, { key: item.id, item }) }),
+      // LIVE tail (streaming assistant + running tools), re-rendered each frame.
+      ...live.map((item) => React.createElement(Row, { key: item.id, item })),
+      React.createElement(StatusRow, { state }),
+      React.createElement(Overlay, { state }),
+      React.createElement(Composer, { state }),
+    );
+  };
+}

--- a/cli/v4/frame/inkRuntime.ts
+++ b/cli/v4/frame/inkRuntime.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * cli/v4/frame/inkRuntime.ts — the single frame OWNER (Ink-backed).
+ *
+ * Mounts ONE persistent Ink tree that owns the terminal frame + final cursor
+ * for the whole session. Every event goes `dispatch → frameReducer → FrameState
+ * → Ink rerender`; stream deltas are coalesced (~24ms) so a fast model doesn't
+ * thrash the reconciler (content is never dropped, only frames). Ink itself
+ * redraws the full frame on resize. The terminalDriver writer-singleton guard
+ * (armed here) makes any stray non-Ink stdout write throw — so nothing can race
+ * the frame while Ink owns it.
+ *
+ * Gated by `inkEnabled()` (AIDEN_INK=1); the default render path never
+ * constructs this. Ink no-ops its paint in CI, so this is import-safe in tests.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const React = require('react') as typeof import('react');
+
+import { installGuard, arm, disarm, getDriverStream } from './terminalDriver';
+import {
+  frameReducer, initialFrameState, type FrameEvent, type FrameState,
+} from './frameReducer';
+import { makeCoalescer } from './coalescer';
+import { makeInkApp, type InkAppComponents } from './inkApp';
+
+// Minimal Ink surface (see runtime.ts for why the type is hand-rolled + the
+// import is deferred past tsc's moduleResolution).
+interface InkModule extends InkAppComponents {
+  render: (node: React.ReactElement, opts?: {
+    stdout?: NodeJS.WriteStream; stdin?: NodeJS.ReadStream; exitOnCtrlC?: boolean; patchConsole?: boolean;
+  }) => { unmount: () => void; rerender: (n: React.ReactElement) => void; clear: () => void };
+}
+let inkModuleP: Promise<InkModule> | null = null;
+const _dynamicImport = new Function('m', 'return import(m)') as (m: string) => Promise<unknown>;
+async function loadInk(): Promise<InkModule> {
+  if (!inkModuleP) inkModuleP = _dynamicImport('ink') as Promise<InkModule>;
+  return inkModuleP;
+}
+
+export interface InkRuntime {
+  /** Apply an event and repaint. */
+  dispatch(ev: FrameEvent): void;
+  /** Push a coalesced stream delta (batched into ~1 frame per interval). */
+  streamDelta(turnId: number, text: string): void;
+  /** Flush any buffered delta immediately (e.g. at a tool boundary / turn end). */
+  flush(): void;
+  getState(): FrameState;
+  shutdown(): void;
+}
+
+/** True when the Ink single-frame renderer is opted into (default OFF — the
+ *  legacy path is untouched until this is smoke-proven on a real terminal). */
+export function inkEnabled(): boolean {
+  return process.env.AIDEN_INK === '1';
+}
+
+export async function createInkRuntime(
+  opts: { nowFn?: () => number; coalesceMs?: number } = {},
+): Promise<InkRuntime> {
+  const nowFn = opts.nowFn ?? (() => Date.now());
+  installGuard();
+  const ink = await loadInk();
+  const InkApp = makeInkApp({ Box: ink.Box, Text: ink.Text, Static: ink.Static });
+
+  let state = initialFrameState();
+  const coalescer = makeCoalescer(opts.coalesceMs ?? 24);
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentTurn: number | null = null;
+
+  const stream = getDriverStream();
+  const instance = ink.render(
+    React.createElement(InkApp, { state }),
+    { stdout: stream as unknown as NodeJS.WriteStream, stdin: process.stdin, exitOnCtrlC: false, patchConsole: false },
+  );
+  arm();
+
+  const repaint = (): void => { instance.rerender(React.createElement(InkApp, { state })); };
+  const apply = (ev: FrameEvent): void => { state = frameReducer(state, ev); if (ev.type === 'turn/start') currentTurn = ev.turnId; };
+
+  const drainDelta = (): void => {
+    if (!coalescer.pending() || currentTurn === null) return;
+    apply({ type: 'stream/delta', turnId: currentTurn, text: coalescer.flush(nowFn()) });
+    repaint();
+  };
+
+  return {
+    dispatch(ev) { apply(ev); if (ev.type === 'turn/end' || ev.type === 'turn/interrupt') { if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; } } repaint(); },
+    streamDelta(turnId, text) {
+      currentTurn = turnId;
+      coalescer.push(text);
+      if (flushTimer === null) {
+        flushTimer = setTimeout(() => { flushTimer = null; drainDelta(); }, opts.coalesceMs ?? 24);
+      }
+    },
+    flush() { if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; } drainDelta(); },
+    getState() { return state; },
+    shutdown() {
+      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      try { instance.clear(); } catch { /* noop */ }
+      try { instance.unmount(); } catch { /* noop */ }
+      disarm();
+    },
+  };
+}

--- a/cli/v4/tuiCallbacks.ts
+++ b/cli/v4/tuiCallbacks.ts
@@ -247,10 +247,8 @@ Reply with ONE word: safe, caution, or dangerous.`;
 
   /** Compression sink. Inline. */
   onCompression = (result: CompressionResult): void => {
-    if (result.refused) {
-      this.opts.appendHistory(
-        '{gray-fg}[compress] refused — conversation too short{/gray-fg}',
-      );
+    // v4.14 — a refusal is internal housekeeping; never surface it in chat.
+    if (result.refused && !result.error) {
       return;
     }
     if (result.error) {

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -838,7 +838,11 @@ export class AidenAgent {
     //     (network reset mid-summary, etc.); it now synthesises an
     //     error envelope + fires the callback so the user sees the
     //     abort rather than wondering why nothing happened.
-    if (this.contextCompressor) {
+    // v4.14 — do NOT attempt auto-compression on a below-threshold (fresh /
+    // short) conversation: it could only be refused, and a refusal is internal
+    // housekeeping that must never surface in the user's chat. No attempt → no
+    // "[compress] refused" leak. Manual /compress still attempts (own command).
+    if (this.contextCompressor && this.contextCompressor.shouldAutoAttempt(messages.length)) {
       try {
         const result = await this.contextCompressor.compress(
           messages,

--- a/core/v4/contextCompressor.ts
+++ b/core/v4/contextCompressor.ts
@@ -109,6 +109,17 @@ export class ContextCompressor {
   }
 
   /**
+   * v4.14 — whether the AUTO path should even ATTEMPT compression. Below the
+   * minimum message count a fresh/short conversation can only be REFUSED, and a
+   * refusal is a non-event that must never reach the user's chat. Gating the
+   * attempt here means "no attempt → no refusal message" at the source. The
+   * manual `/compress` command bypasses this (it always attempts + explains).
+   */
+  shouldAutoAttempt(messageCount: number): boolean {
+    return messageCount >= MIN_FOR_COMPRESSION;
+  }
+
+  /**
    * v4.11 retrofit — accepts an optional `tools` array. When supplied,
    * the threshold check counts tool-schema tokens (principle #2) so the
    * 68-tool catalog (6-13K tokens) influences when compression fires.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-runtime",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/v4/cli/callbacks.test.ts
+++ b/tests/v4/cli/callbacks.test.ts
@@ -477,7 +477,7 @@ describe('CliCallbacks.onCompression', () => {
     }
   });
 
-  it('reports refusal cleanly', () => {
+  it('a refusal is SILENT in chat (v4.14 — housekeeping, never a user-facing line)', () => {
     const { display, output } = makeDisplay();
     const cb = new CliCallbacks({ display });
     cb.onCompression({
@@ -487,7 +487,8 @@ describe('CliCallbacks.onCompression', () => {
       preservedRecentCount: 0,
       refused: true,
     });
-    expect(output()).toMatch(/refused/);
+    expect(output()).not.toMatch(/refused|\[compress\]/);   // no "[compress] refused" leak
+    expect(output().trim()).toBe('');
   });
 });
 

--- a/tests/v4/cli/composerHint.test.ts
+++ b/tests/v4/cli/composerHint.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 composer polish:
+ *   Issue 1 — the BUSY hint is width-safe: full on a wide terminal, and on a
+ *   narrow one it keeps the FRONT ("Enter → …") with an ellipsis, never the
+ *   wrapped tail ("…change · Ctrl+C stop") the single-line repaint used to show.
+ *   Issue 2 — the persistent IDLE hint shows only when idle and nothing else
+ *   owns the footer (no ghost/dropdown).
+ */
+import { describe, it, expect } from 'vitest';
+import { Writable } from 'node:stream';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { shouldShowIdleHint } from '../../../cli/v4/aidenPrompt';
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+function makeDisplay(columns: number) {
+  const chunks: string[] = [];
+  const out = new Writable({ write(c, _e, cb) { chunks.push(c.toString()); cb(); } }) as Writable & { isTTY?: boolean; columns?: number };
+  out.isTTY = true; out.columns = columns;
+  return { d: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out as unknown as NodeJS.WriteStream }), chunks };
+}
+
+describe('busy hint — width-safe (Issue 1)', () => {
+  const HINT = 'Enter → steer · /busy to change · Ctrl+C stop';
+
+  it('a WIDE terminal shows the FULL hint (no truncation)', () => {
+    const { d, chunks } = makeDisplay(100);
+    const ind = d.activityIndicator('thinking');
+    chunks.length = 0;
+    d.setBusyHint(HINT);
+    expect(stripAnsi(chunks.join(''))).toContain(HINT);   // complete, end-to-end
+    ind.stop();
+  });
+
+  it('a NARROW terminal keeps the FRONT with an ellipsis — never the tail-only garbage', () => {
+    const { d, chunks } = makeDisplay(40);
+    const ind = d.activityIndicator('thinking');
+    chunks.length = 0;
+    d.setBusyHint(HINT);
+    const painted = stripAnsi(chunks.join(''));
+    expect(painted).toContain('Enter →');        // the important front is kept
+    expect(painted).toContain('…');              // front-fit ellipsis
+    expect(painted).not.toContain('Ctrl+C stop'); // the TAIL is dropped, not the front
+    ind.stop();
+  });
+
+  it('long typed text keeps the CURSOR END (tail-fit), unlike the hint', () => {
+    const { d, chunks } = makeDisplay(80);   // avail 50; label + 48-char text overflows → tail-fit
+    const ind = d.activityIndicator('thinking');
+    chunks.length = 0;
+    d.setComposer('a very long message the user is typing right now', 'redirect');
+    const painted = stripAnsi(chunks.join(''));
+    expect(painted).toContain('…');              // ellipsis at the FRONT (tail-fit for typed text)
+    expect(painted).toContain('right now');      // most-recent chars (cursor end) kept
+    ind.stop();
+  });
+});
+
+describe('shouldShowIdleHint — persistent idle hint (Issue 2)', () => {
+  const HINT = 'Type your message · /help · /mode';
+  it('shows when idle, a hint is set, and no ghost/dropdown owns the footer', () => {
+    expect(shouldShowIdleHint(false, HINT, 'idle')).toBe(true);
+  });
+  it('hidden when a ghost/dropdown already owns the footer', () => {
+    expect(shouldShowIdleHint(true, HINT, 'idle')).toBe(false);
+  });
+  it('hidden when not idle (submitting/done)', () => {
+    expect(shouldShowIdleHint(false, HINT, 'done')).toBe(false);
+  });
+  it('hidden when no hint is configured', () => {
+    expect(shouldShowIdleHint(false, undefined, 'idle')).toBe(false);
+    expect(shouldShowIdleHint(false, '', 'idle')).toBe(false);
+  });
+});

--- a/tests/v4/cli/compressLeak.test.ts
+++ b/tests/v4/cli/compressLeak.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the "[compress] refused — conversation too short" chat leak is killed
+ * at the SOURCE: the auto path does not ATTEMPT compression below the threshold
+ * (no attempt → no refusal), and the sink stays SILENT on a refusal anyway
+ * (internal housekeeping → never the user chat). A long conversation still
+ * compresses, silently.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Writable } from 'node:stream';
+import { CliCallbacks } from '../../../cli/v4/callbacks';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { AidenAgent, type ToolExecutor } from '../../../core/v4/aidenAgent';
+import { MockProviderAdapter } from '../../../core/v4/__mocks__/mockProvider';
+import { ContextCompressor } from '../../../core/v4/contextCompressor';
+import { ModelMetadata } from '../../../core/v4/modelMetadata';
+import type { AuxiliaryClient } from '../../../core/v4/auxiliaryClient';
+import type { Message } from '../../../providers/v4/types';
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+function makeDisplay() {
+  const chunks: string[] = [];
+  const out = new Writable({ write(c, _e, cb) { chunks.push(c.toString()); cb(); } }) as unknown as NodeJS.WriteStream;
+  return { display: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out }), output: () => stripAnsi(chunks.join('')) };
+}
+const userMsg = (c: string): Message => ({ role: 'user', content: c });
+const execOk: ToolExecutor = async (call) => ({ id: call.id, name: call.name, result: 'ok' });
+
+describe('ContextCompressor.shouldAutoAttempt — the threshold gate', () => {
+  it('is false below the minimum, true at/above it', () => {
+    const c = new ContextCompressor(new ModelMetadata(), {} as unknown as AuxiliaryClient);
+    expect(c.shouldAutoAttempt(0)).toBe(false);   // empty / first message
+    expect(c.shouldAutoAttempt(9)).toBe(false);   // short
+    expect(c.shouldAutoAttempt(10)).toBe(true);   // at threshold
+    expect(c.shouldAutoAttempt(50)).toBe(true);   // long
+  });
+});
+
+describe('agent auto-compress gate — no attempt on a short conversation', () => {
+  function fakeCompressor(): { c: ContextCompressor; compress: ReturnType<typeof vi.fn> } {
+    const compress = vi.fn(async () => ({
+      compressedMessages: [], removedMessageCount: 0, summaryTokens: 0,
+      preservedRecentCount: 0, refused: true, errorMessage: 'too short',
+    }));
+    const c = { shouldAutoAttempt: (n: number) => n >= 10, compress } as unknown as ContextCompressor;
+    return { c, compress };
+  }
+
+  it('a SHORT convo → compress is NOT attempted and onCompression NEVER fires (no leak)', async () => {
+    const { c, compress } = fakeCompressor();
+    const onCompression = vi.fn();
+    const agent = new AidenAgent({
+      provider: new MockProviderAdapter([MockProviderAdapter.stop('hi')]),
+      tools: [], toolExecutor: execOk, contextCompressor: c, onCompression,
+    });
+    await agent.runConversation([userMsg('hello')], {});
+    expect(compress).not.toHaveBeenCalled();        // gated at the source
+    expect(onCompression).not.toHaveBeenCalled();   // → no refusal event, no chat leak
+  });
+
+  it('a LONG convo (>= threshold) → compress IS attempted (gate does not over-block)', async () => {
+    const { c, compress } = fakeCompressor();
+    const history: Message[] = [];
+    for (let i = 0; i < 6; i += 1) { history.push({ role: 'user', content: `u${i}` }); history.push({ role: 'assistant', content: `a${i}` }); }
+    const agent = new AidenAgent({
+      provider: new MockProviderAdapter([MockProviderAdapter.stop('done')]),
+      tools: [], toolExecutor: execOk, contextCompressor: c,
+    });
+    await agent.runConversation(history, {});       // 12 messages ≥ 10
+    expect(compress).toHaveBeenCalled();
+  });
+});
+
+describe('callbacks sink — a refusal is silent in chat', () => {
+  it('onCompression(refused) writes NOTHING to the user chat', () => {
+    const { display, output } = makeDisplay();
+    const cb = new CliCallbacks({ display });
+    cb.onCompression({
+      compressedMessages: [], removedMessageCount: 0, summaryTokens: 0,
+      preservedRecentCount: 0, refused: true, errorMessage: 'Conversation too short to compress',
+    });
+    expect(output()).not.toMatch(/\[compress\]/);   // no "[compress] refused …" leak
+    expect(output()).not.toMatch(/too short/i);
+    expect(output().trim()).toBe('');
+  });
+
+  it('onCompression(success) is silent in chat by default (housekeeping)', () => {
+    const { display, output } = makeDisplay();
+    const cb = new CliCallbacks({ display });
+    cb.onCompression({ compressedMessages: [], removedMessageCount: 5, summaryTokens: 200, preservedRecentCount: 4 });
+    expect(output()).not.toMatch(/\[compress\]/);   // success is telemetry, not chat noise
+  });
+});

--- a/tests/v4/cli/frame/frameComposerCoalesce.test.ts
+++ b/tests/v4/cli/frame/frameComposerCoalesce.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the ONE composer's state→view mapping (idle vs busy submit policy +
+ * plain-language hint) and the render coalescer (batch deltas, never drop
+ * content). Both pure + deterministic.
+ */
+import { describe, it, expect } from 'vitest';
+import { composerView } from '../../../../cli/v4/frame/composerModel';
+import { makeCoalescer } from '../../../../cli/v4/frame/coalescer';
+
+describe('composerView — ONE composer, two policies', () => {
+  it('IDLE → send, calm plain-language hint', () => {
+    const v = composerView({ phase: 'idle', busyMode: 'queue', paused: false });
+    expect(v.submit).toBe('send');
+    expect(v.hint).toBe('Type your message · /help · /mode to change');
+  });
+
+  it('BUSY reflects the active mode as Enter action, plain-language (never cryptic)', () => {
+    expect(composerView({ phase: 'busy', busyMode: 'redirect', paused: false }))
+      .toEqual({ submit: 'steer', hint: 'Enter → steer · Ctrl+Enter queue · Ctrl+C stop' });
+    expect(composerView({ phase: 'busy', busyMode: 'queue', paused: false }))
+      .toEqual({ submit: 'queue', hint: 'Enter → queue · Ctrl+Enter queue · Ctrl+C stop' });
+    expect(composerView({ phase: 'busy', busyMode: 'interrupt', paused: false }))
+      .toEqual({ submit: 'stop', hint: 'Enter → stop · Ctrl+Enter queue · Ctrl+C stop' });
+  });
+
+  it('PAUSED (busy) → resume-first hint, Enter still does the mode action', () => {
+    const v = composerView({ phase: 'busy', busyMode: 'redirect', paused: true });
+    expect(v.submit).toBe('steer');
+    expect(v.hint).toBe('Paused · /resume to continue · Ctrl+C stop');
+  });
+
+  it('no cryptic tokens anywhere (no "msg=", no "mode:")', () => {
+    for (const mode of ['queue', 'interrupt', 'redirect'] as const) {
+      for (const phase of ['idle', 'busy'] as const) {
+        const { hint } = composerView({ phase, busyMode: mode, paused: false });
+        expect(hint).not.toMatch(/msg=|mode:|=interrupt/);
+      }
+    }
+  });
+});
+
+describe('makeCoalescer — batch frames, never drop content', () => {
+  it('accumulates deltas and flushes the WHOLE buffer (no content lost)', () => {
+    const c = makeCoalescer(24);
+    c.push('Hel'); c.push('lo');
+    expect(c.pending()).toBe(true);
+    expect(c.flush(100)).toBe('Hello');
+    expect(c.pending()).toBe(false);
+  });
+
+  it('shouldFlush respects the interval (coalesces bursts into ~1 frame)', () => {
+    const c = makeCoalescer(24);
+    c.push('a');
+    expect(c.shouldFlush(0)).toBe(true);      // first content, lastFlush=-Inf → paint
+    c.flush(0);
+    c.push('b');
+    expect(c.shouldFlush(10)).toBe(false);    // only 10ms since last paint → hold
+    expect(c.shouldFlush(24)).toBe(true);     // 24ms passed → paint
+  });
+
+  it('shouldFlush is false with an empty buffer (no empty frames)', () => {
+    const c = makeCoalescer(24);
+    expect(c.shouldFlush(1000)).toBe(false);
+  });
+
+  it('the accumulated content across a fast burst is byte-complete on flush', () => {
+    const c = makeCoalescer(24);
+    const parts = ['The ', 'quick ', 'brown ', 'fox'];
+    for (const p of parts) c.push(p);
+    expect(c.flush(50)).toBe('The quick brown fox');   // nothing dropped, only batched
+  });
+});

--- a/tests/v4/cli/frame/frameReducer.test.ts
+++ b/tests/v4/cli/frame/frameReducer.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the Ink frame's single UI store. Proves "every event → one pure
+ * reducer → FrameState": turn lifecycle, streaming deltas accumulate, tool rows
+ * start/progress/complete, status, and — the load-bearing invariant — turnId
+ * discipline: LATE events from a finished/interrupted turn are IGNORED, never
+ * resurrected.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  frameReducer, initialFrameState, _resetFrameIds,
+  type FrameState, type FrameEvent,
+} from '../../../../cli/v4/frame/frameReducer';
+
+beforeEach(() => _resetFrameIds());
+const run = (s: FrameState, evs: FrameEvent[]): FrameState => evs.reduce(frameReducer, s);
+const start = initialFrameState();
+
+describe('frameReducer — turn lifecycle', () => {
+  it('turn/start goes busy with the turn id; turn/end returns to idle', () => {
+    const busy = frameReducer(start, { type: 'turn/start', turnId: 1 });
+    expect(busy.phase).toBe('busy');
+    expect(busy.turnId).toBe(1);
+    const idle = frameReducer(busy, { type: 'turn/end', turnId: 1 });
+    expect(idle.phase).toBe('idle');
+    expect(idle.turnId).toBeNull();
+  });
+
+  it('turn/interrupt closes any still-running tool (never left lingering)', () => {
+    const s = run(start, [
+      { type: 'turn/start', turnId: 1 },
+      { type: 'tool/start', turnId: 1, id: 't1', name: 'web_research' },
+      { type: 'turn/interrupt', turnId: 1 },
+    ]);
+    expect(s.phase).toBe('idle');
+    const tool = s.transcript.find((t) => t.kind === 'tool');
+    expect(tool).toMatchObject({ status: 'error', detail: 'interrupted' });
+  });
+});
+
+describe('frameReducer — streaming + tools become transcript items', () => {
+  it('stream deltas ACCUMULATE onto one assistant item (canonical raw content)', () => {
+    const s = run(start, [
+      { type: 'turn/start', turnId: 1 },
+      { type: 'stream/delta', turnId: 1, text: 'Hel' },
+      { type: 'stream/delta', turnId: 1, text: 'lo w' },
+      { type: 'stream/delta', turnId: 1, text: 'orld' },
+    ]);
+    const asst = s.transcript.filter((t) => t.kind === 'assistant');
+    expect(asst).toHaveLength(1);
+    expect((asst[0] as { text: string }).text).toBe('Hello world');
+  });
+
+  it('tool start → running, progress updates detail, complete sets status', () => {
+    const s = run(start, [
+      { type: 'turn/start', turnId: 1 },
+      { type: 'tool/start', turnId: 1, id: 't1', name: 'web_search', detail: 'q' },
+      { type: 'tool/progress', turnId: 1, id: 't1', detail: '3 results' },
+      { type: 'tool/complete', turnId: 1, id: 't1', status: 'ok', detail: 'done' },
+    ]);
+    expect(s.transcript.find((t) => t.kind === 'tool')).toMatchObject({ name: 'web_search', status: 'ok', detail: 'done' });
+  });
+
+  it('user message + note land as transcript items in order', () => {
+    const s = run(start, [
+      { type: 'user/message', text: 'hi' },
+      { type: 'turn/start', turnId: 1 },
+      { type: 'note', turnId: 1, text: 'queued (1 pending)' },
+    ]);
+    expect(s.transcript.map((t) => t.kind)).toEqual(['user', 'note']);
+  });
+});
+
+describe('frameReducer — turnId discipline (LATE events ignored, not resurrected)', () => {
+  it('a stream delta from a FINISHED turn is dropped', () => {
+    let s = run(start, [
+      { type: 'turn/start', turnId: 1 },
+      { type: 'stream/delta', turnId: 1, text: 'a' },
+      { type: 'turn/end', turnId: 1 },
+    ]);
+    const before = s;
+    // Late delta from turn 1 arrives after it ended → must be ignored.
+    s = frameReducer(s, { type: 'stream/delta', turnId: 1, text: 'ZOMBIE' });
+    expect(s).toBe(before);                                   // unchanged reference
+    expect(JSON.stringify(s.transcript)).not.toContain('ZOMBIE');
+  });
+
+  it('a tool event from a PREVIOUS turn is dropped once turn 2 is active', () => {
+    let s = run(start, [
+      { type: 'turn/start', turnId: 1 },
+      { type: 'turn/end', turnId: 1 },
+      { type: 'turn/start', turnId: 2 },
+    ]);
+    s = frameReducer(s, { type: 'tool/start', turnId: 1, id: 'old', name: 'stale' });
+    expect(s.transcript.find((t) => t.kind === 'tool')).toBeUndefined();  // turn-1 tool never appears
+  });
+
+  it('a turn-scoped event while IDLE (turnId null) is dropped', () => {
+    const s = frameReducer(start, { type: 'stream/delta', turnId: 7, text: 'x' });
+    expect(s).toBe(start);
+  });
+
+  it('a stale turn/end for a non-active turn does not clobber the active one', () => {
+    const s = run(start, [
+      { type: 'turn/start', turnId: 2 },
+      { type: 'turn/end', turnId: 1 },   // stale end for turn 1
+    ]);
+    expect(s.phase).toBe('busy');        // turn 2 still active
+    expect(s.turnId).toBe(2);
+  });
+});
+
+describe('frameReducer — non-turn events apply in any state (incl. idle)', () => {
+  it('composer/set, busyMode/set, pause/set, overlay/set work while idle', () => {
+    const s = run(start, [
+      { type: 'composer/set', buffer: 'draft', cursor: 5 },
+      { type: 'busyMode/set', mode: 'redirect' },
+      { type: 'pause/set', paused: true },
+      { type: 'overlay/set', overlay: { kind: 'slash', items: ['/help', '/mode'], selected: 0 } },
+    ]);
+    expect(s.composer).toEqual({ buffer: 'draft', cursor: 5 });
+    expect(s.busyMode).toBe('redirect');
+    expect(s.paused).toBe(true);
+    expect(s.overlay).toMatchObject({ kind: 'slash', selected: 0 });
+  });
+
+  it('the composer draft SURVIVES an interrupt (typed text is not lost)', () => {
+    const s = run(start, [
+      { type: 'turn/start', turnId: 1 },
+      { type: 'composer/set', buffer: 'half-typed', cursor: 4 },
+      { type: 'turn/interrupt', turnId: 1 },
+    ]);
+    expect(s.composer.buffer).toBe('half-typed');   // draft preserved across interrupt
+    expect(s.phase).toBe('idle');
+  });
+});

--- a/tests/v4/cli/frame/inkApp.test.ts
+++ b/tests/v4/cli/frame/inkApp.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ *
+ * Aiden — local-first agent.
+ */
+/**
+ * v4.14 — the Ink render tree's PURE helpers: the settled/live transcript split
+ * (settled → Static/scrollback, live tail re-rendered) and the per-item line
+ * rendering. Plus the AIDEN_INK opt-in flag (default OFF).
+ */
+import { describe, it, expect } from 'vitest';
+import { splitTranscript, itemLine } from '../../../../cli/v4/frame/inkApp';
+import { inkEnabled } from '../../../../cli/v4/frame/inkRuntime';
+import type { TranscriptItem } from '../../../../cli/v4/frame/frameReducer';
+
+const user  = (t: string): TranscriptItem => ({ kind: 'user', id: 'u', text: t });
+const asst  = (t: string): TranscriptItem => ({ kind: 'assistant', id: 'a', text: t });
+const tool  = (s: 'running' | 'ok' | 'error'): TranscriptItem => ({ kind: 'tool', id: 't', name: 'web_research', status: s, detail: 'q' });
+
+describe('splitTranscript — settled (scrollback) vs live (tail)', () => {
+  it('IDLE → everything is settled (flows to scrollback), nothing live', () => {
+    const { settled, live } = splitTranscript([user('hi'), asst('done')], 'idle');
+    expect(settled).toHaveLength(2);
+    expect(live).toHaveLength(0);
+  });
+
+  it('BUSY with a streaming assistant at the tail → that assistant is LIVE', () => {
+    const { settled, live } = splitTranscript([user('hi'), asst('typing…')], 'busy');
+    expect(settled.map((i) => i.kind)).toEqual(['user']);
+    expect(live.map((i) => i.kind)).toEqual(['assistant']);
+  });
+
+  it('a RUNNING tool at the tail is live; a completed one settles', () => {
+    expect(splitTranscript([asst('x'), tool('running')], 'busy').live.map((i) => i.kind)).toEqual(['tool']);
+    expect(splitTranscript([asst('x'), tool('ok')], 'busy').live).toHaveLength(0);   // settled tool → scrollback
+  });
+
+  it('settled items are a stable PREFIX (only grows) — Static-safe', () => {
+    const t = [user('a'), asst('b'), tool('running')];
+    const { settled } = splitTranscript(t, 'busy');
+    expect(settled).toEqual([t[0], t[1]]);   // prefix, in order
+  });
+});
+
+describe('itemLine — per-row rendering', () => {
+  it('renders each kind with its glyph', () => {
+    expect(itemLine(user('hello'))).toBe('▲ hello');
+    expect(itemLine(asst('hi there'))).toBe('┃ hi there');
+    expect(itemLine({ kind: 'note', id: 'n', text: 'queued (1)' })).toBe('  queued (1)');
+    expect(itemLine(tool('running'))).toBe('  ⋯ web_research — q');
+    expect(itemLine(tool('ok'))).toBe('  ✓ web_research — q');
+    expect(itemLine(tool('error'))).toBe('  ✗ web_research — q');
+  });
+});
+
+describe('inkEnabled — opt-in (default OFF)', () => {
+  it('reads AIDEN_INK', () => {
+    const prev = process.env.AIDEN_INK;
+    try {
+      delete process.env.AIDEN_INK;
+      expect(inkEnabled()).toBe(false);         // safe default: legacy path untouched
+      process.env.AIDEN_INK = '1';
+      expect(inkEnabled()).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.AIDEN_INK; else process.env.AIDEN_INK = prev;
+    }
+  });
+});

--- a/tests/v4/cli/frame/sourceContract.test.ts
+++ b/tests/v4/cli/frame/sourceContract.test.ts
@@ -51,11 +51,19 @@ describe('frame source-contract guard', () => {
   it('frame directory exists with the expected source set', () => {
     const files = readdirSync(FRAME_DIR).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
     expect(files.sort()).toEqual([
+      // v4.14 — the Ink single-owner frame: pure event→state core + render tree
+      // + runtime. All driver-routed (no raw stdout/ANSI), so the single-writer
+      // contract below still holds; the per-file guard proves it.
+      'coalescer.ts',
       'composer.ts',
+      'composerModel.ts',
+      'frameReducer.ts',
       // v4.12.1 Pillar 4 Slice 1 — pure glass-dashboard models (no stdout/ANSI;
       // the frame renderer paints them; the driver-only contract still holds).
       'glassHelpers.ts',
       'index.ts',
+      'inkApp.ts',
+      'inkRuntime.ts',
       'interruptControls.ts',
       'runtime.ts',
       'state.ts',


### PR DESCRIPTION
The input bar is always there, and connecting a server is one command.

- **One-tap MCP connect.** `/mcp connect <name>` adds the server, authorizes it, and connects — one command, no env vars, no three-step dance.
- **Always-present steering bar.** The input line stays live while Aiden works. Steer it mid-task, queue your next message, or stop with Ctrl+C — in both idle and busy.
- **`/mode` — pick your trust level.** Safe by default: Aiden asks before risky, spendy, or out-of-folder actions. `/mode auto` opts into hands-off; the floors always hold.
- **Warm intro + greeting.** Aiden asks your name once and actually uses it, and the boot greeting knows how long you've been away.

Fixes: no more "[compress] refused" noise on a fresh chat; the busy-hint text is width-safe.
