### PR TITLE
fix: harden terminal input and provider streaming

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -71,7 +71,7 @@ import { entityGraph }                                  from '../core/entityGrap
 import { learningMemory }                               from '../core/learningMemory'
 import { knowledgeBase }                               from '../core/knowledgeBase'
 import { extractYouTubeTranscript }                    from '../core/youtubeTranscript'
-import { importChatGPT, importOpenClaw }               from '../core/importers'
+import { importConversationArchive, importOpenClaw }  from '../core/importers'
 import { logBuffer }                                   from '../core/logBuffer'
 import { deepKB }                                      from '../core/deepKB'
 import multer                                           from 'multer'
@@ -5008,7 +5008,7 @@ export function createApiServer(): Express {
     if (!filePath) { res.status(400).json({ error: 'filePath required' }); return }
     if (!fs.existsSync(filePath)) { res.status(400).json({ error: 'File not found' }); return }
     try {
-      const result = await importChatGPT(filePath)
+      const result = await importConversationArchive(filePath)
       res.json(result)
     } catch (e: any) { res.status(500).json({ error: e.message }) }
   })

--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -1,0 +1,144 @@
+/** Central lifecycle owner for live CLI tool activity rows. */
+import type { ToolRowHandle } from './display';
+
+export type ActivityState = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+interface ActivityEntry {
+  id: string;
+  name: string;
+  state: ActivityState;
+  startedAt: number;
+  handle: ToolRowHandle;
+}
+
+export type ActivityOutcome =
+  | { state: 'completed'; retries?: number; dismiss?: boolean }
+  | { state: 'failed'; retries?: number }
+  | { state: 'cancelled'; dismiss?: boolean }
+  | { state: 'blocked' }
+  | { state: 'degraded'; reason?: string };
+
+export class ActivityRegistry {
+  private readonly entries = new Map<string, ActivityEntry>();
+  private readonly terminalStates = new Map<string, ActivityState>();
+  private modalDepth = 0;
+  private static readonly MAX_TERMINAL_TOMBSTONES = 2_048;
+
+  constructor(
+    private readonly createRow: (name: string, args: unknown) => ToolRowHandle,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  start(id: string, name: string, args: unknown): boolean {
+    if (this.entries.has(id) || this.terminalStates.has(id)) return false;
+    const entry: ActivityEntry = {
+      id,
+      name,
+      state: 'pending',
+      startedAt: this.now(),
+      handle: this.createRow(name, args),
+    };
+    entry.state = 'running';
+    this.entries.set(id, entry);
+    if (this.modalDepth > 0) entry.handle.pause();
+    return true;
+  }
+
+  settle(id: string, outcome: ActivityOutcome): boolean {
+    const entry = this.entries.get(id);
+    if (!entry || this.terminalStates.has(id)) return false;
+    p2aDiag('activity.settle.start', {
+      id, name: entry.name, outcome: outcome.state,
+      modalDepth: this.modalDepth, activeCount: this.entries.size,
+    });
+    this.entries.delete(id);
+    const duration = Math.max(0, this.now() - entry.startedAt);
+    if (outcome.state === 'completed') {
+      entry.state = 'completed';
+      this.rememberTerminal(id, entry.state);
+      if (outcome.dismiss) entry.handle.dismiss();
+      else entry.handle.ok(duration, outcome.retries ?? 0);
+    } else if (outcome.state === 'failed') {
+      entry.state = 'failed';
+      this.rememberTerminal(id, entry.state);
+      entry.handle.fail(duration, outcome.retries ?? 0);
+    } else if (outcome.state === 'cancelled') {
+      entry.state = 'cancelled';
+      this.rememberTerminal(id, entry.state);
+      if (outcome.dismiss) entry.handle.dismiss();
+      else entry.handle.cancel(duration);
+    } else if (outcome.state === 'blocked') {
+      entry.state = 'failed';
+      this.rememberTerminal(id, entry.state);
+      entry.handle.blocked();
+    } else {
+      entry.state = 'completed';
+      this.rememberTerminal(id, entry.state);
+      entry.handle.degraded(duration, outcome.reason);
+    }
+    p2aDiag('activity.settle.complete', {
+      id, state: entry.state, modalDepth: this.modalDepth,
+      activeCount: this.entries.size,
+    });
+    return true;
+  }
+
+  pauseForModal(): void {
+    this.modalDepth += 1;
+    p2aDiag('activity.modal.pause', {
+      modalDepth: this.modalDepth, activeCount: this.entries.size,
+      activities: [...this.entries.values()].map((entry) => ({ id: entry.id, name: entry.name, state: entry.state })),
+    });
+    if (this.modalDepth !== 1) return;
+    for (const entry of this.entries.values()) entry.handle.pause();
+  }
+
+  resumeAfterModal(): void {
+    if (this.modalDepth === 0) return;
+    this.modalDepth -= 1;
+    p2aDiag('activity.modal.resume', {
+      modalDepth: this.modalDepth, activeCount: this.entries.size,
+      activities: [...this.entries.values()].map((entry) => ({ id: entry.id, name: entry.name, state: entry.state })),
+    });
+    if (this.modalDepth !== 0) return;
+    for (const entry of this.entries.values()) entry.handle.resume();
+  }
+
+  async runModal<T>(run: () => Promise<T>): Promise<T> {
+    this.pauseForModal();
+    try {
+      return await run();
+    } finally {
+      this.resumeAfterModal();
+    }
+  }
+
+  sweep(): void {
+    for (const id of [...this.entries.keys()]) {
+      this.settle(id, { state: 'cancelled', dismiss: true });
+    }
+    this.modalDepth = 0;
+  }
+
+  activeCount(): number { return this.entries.size; }
+  timerCount(): number { return this.entries.size; }
+  modalPauseDepth(): number { return this.modalDepth; }
+  stateOf(id: string): ActivityState | null {
+    return this.entries.get(id)?.state ?? this.terminalStates.get(id) ?? null;
+  }
+
+  private rememberTerminal(id: string, state: ActivityState): void {
+    this.terminalStates.set(id, state);
+    if (this.terminalStates.size <= ActivityRegistry.MAX_TERMINAL_TOMBSTONES) return;
+    const oldest = this.terminalStates.keys().next().value as string | undefined;
+    if (oldest !== undefined) this.terminalStates.delete(oldest);
+  }
+}
+
+function p2aDiag(event: string, data: Record<string, unknown>): void {
+  if (process.env.AIDEN_P2A_DIAG !== '1') return;
+  try {
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
+  } catch { /* diagnostics must never affect activity lifecycle */ }
+}

--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -1,5 +1,6 @@
 /** Central lifecycle owner for live CLI tool activity rows. */
 import type { ToolRowHandle } from './display';
+import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 
 export type ActivityState = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -41,6 +42,9 @@ export class ActivityRegistry {
     entry.state = 'running';
     this.entries.set(id, entry);
     if (this.modalDepth > 0) entry.handle.pause();
+    turnIdleDiagnostic('activity.start', {
+      id, name, activeCount: this.entries.size, modalDepth: this.modalDepth,
+    });
     return true;
   }
 
@@ -80,6 +84,10 @@ export class ActivityRegistry {
       id, state: entry.state, modalDepth: this.modalDepth,
       activeCount: this.entries.size,
     });
+    turnIdleDiagnostic('activity.settle', {
+      id, name: entry.name, state: entry.state,
+      activeCount: this.entries.size, modalDepth: this.modalDepth,
+    });
     return true;
   }
 
@@ -114,10 +122,16 @@ export class ActivityRegistry {
   }
 
   sweep(): void {
+    turnIdleDiagnostic('activity.sweep.start', {
+      activeCount: this.entries.size, modalDepth: this.modalDepth,
+    });
     for (const id of [...this.entries.keys()]) {
       this.settle(id, { state: 'cancelled', dismiss: true });
     }
     this.modalDepth = 0;
+    turnIdleDiagnostic('activity.sweep.complete', {
+      activeCount: this.entries.size, modalDepth: this.modalDepth,
+    });
   }
 
   activeCount(): number { return this.entries.size; }

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -43,6 +43,7 @@ import {
 import { findGhost } from './ghostMatch';
 import { getSkinEngine } from './skinEngine';
 import { emitComposerReadyForTests } from './composerReadiness';
+import { nextComposerGeneration, turnIdleDiagnostic } from './turnIdleDiagnostics';
 
 /** Lightweight slash command shape — minimum the dropdown needs. */
 export interface SlashCommandLite {
@@ -155,6 +156,7 @@ function defaultFilter(
  * highlighted row, resolves with `/<row.name>` instead.
  */
 export default createPrompt<string, AidenPromptConfig>((config, done) => {
+  const generationRef = useRef(0);
   const theme = makeTheme<Theme>({}, config.theme);
   const [status, setStatus] = useState<'idle' | 'done'>('idle');
   const [value, setValue] = useState('');
@@ -165,17 +167,6 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
   // Snapshot of the typed value when the user starts navigating
   // history — restored when they reach the bottom of the stack.
   const historyDraftRef = useRef('');
-  // Tier-3.1c: paste-burst guard. When bracketed paste mode isn't
-  // honoured by the terminal (no CSI 200~/201~ wrap) the paste
-  // arrives as raw bytes; the first internal `\n` becomes an Enter
-  // event and submits before the user can review. We can't always
-  // suppress that at the stdin level, so as a defence-in-depth the
-  // prompt records the timestamp of the last NON-Enter keypress and
-  // refuses to submit on Enter that arrives within
-  // PASTE_BURST_GUARD_MS of it. Real user Enter comes after a
-  // pause, so this only blocks the rapid Enter-from-paste path.
-  const lastNonEnterKeyMsRef = useRef(0);
-
   const prefix = usePrefix({ status, theme });
   const dropdownLimit = config.dropdownLimit ?? DEFAULT_DROPDOWN_LIMIT;
   const filterFn = config.filter
@@ -207,33 +198,29 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
     setValue('');
     setGhost(null);
     setDropdownOpen(false);
+    generationRef.current = nextComposerGeneration();
+    const diagnosticReadline = rl as typeof rl & { isPaused?: () => boolean };
+    turnIdleDiagnostic('composer.ready', {
+      generation: generationRef.current,
+      readlineActive: true,
+      readlinePaused: typeof diagnosticReadline.isPaused === 'function'
+        ? diagnosticReadline.isPaused()
+        : undefined,
+    });
     emitComposerReadyForTests();
-    void rl;
   }, []);
 
   useKeypress((key, rl) => {
     if (status !== 'idle') return;
+    turnIdleDiagnostic('composer.key', {
+      generation: generationRef.current,
+      key: key.name ?? null,
+      sequenceLength: (key as typeof key & { sequence?: string }).sequence?.length ?? 0,
+      lineLength: rl.line.length,
+    });
 
     // ── Submit ──
     if (isEnterKey(key)) {
-      // Tier-3.1c: paste-burst guard. If a non-Enter keystroke fired
-      // within the last 50ms, this Enter is almost certainly an
-      // internal `\n` from an unbracketed paste, not a deliberate
-      // user submit. Suppress and let readline keep accumulating
-      // bytes — the user will press Enter again once the paste
-      // settles.
-      const PASTE_BURST_GUARD_MS = 50;
-      const sinceLastKey = Date.now() - lastNonEnterKeyMsRef.current;
-      if (lastNonEnterKeyMsRef.current > 0 && sinceLastKey < PASTE_BURST_GUARD_MS) {
-        // Reset so subsequent rapid Enters are also caught while
-        // the burst continues.
-        lastNonEnterKeyMsRef.current = Date.now();
-        // Resync value in case readline already cleared the line
-        // on this Enter (it does — we can't fully prevent that, but
-        // we keep the buffered fragments in `value` for context).
-        rederive(rl.line);
-        return;
-      }
       if (dropdownOpen) {
         const matches = filterFn(value);
         const picked = matches[selectedIdx];
@@ -337,17 +324,12 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
     if (isBackspaceKey(key)) {
       // rl.line already updated by the readline event before this
       // handler runs, so we just resync.
-      lastNonEnterKeyMsRef.current = Date.now();
       setHistoryIdx(null);
       rederive(rl.line);
       return;
     }
 
     // ── Default — sync from rl.line, recompute derived state ──
-    // Tier-3.1c: any non-Enter keystroke updates the burst-guard
-    // timestamp; the Enter handler reads it to decide whether the
-    // submit is a real user Enter or part of a paste burst.
-    lastNonEnterKeyMsRef.current = Date.now();
     setHistoryIdx(null);
     rederive(rl.line);
   });

--- a/cli/v4/aidenPrompt.ts
+++ b/cli/v4/aidenPrompt.ts
@@ -42,6 +42,7 @@ import {
 
 import { findGhost } from './ghostMatch';
 import { getSkinEngine } from './skinEngine';
+import { emitComposerReadyForTests } from './composerReadiness';
 
 /** Lightweight slash command shape — minimum the dropdown needs. */
 export interface SlashCommandLite {
@@ -206,6 +207,7 @@ export default createPrompt<string, AidenPromptConfig>((config, done) => {
     setValue('');
     setGhost(null);
     setDropdownOpen(false);
+    emitComposerReadyForTests();
     void rl;
   }, []);
 

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -315,6 +315,10 @@ export class CliCallbacks {
     this.toolTraceAfterHook = undefined;
   }
 
+  settleActivitiesBeforeOutput(): void {
+    this.activities.sweep();
+  }
+
   activeActivityCount(): number { return this.activities.activeCount(); }
   activityTimerCount(): number { return this.activities.timerCount(); }
   activityModalPauseDepth(): number { return this.activities.modalPauseDepth(); }

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -17,7 +17,8 @@
  * v4.1 alongside the multi-pane TUI.
  */
 
-import type { Display, ToolRowHandle } from './display';
+import type { Display } from './display';
+import { ActivityRegistry } from './activityRegistry';
 import { boxBottom, boxLine, boxTopTitled } from './box';
 import type {
   ApprovalRequest,
@@ -37,6 +38,7 @@ import type { BlockerKind, BlockerSurface } from '../../tools/v4/browser/browser
 // v4.8.0 Slice 5 — verbose-mode gate for internal-telemetry dim lines.
 import { isVerbose, glyphs } from './design/tokens';
 import type { ColorKind } from './skinEngine';
+import type { InputOwner, ModalStdin } from './inputAuthority';
 /* Phase 23.6 rollback — Ink controller bridge stashed to
  * docs/sprint/_internal/v4.1-ink-stash/.  Re-introduce when v4.1 picks
  * up the Ink rebuild. */
@@ -66,24 +68,24 @@ export interface PromptApi {
   select(opts: {
     message: string;
     choices: { name: string; value: string }[];
-  }): Promise<string>;
-  confirm(opts: { message: string; default?: boolean }): Promise<boolean>;
+  }, context?: { input?: ModalStdin }): Promise<string>;
+  confirm(opts: { message: string; default?: boolean }, context?: { input?: ModalStdin }): Promise<boolean>;
   /** v4.11 — free-text line input (for the clarify tool's open answers). */
-  input(opts: { message: string; default?: string }): Promise<string>;
+  input(opts: { message: string; default?: string }, context?: { input?: ModalStdin }): Promise<string>;
 }
 
 async function defaultPrompts(): Promise<PromptApi> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const inq = require('@inquirer/prompts');
   return {
-    async select(opts) {
-      return inq.select(opts);
+    async select(opts, context) {
+      return inq.select(opts, context);
     },
-    async confirm(opts) {
-      return inq.confirm(opts);
+    async confirm(opts, context) {
+      return inq.confirm(opts, context);
     },
-    async input(opts) {
-      return inq.input(opts);
+    async input(opts, context) {
+      return inq.input(opts, context);
     },
   };
 }
@@ -229,8 +231,7 @@ export class CliCallbacks {
   // sequential before/after pairs find each other. Cleared per-call.
   // `beforeFirstToolHook` lets chatSession stop the "thinking…" spinner
   // the moment the first row prints — registered fresh each turn.
-  private toolRows = new Map<string, ToolRowHandle>();
-  private toolStartTimes = new Map<string, number>();
+  private readonly activities: ActivityRegistry;
   private beforeFirstToolHook?: () => void;
   private firstToolFiredThisTurn = false;
 
@@ -269,6 +270,7 @@ export class CliCallbacks {
   // `setSkillTeacher(...)` because the teacher is built AFTER the
   // CliCallbacks instance during boot.
   private skillTeacher?: import('../../moat/skillTeacher').SkillTeacher;
+  private exclusiveInput?: <T>(owner: Exclude<InputOwner, 'during_turn'>, run: (stdin: ModalStdin) => Promise<T>) => Promise<T>;
 
   constructor(opts: CliCallbacksOptions) {
     this.display = opts.display;
@@ -278,6 +280,7 @@ export class CliCallbacks {
       ? Promise.resolve(opts.promptModule)
       : defaultPrompts();
     this.skillTeacher = opts.skillTeacher;
+    this.activities = new ActivityRegistry((name, args) => this.display.toolRow(name, args));
   }
 
   /**
@@ -291,6 +294,30 @@ export class CliCallbacks {
   setSkillTeacher(teacher: import('../../moat/skillTeacher').SkillTeacher): void {
     this.skillTeacher = teacher;
   }
+
+  setExclusiveInputRunner(
+    runner: <T>(owner: Exclude<InputOwner, 'during_turn'>, run: (stdin: ModalStdin) => Promise<T>) => Promise<T>,
+  ): void {
+    this.exclusiveInput = runner;
+  }
+
+  async withModalActivity<T>(run: () => Promise<T>): Promise<T> {
+    return this.activities.runModal(run);
+  }
+
+  completeActivityTurn(): void {
+    this.activities.sweep();
+    this.beforeFirstToolHook = undefined;
+    this.beforeToolHook = undefined;
+    this.afterEachToolHook = undefined;
+    this.phaseVerbHook = undefined;
+    this.toolTraceBeforeHook = undefined;
+    this.toolTraceAfterHook = undefined;
+  }
+
+  activeActivityCount(): number { return this.activities.activeCount(); }
+  activityTimerCount(): number { return this.activities.timerCount(); }
+  activityModalPauseDepth(): number { return this.activities.modalPauseDepth(); }
 
   /** Update verbose mode at runtime (wired to /verbose). */
   setVerboseMode(mode: VerboseMode): void {
@@ -386,6 +413,7 @@ export class CliCallbacks {
     result?: ToolCallResult,
   ): void => {
     if (phase === 'before') {
+      if (!this.activities.start(call.id, call.name, call.arguments)) return;
       if (!this.firstToolFiredThisTurn) {
         this.firstToolFiredThisTurn = true;
         try {
@@ -406,53 +434,9 @@ export class CliCallbacks {
       // suppressed from the visible trail) so the trace covers the
       // full agent loop, not just user-visible work.
       try { this.toolTraceBeforeHook?.(call.id, call.name); } catch { /* defensive */ }
-      const handle = this.display.toolRow(call.name, call.arguments);
-      this.toolRows.set(call.id, handle);
-      this.toolStartTimes.set(call.id, Date.now());
       return;
     }
-    // 'after'
-    const handle = this.toolRows.get(call.id);
-    const startedAt = this.toolStartTimes.get(call.id);
-    this.toolRows.delete(call.id);
-    this.toolStartTimes.delete(call.id);
-    if (!handle || startedAt === undefined) {
-      // Even if we lost the handle, the indicator may still need to
-      // be re-armed so the next gap shows activity. Tool-name-aware
-      // verb selection happens in the hook itself.
-      try { this.afterEachToolHook?.(call.name); } catch { /* defensive */ }
-      // v4.1.5+ Path A — loop-trace sink fires even when handle was
-      // lost (rare; happens if before/after pairing slipped) so the
-      // trace never under-counts tool calls.
-      try {
-        this.toolTraceAfterHook?.(call.id, call.name, call.arguments);
-      } catch { /* defensive */ }
-      return;
-    }
-    const ms = Date.now() - startedAt;
     const err = result?.error;
-    if (typeof err === 'string' && err.includes('URL provenance gate')) {
-      handle.blocked();
-      // v4.1.5+ Path A — blocked path still needs the trace sink so
-      // the URL-provenance failure mode shows up in loop diagnostics.
-      try {
-        this.toolTraceAfterHook?.(call.id, call.name, call.arguments);
-      } catch { /* defensive */ }
-      return;
-    }
-    // v4.3 Phase 3 — render a structured "agent needs human help"
-    // card when the browser observer detected a manual blocker
-    // (CAPTCHA / login / 2FA / verification / consent). Renders for
-    // ALL trail-row outcomes below — the blocker is independent of
-    // the tool's own success/fail signal. Inline placement gives
-    // the user immediate awareness; the model's next reply will
-    // explain in prose. Defensive: missing fields silently skip.
-    try { this.renderBlockerCardIfPresent(result); } catch { /* defensive */ }
-    // v4.1.4 reply-quality polish — Part 1.6. Helper used by ALL
-    // outcome branches below so the activity indicator gets re-armed
-    // for the gap that follows this tool (next tool, or final reply).
-    // Tool-name-aware verb selection happens in the hook (chatSession
-    // wires it through `verbForActivity`).
     const fireAfter = (): void => {
       try { this.afterEachToolHook?.(call.name); } catch { /* defensive */ }
       // v4.1.5+ Path A — also fire the loop-trace `after` sink so the
@@ -464,33 +448,36 @@ export class CliCallbacks {
       } catch { /* defensive */ }
     };
 
+    let settled: boolean;
     if (typeof err === 'string' && err.includes('URL provenance gate')) {
-      handle.blocked();
-      fireAfter();
-      return;
+      settled = this.activities.settle(call.id, { state: 'blocked' });
+    } else if (err) {
+      settled = this.activities.settle(call.id, { state: 'failed' });
+    } else if (result?.degraded) {
+      settled = this.activities.settle(call.id, {
+        state: 'degraded',
+        reason: result.degradedReason,
+      });
+    } else {
+      const payload = result?.result;
+      const status = payload && typeof payload === 'object'
+        ? (payload as { status?: unknown }).status
+        : undefined;
+      const dismiss = call.name === 'clarify' || call.name === 'plan_approval';
+      settled = status === 'cancelled'
+        ? this.activities.settle(call.id, { state: 'cancelled', dismiss })
+        : this.activities.settle(call.id, { state: 'completed', dismiss });
     }
+
+    // Duplicate and stale terminal callbacks cannot repaint or re-arm rows.
+    if (!settled) return;
+
+    try { this.renderBlockerCardIfPresent(result); } catch { /* defensive */ }
     if (err) {
-      handle.fail(ms);
-      // v4.1.3-essentials: when the tool's failure payload includes a
-      // structured capability card (auth missing, platform unsupported),
-      // render the card immediately after the fail row. The card sits
-      // on its own multi-line block — the fail row is still useful as
-      // the action timeline anchor; the card adds the state assessment
-      // the user actually needs. No card → plain failure surface.
       if (result?.capabilityCard) {
         this.display.capabilityCard(result.capabilityCard);
       }
-      fireAfter();
-      return;
     }
-    // v4.1.3-repl-polish: degraded outcome — tool completed but with a
-    // partial / best-effort result. Show in trail yellow instead of silent.
-    if (result?.degraded) {
-      handle.degraded(ms, result.degradedReason);
-      fireAfter();
-      return;
-    }
-    handle.ok(ms);
     fireAfter();
   };
 
@@ -522,6 +509,12 @@ export class CliCallbacks {
 
   /** ApprovalEngine.callbacks.promptUser */
   promptApproval = async (req: ApprovalRequest): Promise<ApprovalDecision> => {
+    return this.withModalActivity(() => this.exclusiveInput
+      ? this.exclusiveInput('approval', (stdin) => this.promptApprovalCore(req, stdin))
+      : this.promptApprovalCore(req));
+  };
+
+  private promptApprovalCore = async (req: ApprovalRequest, stdin?: ModalStdin): Promise<ApprovalDecision> => {
     // Phase 22 Task 5B: yellow-bordered rounded box for emphasis.
     // Yellow distinguishes the awaiting-attention state from the
     // brand-orange (informational) frames used by setup-complete and
@@ -538,7 +531,7 @@ export class CliCallbacks {
       choice = await prompts.select({
         message: 'Decision',
         choices: decisionChoicesFor(req),
-      });
+      }, stdin ? { input: stdin } : undefined);
     } catch {
       // The prompt was interrupted (Ctrl+C / the turn ended) before the user
       // answered. Fail closed — the tool does NOT run — but report it as an
@@ -557,6 +550,22 @@ export class CliCallbacks {
    * a menu plus an "Other" escape to free text.
    */
   promptClarify = async (question: string, options?: string[]): Promise<string | null> => {
+    p2aDiag('clarify.callback.start', { question, hasOptions: !!options?.length });
+    const answer = await this.withModalActivity(() => this.exclusiveInput
+      ? this.exclusiveInput('clarify', (stdin) => this.promptClarifyCore(question, options, stdin))
+      : this.promptClarifyCore(question, options));
+    p2aDiag('clarify.callback.resolve', {
+      answer, activeActivities: this.activities.activeCount(),
+      modalDepth: this.activities.modalPauseDepth(),
+    });
+    return answer;
+  };
+
+  private promptClarifyCore = async (
+    question: string,
+    options?: string[],
+    stdin?: ModalStdin,
+  ): Promise<string | null> => {
     const prompts = await this.promptsPromise;
     const OTHER = '__clarify_other__';
     try {
@@ -565,12 +574,13 @@ export class CliCallbacks {
           .slice(0, 4)
           .map((o) => ({ name: o, value: o }));
         choices.push({ name: 'Other (type a custom answer)…', value: OTHER });
-        const picked = await prompts.select({ message: question, choices });
+        const context = stdin ? { input: stdin } : undefined;
+        const picked = await prompts.select({ message: question, choices }, context);
         if (picked !== OTHER) return picked;
-        const typed = await prompts.input({ message: 'Your answer' });
+        const typed = await prompts.input({ message: 'Your answer' }, context);
         return typed.trim().length > 0 ? typed : null;
       }
-      const typed = await prompts.input({ message: question });
+      const typed = await prompts.input({ message: question }, stdin ? { input: stdin } : undefined);
       return typed.trim().length > 0 ? typed : null;
     } catch {
       // Ctrl+C / cancel — mirror approval's fail path. Return null so the
@@ -606,6 +616,12 @@ Reply with ONE word: safe, caution, or dangerous.`;
 
   /** SkillTeacher.callbacks.promptUser */
   promptSkillProposal = async (proposal: SkillProposal): Promise<boolean> => {
+    return this.exclusiveInput
+      ? this.exclusiveInput('skill_prompt', (stdin) => this.promptSkillProposalCore(proposal, stdin))
+      : this.promptSkillProposalCore(proposal);
+  };
+
+  private promptSkillProposalCore = async (proposal: SkillProposal, stdin?: ModalStdin): Promise<boolean> => {
     // Phase 23.5: dividers removed — blank lines carry the boundary.
     this.display.write('\n');
     this.display.info(`Skill suggestion: ${proposal.proposedName}`);
@@ -621,7 +637,7 @@ Reply with ONE word: safe, caution, or dangerous.`;
       return await prompts.confirm({
         message: 'Save this as a reusable skill?',
         default: false,
-      });
+      }, stdin ? { input: stdin } : undefined);
     } catch {
       return false;
     }
@@ -806,6 +822,14 @@ Reply with ONE word: safe, caution, or dangerous.`;
       };
     }
   };
+}
+
+function p2aDiag(event: string, data: Record<string, unknown>): void {
+  if (process.env.AIDEN_P2A_DIAG !== '1') return;
+  try {
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
+  } catch { /* diagnostics must never affect callbacks */ }
 }
 
 // Tier-3.1 (v4.1-tier3.1): replaced 🟢/🟡/🔴 emoji badges with

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -119,6 +119,7 @@ import { captureArtifactFromTrace } from '../../core/v4/daemon/artifactStore';
 import { DuringTurnInput, resolveConfiguredBusyMode, type BusyEnterMode } from './duringTurnInput';
 import { modeStatusLine } from './commands/mode';
 import { attachTurnInputListener } from './turnInputListener';
+import { InputAuthority } from './inputAuthority';
 import { requestTurnCancel } from './frame/interruptControls';
 
 /**
@@ -636,6 +637,8 @@ export class ChatSession implements ChatSessionLike {
    * listener attached for the duration of each turn.
    */
   private readonly duringTurnInput = new DuringTurnInput();
+  /** P2A transitional lease for prompts that overlap during-turn input. */
+  private readonly inputAuthority = new InputAuthority();
 
   // ── Slice 2a public surface for /busy + /queue commands ──────────────────
   setBusyMode(mode: BusyEnterMode): void { this.duringTurnInput.setMode(mode); }
@@ -654,6 +657,7 @@ export class ChatSession implements ChatSessionLike {
   private static readonly FORCE_EXIT_WINDOW_MS = 2000;
 
   constructor(private opts: ChatSessionOptions) {
+    this.opts.callbacks.setExclusiveInputRunner?.((owner, run) => this.inputAuthority.runExclusive(owner, run));
     this.currentProviderId = opts.initialProviderId;
     this.currentModelId = opts.initialModelId;
     this.modelMetadata = opts.modelMetadata ?? new ModelMetadata();
@@ -1655,6 +1659,9 @@ export class ChatSession implements ChatSessionLike {
     // a non-TTY. Detached in the finally below (all paths) so raw mode is
     // always restored.
     const detachTurnInput = attachTurnInputListener({
+      // P2A — mount as the `during_turn` raw owner so an exclusive prompt can suspend this source
+      // for its duration. No-op path unchanged on non-TTY.
+      authority: this.inputAuthority,
       cb: {
         onLine: (text) => {
           // v4.14 — during-turn control words act IMMEDIATELY (never queued).
@@ -2068,7 +2075,40 @@ export class ChatSession implements ChatSessionLike {
       this.opts.display.streamPartial(batch);
     };
 
+    const p2aDiagEnabled = process.env.AIDEN_P2A_DIAG === '1';
+    const emitP2aDiag = (event: string, data: Record<string, unknown>): void => {
+      if (!p2aDiagEnabled) return;
+      try {
+        const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+        process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, turnId, ...data })}\n`);
+      } catch { /* diagnostics must never affect the turn */ }
+    };
+    let lastHeartbeatAt = Number(process.hrtime.bigint() / 1_000_000n);
+    const p2aHeartbeat = p2aDiagEnabled
+      ? setInterval(() => {
+          const now = Number(process.hrtime.bigint() / 1_000_000n);
+          emitP2aDiag('turn.heartbeat', {
+            eventLoopDelayMs: Math.max(0, now - lastHeartbeatAt - 1_000),
+            pendingPromises: ['agent.runConversation'],
+            aborted: turnAbort.signal.aborted,
+            duringTurnPaused: this.duringTurnInput.isPaused(),
+            activityCount: this.opts.callbacks.activeActivityCount?.() ?? 0,
+            activityTimers: this.opts.callbacks.activityTimerCount?.() ?? 0,
+            activityModalDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
+            inputOwner: this.inputAuthority.currentOwner(),
+            inputLeaseId: this.inputAuthority.currentLeaseId(),
+            inputEpoch: this.inputAuthority.currentEpoch(),
+          });
+          lastHeartbeatAt = now;
+        }, 1_000)
+      : null;
+    p2aHeartbeat?.unref?.();
+
     try {
+      emitP2aDiag('turn.agent_run.start', {
+        aborted: turnAbort.signal.aborted,
+        pendingPromises: ['agent.runConversation'],
+      });
       const result = await this.opts.agent.runConversation(baseHistory, {
         stream: streamingEnabled,
         // v4.12 BE.1 — seed the per-session token cap with tokens already spent
@@ -2211,6 +2251,12 @@ export class ChatSession implements ChatSessionLike {
               progressBar.update(outputTokens, maxTokens);
             })
           : undefined,
+      });
+      emitP2aDiag('turn.agent_run.complete', {
+        aborted: turnAbort.signal.aborted,
+        finishReason: result.finishReason,
+        turnCount: result.turnCount,
+        toolCallCount: result.toolCallCount,
       });
       stopIndicatorOnce();
       // Hide the progress bar before any post-stream content
@@ -2490,9 +2536,12 @@ export class ChatSession implements ChatSessionLike {
       // memory-confirmation chrome.
       if (result.skillProposal && this.opts.callbacks?.handleSkillProposal) {
         try {
-          const saveResult = await this.opts.callbacks.handleSkillProposal(
-            result.skillProposal,
-          );
+          const handle = this.opts.callbacks.handleSkillProposal;
+          const proposal = result.skillProposal;
+          const runPrompt = () => handle(proposal);
+          const saveResult = typeof this.opts.callbacks.withModalActivity === 'function'
+            ? await this.opts.callbacks.withModalActivity(runPrompt)
+            : await runPrompt();
           if (saveResult?.created && saveResult.skillName) {
             this.opts.display.dim(
               `  ✓ Saved as skill: ${saveResult.skillName}`,
@@ -2694,6 +2743,15 @@ export class ChatSession implements ChatSessionLike {
         }
       } catch { /* defensive */ }
     } finally {
+      if (p2aHeartbeat) clearInterval(p2aHeartbeat);
+      emitP2aDiag('turn.finally.start', {
+        aborted: turnAbort.signal.aborted,
+        activityCount: this.opts.callbacks.activeActivityCount?.() ?? 0,
+        activityModalDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
+      });
+      // Tool/activity rows are turn-scoped. Terminal callbacks normally settle
+      // them earlier; this sweep catches cancellation and missing callbacks.
+      try { this.opts.callbacks.completeActivityTurn(); } catch { /* defensive */ }
       // v4.11 Slice 3 — release the per-turn cancel handles. ORDER
       // MATTERS:
       //   1. Drop activeTurnId FIRST so any late callbacks already

--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -120,6 +120,7 @@ import { DuringTurnInput, resolveConfiguredBusyMode, type BusyEnterMode } from '
 import { modeStatusLine } from './commands/mode';
 import { attachTurnInputListener } from './turnInputListener';
 import { InputAuthority } from './inputAuthority';
+import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 import { requestTurnCancel } from './frame/interruptControls';
 
 /**
@@ -2168,6 +2169,7 @@ export class ChatSession implements ChatSessionLike {
               // No-op when no tool fired (turnHadTools=false).
               if (!firstStreamByteSeen) {
                 firstStreamByteSeen = true;
+                this.opts.callbacks.settleActivitiesBeforeOutput?.();
                 emitToolReplySeparator();
               }
               // v4.11 Slice 1 — first delta of the segment paints
@@ -2259,6 +2261,7 @@ export class ChatSession implements ChatSessionLike {
         toolCallCount: result.toolCallCount,
       });
       stopIndicatorOnce();
+      if (!streamingActive) this.opts.callbacks.settleActivitiesBeforeOutput?.();
       // Hide the progress bar before any post-stream content
       // (statusFooter, the next prompt) lands on its line.
       progressBar?.hide();
@@ -2752,6 +2755,12 @@ export class ChatSession implements ChatSessionLike {
       // Tool/activity rows are turn-scoped. Terminal callbacks normally settle
       // them earlier; this sweep catches cancellation and missing callbacks.
       try { this.opts.callbacks.completeActivityTurn(); } catch { /* defensive */ }
+      turnIdleDiagnostic('turn.activities.finalized', {
+        turnId,
+        activityCount: this.opts.callbacks.activeActivityCount?.() ?? 0,
+        activityTimers: this.opts.callbacks.activityTimerCount?.() ?? 0,
+        modalPauseDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
+      });
       // v4.11 Slice 3 — release the per-turn cancel handles. ORDER
       // MATTERS:
       //   1. Drop activeTurnId FIRST so any late callbacks already
@@ -2776,7 +2785,19 @@ export class ChatSession implements ChatSessionLike {
       this.lastInterruptAt = 0;
       // v4.12.1 Slice 2a — detach the during-turn listener + restore raw mode
       // on EVERY exit path (success / error / abort / throw).
-      try { detachTurnInput(); } catch { /* defensive — never break turn teardown */ }
+      turnIdleDiagnostic('turn.input.detach.start', {
+        turnId,
+        owner: this.inputAuthority.currentOwner(),
+        leaseId: this.inputAuthority.currentLeaseId(),
+        epoch: this.inputAuthority.currentEpoch(),
+      });
+      try { detachTurnInput({ nextOwner: 'composer' }); } catch { /* defensive — never break turn teardown */ }
+      turnIdleDiagnostic('turn.input.detach.complete', {
+        turnId,
+        owner: this.inputAuthority.currentOwner(),
+        leaseId: this.inputAuthority.currentLeaseId(),
+        epoch: this.inputAuthority.currentEpoch(),
+      });
       // Slice 2c — clear the live composer so the row hands cleanly back to the
       // normal prompt (no stale typed text lingering on the owned row).
       try { this.opts.display.clearComposer(); } catch { /* defensive */ }
@@ -2790,6 +2811,11 @@ export class ChatSession implements ChatSessionLike {
         const { isFrameModeRequested, resumeFrame } = require('./frame') as typeof import('./frame');
         if (isFrameModeRequested()) await resumeFrame();
       } catch { /* never break a turn on frame cleanup */ }
+      turnIdleDiagnostic('turn.finally.complete', {
+        turnId,
+        activityCount: this.opts.callbacks.activeActivityCount?.() ?? 0,
+        activityTimers: this.opts.callbacks.activityTimerCount?.() ?? 0,
+      });
     }
   }
 
@@ -3193,7 +3219,16 @@ export class ChatSession implements ChatSessionLike {
     // our own bare prefix so the result reads `▲ <user input>`.
     const promptText = this.opts.display.promptPrefix();
 
+    turnIdleDiagnostic('composer.read.start', {
+      activityCount: this.opts.callbacks.activeActivityCount?.() ?? 0,
+      activityTimers: this.opts.callbacks.activityTimerCount?.() ?? 0,
+      modalPauseDepth: this.opts.callbacks.activityModalPauseDepth?.() ?? 0,
+      inputOwner: this.inputAuthority.currentOwner(),
+      inputLeaseId: this.inputAuthority.currentLeaseId(),
+      inputEpoch: this.inputAuthority.currentEpoch(),
+    });
     let raw = await api.readLine(promptText);
+    turnIdleDiagnostic('composer.read.settle', { valueLength: raw?.length ?? 0 });
     if (raw == null) return '';
 
     // Tier-3.1a: stdin pre-tap (pasteIntercept) already converted any

--- a/cli/v4/composerReadiness.ts
+++ b/cli/v4/composerReadiness.ts
@@ -1,0 +1,11 @@
+/** Test-only semantic marker emitted after an interactive composer mounts. */
+export const COMPOSER_READY_TOKEN = '__COMPOSER_READY__';
+
+/**
+ * Emit a non-printing terminal marker only for PTY tests. OSC framing keeps
+ * cursor position and normal production output unchanged.
+ */
+export function emitComposerReadyForTests(): void {
+  if (process.env.AIDEN_TEST_COMPOSER_READY !== '1') return;
+  try { process.stderr.write(`\x1b]9;${COMPOSER_READY_TOKEN}\x07`); } catch { /* test seam only */ }
+}

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -1518,6 +1518,9 @@ export class Display {
     const out = this.out;
     const isTty = !!out.isTTY;
     let printed = false;
+    let pausedRow = false;
+    let settled = false;
+    let repaintRunning: (() => void) | null = null;
 
     // v4.1.3-essentials: tick handle for the live-elapsed update. Set
     // when we start the interval; cleared by every terminal method
@@ -1543,7 +1546,10 @@ export class Display {
 
     // Erase the last printed line (TTY only).
     const eraseLast = (): void => {
-      if (isTty && printed) out.write('\x1b[1A\x1b[2K\r');
+      if (isTty && printed) {
+        out.write('\x1b[1A\x1b[2K\r');
+        printed = false;
+      }
     };
 
     const writeFinal = (suffix: string, kind: ColorKindForBracket): void => {
@@ -1551,6 +1557,19 @@ export class Display {
       eraseLast();
       out.write(outcomeRow(suffix, kind));
       printed = true;
+    };
+
+    const startRunningTick = (): void => {
+      if (!isTty || settled || pausedRow || repaintRunning === null || tickTimer !== null) return;
+      tickTimer = setInterval(repaintRunning, 1000);
+      restoreComposerRepaint = this.setComposerRepaint(repaintRunning);
+    };
+
+    const beginSettle = (): boolean => {
+      if (settled) return false;
+      settled = true;
+      pausedRow = false;
+      return true;
     };
 
     if (isTty) {
@@ -1576,15 +1595,18 @@ export class Display {
       // the WRONG line and repaint its runningRow() — hint suffix included —
       // into another tool's activity region. Gating on ownership keeps the
       // busy hint in its lane: composer content never bleeds into tool rows.
-      const repaintRunning = (): void => {
-        if (printed && this.composerRepaintIs(repaintRunning)) { eraseLast(); out.write(runningRow()); }
+      repaintRunning = (): void => {
+        if (printed && !pausedRow && this.composerRepaintIs(repaintRunning!)) {
+          eraseLast();
+          out.write(runningRow());
+          printed = true;
+        }
       };
-      tickTimer = setInterval(repaintRunning, 1000);
       // v4.12.1 Slice 2c — while the tool row owns the bottom, a keystroke
       // repaints IT (so the composer stays live during a long tool call, when
       // the activity indicator is paused). `stopTick` restores the prior
       // repaint (the indicator's) when the tool settles.
-      restoreComposerRepaint = this.setComposerRepaint(repaintRunning);
+      startRunningTick();
     }
     // Non-TTY: hold off until completion (log lines carry final state).
     // No tick — non-TTY sinks (pipes, CI logs) get one line per call
@@ -1592,6 +1614,7 @@ export class Display {
 
     return {
       ok(durationMs: number, retries = 0) {
+        if (!beginSettle()) return;
         stopTick();
         if (retries > 0) {
           // Showed retries — surface the eventual success in warn so the
@@ -1629,6 +1652,7 @@ export class Display {
         }
       },
       fail(durationMs: number, retries = 0) {
+        if (!beginSettle()) return;
         const suffix =
           retries > 0
             ? `fail ${formatToolDuration(durationMs)} after ${retries} ${retries === 1 ? 'retry' : 'retries'}`
@@ -1636,12 +1660,14 @@ export class Display {
         writeFinal(suffix, 'error');
       },
       degraded(durationMs: number, reason?: string) {
+        if (!beginSettle()) return;
         const suffix = reason
           ? `partial ${formatToolDuration(durationMs)} — ${reason}`
           : `partial ${formatToolDuration(durationMs)}`;
         writeFinal(suffix, 'degraded');
       },
       retry(n: number, m: number) {
+        if (settled) return;
         // v4.1.3-essentials: retry is a state-change announcement —
         // freeze the row at the retry counter until next state change.
         // Stopping the ticker prevents the next 1s tick from racing
@@ -1657,14 +1683,41 @@ export class Display {
         printed = true;
       },
       blocked() {
+        if (!beginSettle()) return;
         writeFinal('blocked', 'warn');
       },
       emptyRetry() {
+        if (!beginSettle()) return;
         writeFinal('empty retry', 'warn');
       },
       emptyFail() {
+        if (!beginSettle()) return;
         writeFinal('empty fail', 'error');
       },
+      cancel(durationMs: number) {
+        if (!beginSettle()) return;
+        writeFinal(`cancelled ${formatToolDuration(durationMs)}`, 'muted');
+      },
+      dismiss() {
+        if (!beginSettle()) return;
+        stopTick();
+        eraseLast();
+      },
+      pause() {
+        if (settled || pausedRow) return;
+        pausedRow = true;
+        stopTick();
+        eraseLast();
+      },
+      resume() {
+        if (settled || !pausedRow) return;
+        pausedRow = false;
+        if (!isTty) return;
+        out.write(runningRow());
+        printed = true;
+        startRunningTick();
+      },
+      isActive() { return !settled; },
     };
   }
 
@@ -2763,6 +2816,11 @@ export function makeNoOpToolRowHandle(): ToolRowHandle {
     blocked:    () => { /* no-op: hidden from trail */ },
     emptyRetry: () => { /* no-op: hidden from trail */ },
     emptyFail:  () => { /* no-op: hidden from trail */ },
+    cancel:     () => { /* no-op: hidden from trail */ },
+    dismiss:    () => { /* no-op: hidden from trail */ },
+    pause:      () => { /* no-op: hidden from trail */ },
+    resume:     () => { /* no-op: hidden from trail */ },
+    isActive:   () => false,
   };
 }
 
@@ -2791,6 +2849,11 @@ export interface ToolRowHandle {
   blocked(): void;
   emptyRetry(): void;
   emptyFail(): void;
+  cancel(durationMs: number): void;
+  dismiss(): void;
+  pause(): void;
+  resume(): void;
+  isActive(): boolean;
 }
 
 /**

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -48,6 +48,7 @@ import { renderCitationFooter } from './citationFooter';
 import { buildToolPreview } from './toolPreview';
 import { renderComposerBuffer } from './composerRow';
 import { ComposerLane, composerLaneEnabled, type LaneSink } from './composerLane';
+import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 // v4.1.4 reply-quality polish: shared frame math for width + indent.
 // `cols()`, `rule()`, `agentTurn`, and `tryRerenderInPlace` all route
 // through frame helpers so the visible left edge / right margin / wrap
@@ -1501,9 +1502,16 @@ export class Display {
       const liveSuffix = elapsed >= 1000
         ? `  ${sk.applyColors(`running ${formatToolDuration(elapsed)}…`, 'muted')}`
         : '';
-      return `${sk.applyColors(TRAIL_PIPE, 'muted')} ${glyph}  ` +
-             `${sk.applyColors(padVerb(verb), 'tool')} ` +
-             `${sk.applyColors(detail, 'muted')}${liveSuffix}${this.composerSuffix()}\n`;
+      const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${glyph}  ` +
+        `${sk.applyColors(padVerb(verb), 'tool')} `;
+      const suffix = `${liveSuffix}${this.composerSuffix()}`;
+      const detailText = sk.applyColors(detail, 'muted');
+      if (terminalRowWidth === null) return `${prefix}${detailText}${suffix}\n`;
+      const availableDetail = Math.max(
+        0,
+        terminalRowWidth - visibleLength(prefix) - visibleLength(suffix),
+      );
+      return `${prefix}${truncateVisible(detailText, availableDetail)}${suffix}\n`;
     };
 
     // Outcome row — entire line colored by outcome kind.
@@ -1517,6 +1525,13 @@ export class Display {
     // Capture stream reference so closures don't need `this`.
     const out = this.out;
     const isTty = !!out.isTTY;
+    // Keep a two-cell safety margin. Windows ConPTY can report the cursor
+    // width one cell beyond the last safe printable column; filling that cell
+    // sets the terminal's pending-wrap flag and makes the next repaint walk
+    // down the screen instead of replacing the existing activity row.
+    const terminalRowWidth = isTty && typeof out.columns === 'number'
+      ? Math.max(1, out.columns - 2)
+      : null;
     let printed = false;
     let pausedRow = false;
     let settled = false;
@@ -1544,6 +1559,19 @@ export class Display {
       }
     };
 
+    const fitTerminalRow = (row: string): string => {
+      if (terminalRowWidth === null) return row;
+      const body = row.endsWith('\n') ? row.slice(0, -1) : row;
+      return `${truncateVisible(body, terminalRowWidth)}\n`;
+    };
+
+    const replaceLast = (row: string): void => {
+      const fitted = fitTerminalRow(row);
+      if (isTty && printed) out.write(`\x1b[1A\x1b[2K\r${fitted}`);
+      else out.write(fitted);
+      printed = true;
+    };
+
     // Erase the last printed line (TTY only).
     const eraseLast = (): void => {
       if (isTty && printed) {
@@ -1554,9 +1582,8 @@ export class Display {
 
     const writeFinal = (suffix: string, kind: ColorKindForBracket): void => {
       stopTick();
-      eraseLast();
-      out.write(outcomeRow(suffix, kind));
-      printed = true;
+      turnIdleDiagnostic('activity.row.final', { name });
+      replaceLast(outcomeRow(suffix, kind));
     };
 
     const startRunningTick = (): void => {
@@ -1579,7 +1606,7 @@ export class Display {
       // its own newline-fencing + in-place rerender of the just-streamed
       // chunk so this row lands cleanly on its own line below.
       this.commitStreamChunk();
-      out.write(runningRow());
+      out.write(fitTerminalRow(runningRow()));
       printed = true;
       // v4.1.3-essentials: start the live-elapsed ticker. Fires every
       // 1s; first tick at +1s, when `runningRow()` starts emitting the
@@ -1597,9 +1624,8 @@ export class Display {
       // busy hint in its lane: composer content never bleeds into tool rows.
       repaintRunning = (): void => {
         if (printed && !pausedRow && this.composerRepaintIs(repaintRunning!)) {
-          eraseLast();
-          out.write(runningRow());
-          printed = true;
+          turnIdleDiagnostic('activity.row.timer', { name });
+          replaceLast(runningRow());
         }
       };
       // v4.12.1 Slice 2c — while the tool row owns the bottom, a keystroke
@@ -1676,11 +1702,9 @@ export class Display {
         // Update the running row with retry count.
         // v4.8.0 Slice 11c — double-space between glyph and verb (see
         // runningRow comment above for the emoji-width rationale).
-        eraseLast();
         const content =
           `${TRAIL_PIPE} ${glyph}  ${padVerb(verb)} ${detail}  retry ${n}/${m} …`;
-        out.write(sk.applyColors(content, 'warn') + '\n');
-        printed = true;
+        replaceLast(sk.applyColors(content, 'warn') + '\n');
       },
       blocked() {
         if (!beginSettle()) return;
@@ -1713,7 +1737,7 @@ export class Display {
         if (settled || !pausedRow) return;
         pausedRow = false;
         if (!isTty) return;
-        out.write(runningRow());
+        out.write(fitTerminalRow(runningRow()));
         printed = true;
         startRunningTick();
       },

--- a/cli/v4/frame/runtime.ts
+++ b/cli/v4/frame/runtime.ts
@@ -34,6 +34,7 @@ import {
 } from './terminalDriver';
 import { makeInitialState, reducer, type FrameState, type FrameAction } from './state';
 import { makeComposer, type InkComponents } from './composer';
+import { emitComposerReadyForTests } from '../composerReadiness';
 
 // Lazily imported Ink module (ESM). Captured once per process so the
 // dynamic import cost is paid only on first frame mount.
@@ -240,6 +241,7 @@ export async function createFrameRuntime(): Promise<FrameRuntime> {
     // (which routes through unsafeWrite — already token-bypassed —
     // but arming first is still cleaner).
     arm();
+    emitComposerReadyForTests();
 
     try {
       return await finished;

--- a/cli/v4/inputAuthority.ts
+++ b/cli/v4/inputAuthority.ts
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) 2026 Shiva Deore (Taracod).
+ * Licensed under AGPL-3.0. See LICENSE for details.
+ */
+/** Render-free exclusive-input lease for prompts that run during a turn. */
+import type { TurnKey } from './turnInputListener';
+
+export type RawKeyHandler = (str: string | undefined, key: TurnKey) => void;
+export type InputOwner = 'during_turn' | 'approval' | 'skill_prompt' | 'clarify';
+export type ModalStdin = NodeJS.ReadStream;
+
+export interface RawStdinLike {
+  isTTY?: boolean;
+  isRaw?: boolean;
+  setRawMode?(mode: boolean): unknown;
+  readableFlowing?: boolean | null;
+  isPaused?(): boolean;
+  resume?(): unknown;
+  pause?(): unknown;
+  on(event: 'keypress', handler: RawKeyHandler): unknown;
+  removeListener(event: 'keypress', handler: RawKeyHandler): unknown;
+}
+
+export interface InputAuthorityOptions {
+  stdin?: RawStdinLike;
+  emitKeypressEvents?: (stdin: RawStdinLike) => void;
+  onProcessExit?: (fn: () => void) => void;
+  offProcessExit?: (fn: () => void) => void;
+}
+
+interface RawRegistration {
+  kind: 'raw';
+  owner: 'during_turn';
+  leaseId: number;
+  epoch: number;
+  handler: RawKeyHandler;
+  dispatch: RawKeyHandler;
+  subscribed: boolean;
+  rawBefore: boolean;
+  rawChanged: boolean;
+  initialPaused: boolean;
+  activationPausedBefore: boolean;
+  flowChanged: boolean;
+  exitFn: (() => void) | null;
+}
+
+interface ModalLease {
+  kind: 'modal';
+  owner: Exclude<InputOwner, 'during_turn'>;
+  leaseId: number;
+  epoch: number;
+  previous: RawRegistration | null;
+  rawBefore: boolean;
+  pausedBefore: boolean;
+  flowingBefore: boolean | null | undefined;
+  rawChanged: boolean;
+  flowChanged: boolean;
+  logicalPauseRequested: boolean;
+  logicalResumeRequested: boolean;
+  logicalRawModeRequested: boolean | null;
+  facade: ModalStdin;
+}
+
+type ActiveLease = RawRegistration | ModalLease;
+
+export class InputAuthority {
+  private readonly stdin: RawStdinLike;
+  private readonly emitKeypress: (stdin: RawStdinLike) => void;
+  private readonly onExit: (fn: () => void) => void;
+  private readonly offExit: (fn: () => void) => void;
+  private nextLeaseId = 0;
+  private epoch = 0;
+  private active: ActiveLease | null = null;
+
+  constructor(opts: InputAuthorityOptions = {}) {
+    this.stdin = opts.stdin ?? (process.stdin as unknown as RawStdinLike);
+    this.emitKeypress = opts.emitKeypressEvents ?? defaultEmitKeypress;
+    this.onExit = opts.onProcessExit ?? ((fn) => process.once('exit', fn));
+    this.offExit = opts.offProcessExit ?? ((fn) => process.removeListener('exit', fn));
+  }
+
+  currentEpoch(): number { return this.epoch; }
+  currentLeaseId(): number | null { return this.active?.leaseId ?? null; }
+  currentOwner(): InputOwner | null { return this.active?.owner ?? null; }
+  previousOwner(): InputOwner | null {
+    return this.active?.kind === 'modal' ? this.active.previous?.owner ?? null : null;
+  }
+  mountedCount(): number { return this.active ? 1 : 0; }
+  isRawSubscribed(): boolean { return this.active?.kind === 'raw' && this.active.subscribed; }
+
+  mountRawOwner(owner: 'during_turn', handler: RawKeyHandler): () => void {
+    if (this.active?.kind === 'modal') throw new Error('Cannot mount raw input during an exclusive input lease');
+    if (this.active?.kind === 'raw') this.deactivateRaw(this.active, true);
+    const registration = {} as RawRegistration;
+    Object.assign(registration, {
+      kind: 'raw' as const,
+      owner,
+      leaseId: ++this.nextLeaseId,
+      epoch: ++this.epoch,
+      handler,
+      subscribed: false,
+      rawBefore: this.stdin.isRaw === true,
+      rawChanged: false,
+      initialPaused: this.stdin.isPaused?.() === true,
+      activationPausedBefore: false,
+      flowChanged: false,
+      exitFn: null,
+      dispatch: (str: string | undefined, key: TurnKey) => {
+        if (this.active !== registration || registration.epoch !== this.epoch) return;
+        registration.handler(str, key);
+      },
+    });
+    this.active = registration;
+    this.activateRaw(registration);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      if (this.active !== registration || registration.epoch !== this.epoch) return;
+      ++this.epoch;
+      this.deactivateRaw(registration, true);
+      if (this.active === registration) this.active = null;
+    };
+  }
+
+  async runExclusive<T>(
+    owner: Exclude<InputOwner, 'during_turn'>,
+    run: (stdin: ModalStdin) => Promise<T>,
+  ): Promise<T> {
+    if (this.active?.kind === 'modal') throw new Error('An exclusive input lease is already active');
+    const previous = this.active?.kind === 'raw' ? this.active : null;
+    if (previous) this.suspendRaw(previous);
+    const lease = {} as ModalLease;
+    Object.assign(lease, {
+      kind: 'modal' as const,
+      owner,
+      leaseId: ++this.nextLeaseId,
+      epoch: ++this.epoch,
+      previous,
+      rawBefore: this.stdin.isRaw === true,
+      pausedBefore: this.stdin.isPaused?.() === true,
+      flowingBefore: this.stdin.readableFlowing,
+      rawChanged: false,
+      flowChanged: false,
+      logicalPauseRequested: false,
+      logicalResumeRequested: false,
+      logicalRawModeRequested: null,
+      facade: undefined,
+    });
+    this.active = lease;
+    lease.facade = this.createModalFacade(lease);
+    this.establishModalState(lease);
+    p2aDiag('lease.acquire.complete', {
+      owner, leaseId: lease.leaseId, epoch: lease.epoch,
+      previousOwner: previous?.owner ?? null,
+      raw: this.stdin.isRaw === true,
+      paused: this.stdin.isPaused?.() === true,
+      flowing: this.stdin.readableFlowing,
+    });
+    try {
+      const result = await run(lease.facade);
+      p2aDiag('lease.callback.resolve', {
+        owner, leaseId: lease.leaseId, epoch: lease.epoch,
+      });
+      return result;
+    } finally {
+      p2aDiag('lease.release.start', {
+        owner, leaseId: lease.leaseId, epoch: lease.epoch,
+        isCurrent: this.active === lease && this.epoch === lease.epoch,
+      });
+      if (this.active === lease && this.epoch === lease.epoch) {
+        ++this.epoch;
+        this.active = null;
+        if (lease.previous) {
+          lease.previous.epoch = this.epoch;
+          this.active = lease.previous;
+          this.restoreSuspendedRaw(lease.previous);
+        } else {
+          this.restoreModalState(lease);
+        }
+      }
+      p2aDiag('lease.release.complete', {
+        owner, leaseId: lease.leaseId,
+        activeOwner: this.active?.owner ?? null,
+        activeLeaseId: this.active?.leaseId ?? null,
+        epoch: this.epoch,
+        raw: this.stdin.isRaw === true,
+        paused: this.stdin.isPaused?.() === true,
+        flowing: this.stdin.readableFlowing,
+      });
+    }
+  }
+
+  private createModalFacade(lease: ModalLease): ModalStdin {
+    const authority = this;
+    let facade!: ModalStdin;
+    const isCurrent = (): boolean => authority.active === lease && authority.epoch === lease.epoch;
+    facade = new Proxy(this.stdin as object, {
+      get(target, property) {
+        if (property === 'pause') {
+          return () => {
+            if (isCurrent()) lease.logicalPauseRequested = true;
+            return facade;
+          };
+        }
+        if (property === 'resume') {
+          return () => {
+            if (isCurrent()) lease.logicalResumeRequested = true;
+            return facade;
+          };
+        }
+        if (property === 'setRawMode') {
+          return (mode: boolean) => {
+            if (isCurrent()) lease.logicalRawModeRequested = mode;
+            return facade;
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+      set(target, property, value) {
+        return Reflect.set(target, property, value, target);
+      },
+    }) as unknown as ModalStdin;
+    return facade;
+  }
+
+  private establishModalState(lease: ModalLease): void {
+    if (!this.stdin.isTTY || typeof this.stdin.setRawMode !== 'function') return;
+    try {
+      if (this.stdin.isRaw !== true) {
+        this.stdin.setRawMode(true);
+        lease.rawChanged = true;
+      }
+      if ((this.stdin.isPaused?.() === true || this.stdin.readableFlowing !== true) &&
+          typeof this.stdin.resume === 'function') {
+        this.stdin.resume();
+        lease.flowChanged = true;
+      }
+    } catch { /* prompt setup will report its own failure */ }
+  }
+
+  private restoreModalState(lease: ModalLease): void {
+    if (lease.rawChanged) {
+      try { this.stdin.setRawMode?.(lease.rawBefore); } catch { /* best effort */ }
+      lease.rawChanged = false;
+    }
+    if (lease.flowChanged) {
+      try {
+        if (lease.pausedBefore || lease.flowingBefore === false) this.stdin.pause?.();
+        else this.stdin.resume?.();
+      } catch { /* best effort */ }
+      lease.flowChanged = false;
+    }
+  }
+
+  private activateRaw(reg: RawRegistration): void {
+    if (!this.stdin.isTTY || typeof this.stdin.setRawMode !== 'function') return;
+    try {
+      this.emitKeypress(this.stdin);
+      if (this.stdin.isRaw !== true) { this.stdin.setRawMode(true); reg.rawChanged = true; }
+      this.stdin.on('keypress', reg.dispatch);
+      reg.subscribed = true;
+      reg.activationPausedBefore = this.stdin.isPaused?.() === true;
+      reg.flowChanged = false;
+      if (reg.activationPausedBefore && typeof this.stdin.resume === 'function') {
+        this.stdin.resume();
+        reg.flowChanged = true;
+      }
+      reg.exitFn = () => this.restoreRaw(reg);
+      this.onExit(reg.exitFn);
+    } catch {
+      this.deactivateRaw(reg, false);
+    }
+  }
+
+  private suspendRaw(reg: RawRegistration): void {
+    if (!reg.subscribed) return;
+    try { this.stdin.removeListener('keypress', reg.dispatch); } catch { /* best effort */ }
+    reg.subscribed = false;
+  }
+
+  private restoreSuspendedRaw(reg: RawRegistration): void {
+    if (!this.stdin.isTTY || typeof this.stdin.setRawMode !== 'function') return;
+    try {
+      this.emitKeypress(this.stdin);
+      if (this.stdin.isRaw !== true) {
+        this.stdin.setRawMode(true);
+        reg.rawChanged = true;
+      }
+      this.stdin.on('keypress', reg.dispatch);
+      reg.subscribed = true;
+      if ((this.stdin.isPaused?.() === true || this.stdin.readableFlowing !== true) &&
+          typeof this.stdin.resume === 'function') {
+        this.stdin.resume();
+        reg.flowChanged = true;
+      }
+    } catch {
+      this.deactivateRaw(reg, false);
+    }
+  }
+
+  private deactivateRaw(reg: RawRegistration, finalRelease: boolean): void {
+    if (reg.subscribed) {
+      try { this.stdin.removeListener('keypress', reg.dispatch); } catch { /* best effort */ }
+      reg.subscribed = false;
+    }
+    this.restoreRaw(reg);
+    this.restoreFlow(reg, finalRelease);
+    if (reg.exitFn) {
+      try { this.offExit(reg.exitFn); } catch { /* best effort */ }
+      reg.exitFn = null;
+    }
+  }
+
+  private restoreFlow(reg: RawRegistration, finalRelease: boolean): void {
+    if (!reg.flowChanged) return;
+    const shouldPause = finalRelease ? reg.initialPaused : reg.activationPausedBefore;
+    try {
+      if (shouldPause) reg.flowChanged && this.stdin.pause?.();
+      else this.stdin.resume?.();
+    } catch { /* best effort */ }
+    reg.flowChanged = false;
+  }
+
+  private restoreRaw(reg: RawRegistration): void {
+    if (!reg.rawChanged) return;
+    try { this.stdin.setRawMode?.(reg.rawBefore); } catch { /* best effort */ }
+    reg.rawChanged = false;
+  }
+}
+
+function defaultEmitKeypress(stdin: RawStdinLike): void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const readline = require('node:readline') as typeof import('node:readline');
+  readline.emitKeypressEvents(stdin as unknown as NodeJS.ReadableStream);
+}
+
+function p2aDiag(event: string, data: Record<string, unknown>): void {
+  if (process.env.AIDEN_P2A_DIAG !== '1') return;
+  try {
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
+  } catch { /* diagnostics must never affect input ownership */ }
+}

--- a/cli/v4/inputAuthority.ts
+++ b/cli/v4/inputAuthority.ts
@@ -4,10 +4,12 @@
  */
 /** Render-free exclusive-input lease for prompts that run during a turn. */
 import type { TurnKey } from './turnInputListener';
+import { turnIdleDiagnostic } from './turnIdleDiagnostics';
 
 export type RawKeyHandler = (str: string | undefined, key: TurnKey) => void;
 export type InputOwner = 'during_turn' | 'approval' | 'skill_prompt' | 'clarify';
 export type ModalStdin = NodeJS.ReadStream;
+export type RawReleaseMode = 'restore' | 'handoff';
 
 export interface RawStdinLike {
   isTTY?: boolean;
@@ -88,7 +90,7 @@ export class InputAuthority {
   mountedCount(): number { return this.active ? 1 : 0; }
   isRawSubscribed(): boolean { return this.active?.kind === 'raw' && this.active.subscribed; }
 
-  mountRawOwner(owner: 'during_turn', handler: RawKeyHandler): () => void {
+  mountRawOwner(owner: 'during_turn', handler: RawKeyHandler): (mode?: RawReleaseMode) => void {
     if (this.active?.kind === 'modal') throw new Error('Cannot mount raw input during an exclusive input lease');
     if (this.active?.kind === 'raw') this.deactivateRaw(this.active, true);
     const registration = {} as RawRegistration;
@@ -112,14 +114,28 @@ export class InputAuthority {
     });
     this.active = registration;
     this.activateRaw(registration);
+    turnIdleDiagnostic('input.raw.mount', {
+      owner, leaseId: registration.leaseId, epoch: registration.epoch,
+      initialPaused: registration.initialPaused,
+      flowChanged: registration.flowChanged,
+    });
     let released = false;
-    return () => {
+    return (mode: RawReleaseMode = 'restore') => {
       if (released) return;
       released = true;
       if (this.active !== registration || registration.epoch !== this.epoch) return;
       ++this.epoch;
-      this.deactivateRaw(registration, true);
+      turnIdleDiagnostic('input.raw.release.start', {
+        owner, leaseId: registration.leaseId, epoch: registration.epoch,
+        initialPaused: registration.initialPaused,
+        flowChanged: registration.flowChanged,
+        mode,
+      });
+      this.deactivateRaw(registration, true, mode === 'handoff');
       if (this.active === registration) this.active = null;
+      turnIdleDiagnostic('input.raw.release.complete', {
+        owner, leaseId: registration.leaseId, epoch: this.epoch, mode,
+      });
     };
   }
 
@@ -300,13 +316,21 @@ export class InputAuthority {
     }
   }
 
-  private deactivateRaw(reg: RawRegistration, finalRelease: boolean): void {
+  private deactivateRaw(reg: RawRegistration, finalRelease: boolean, handoff = false): void {
     if (reg.subscribed) {
       try { this.stdin.removeListener('keypress', reg.dispatch); } catch { /* best effort */ }
       reg.subscribed = false;
     }
-    this.restoreRaw(reg);
-    this.restoreFlow(reg, finalRelease);
+    if (handoff) {
+      // The next composer is another raw TTY owner. Transfer the live state so
+      // Windows does not stop and restart its console reader between owners.
+      // The composer performs its own raw/flow cleanup when it settles.
+      reg.rawChanged = false;
+      reg.flowChanged = false;
+    } else {
+      this.restoreRaw(reg);
+      this.restoreFlow(reg, finalRelease);
+    }
     if (reg.exitFn) {
       try { this.offExit(reg.exitFn); } catch { /* best effort */ }
       reg.exitFn = null;

--- a/cli/v4/turnIdleDiagnostics.ts
+++ b/cli/v4/turnIdleDiagnostics.ts
@@ -1,0 +1,28 @@
+let composerGeneration = 0;
+
+export function nextComposerGeneration(): number {
+  composerGeneration += 1;
+  return composerGeneration;
+}
+
+export function turnIdleDiagnostic(event: string, data: Record<string, unknown> = {}): void {
+  if (process.env.AIDEN_TEST_TURN_IDLE_DIAG !== '1') return;
+  try {
+    const stdin = process.stdin;
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[turn-idle] ${JSON.stringify({
+      monoMs,
+      event,
+      stdin: {
+        isRaw: stdin.isRaw === true,
+        isPaused: stdin.isPaused(),
+        readableFlowing: stdin.readableFlowing,
+        dataListeners: stdin.listenerCount('data'),
+        keypressListeners: stdin.listenerCount('keypress'),
+        readableListeners: stdin.listenerCount('readable'),
+      },
+      sigintListeners: process.listenerCount('SIGINT'),
+      ...data,
+    })}\n`);
+  } catch { /* test diagnostics must not affect the terminal lifecycle */ }
+}

--- a/cli/v4/turnInputListener.ts
+++ b/cli/v4/turnInputListener.ts
@@ -121,6 +121,15 @@ export interface AttachOptions {
   emitKeypressEvents?: (stdin: RawStdinLike) => void;
   onProcessExit?:      (fn: () => void) => void;
   offProcessExit?:     (fn: () => void) => void;
+  /**
+   * P2A — when supplied, the during-turn listener mounts as the
+   * `during_turn` RAW owner of the single {@link InputAuthority} instead of
+   * grabbing `process.stdin` directly. The authority owns the one subscription +
+   * raw-mode, and serializes this source against exclusive prompts (so a prompt
+   * that acquires input fully suspends this listener — no double-consume). Absent
+   * ⇒ the legacy direct-attach path (unchanged), used by tests + non-REPL callers.
+   */
+  authority?: import('./inputAuthority').InputAuthority;
 }
 
 /**
@@ -131,6 +140,20 @@ export interface AttachOptions {
  * raw mode even if `detach()` never runs (crash safety).
  */
 export function attachTurnInputListener(opts: AttachOptions): () => void {
+  // P2A — route through the exclusive-input lease when one is supplied.
+  // The authority owns the raw subscription + raw-mode and can suspend this
+  // source while an exclusive prompt reads, closing the double-consume race. The
+  // pure `makeKeypressHandler` is reused verbatim as the routed handler.
+  if (opts.authority) {
+    const handler = makeKeypressHandler(opts.cb);
+    const unmount = opts.authority.mountRawOwner('during_turn', handler);
+    let detached = false;
+    return () => {
+      if (detached) return;
+      detached = true;
+      unmount(); // authority restores raw-mode + removes the subscription
+    };
+  }
   const stdin = (opts.stdin ?? (process.stdin as unknown as RawStdinLike));
   if (!stdin || !stdin.isTTY || typeof stdin.setRawMode !== 'function') {
     return () => { /* no-op: not an interactive TTY */ };

--- a/cli/v4/turnInputListener.ts
+++ b/cli/v4/turnInputListener.ts
@@ -132,6 +132,11 @@ export interface AttachOptions {
   authority?: import('./inputAuthority').InputAuthority;
 }
 
+export interface DetachTurnInputOptions {
+  /** Transfer the active TTY state directly to the next composer. */
+  nextOwner?: 'composer';
+}
+
 /**
  * Attach the during-turn listener; returns an idempotent `detach()`. On a
  * non-TTY stdin it's a no-op (input stays blocked, today's behaviour) — this
@@ -139,7 +144,7 @@ export interface AttachOptions {
  * prior raw-mode state and removes the listener; a process-exit hook restores
  * raw mode even if `detach()` never runs (crash safety).
  */
-export function attachTurnInputListener(opts: AttachOptions): () => void {
+export function attachTurnInputListener(opts: AttachOptions): (detachOpts?: DetachTurnInputOptions) => void {
   // P2A — route through the exclusive-input lease when one is supplied.
   // The authority owns the raw subscription + raw-mode and can suspend this
   // source while an exclusive prompt reads, closing the double-consume race. The
@@ -148,10 +153,10 @@ export function attachTurnInputListener(opts: AttachOptions): () => void {
     const handler = makeKeypressHandler(opts.cb);
     const unmount = opts.authority.mountRawOwner('during_turn', handler);
     let detached = false;
-    return () => {
+    return (detachOpts?: DetachTurnInputOptions) => {
       if (detached) return;
       detached = true;
-      unmount(); // authority restores raw-mode + removes the subscription
+      unmount(detachOpts?.nextOwner === 'composer' ? 'handoff' : 'restore');
     };
   }
   const stdin = (opts.stdin ?? (process.stdin as unknown as RawStdinLike));

--- a/core/agentLoop.ts
+++ b/core/agentLoop.ts
@@ -387,7 +387,7 @@ export function resolveTemplates(input: string, stepOutputs: string[]): string {
 
 // ── SSE stream helpers ─────────────────────────────────────────
 
-export async function streamOpenAIResponse(
+export async function streamProviderResponse(
   res:     any,
   onToken: (token: string) => void,
 ): Promise<void> {
@@ -445,7 +445,7 @@ export async function streamGeminiResponse(
 
 // ── Provider endpoint map ──────────────────────────────────────
 
-const OPENAI_COMPAT_ENDPOINTS: Record<string, string> = {
+const COMPATIBLE_API_ENDPOINTS: Record<string, string> = {
   groq:       'https://api.groq.com/openai/v1/chat/completions',
   openrouter: 'https://openrouter.ai/api/v1/chat/completions',
   cerebras:   'https://api.cerebras.ai/v1/chat/completions',
@@ -487,7 +487,7 @@ function extractChatMessageContent(content: unknown): string {
  * C9b: Resolve streaming URL for any provider — custom or known.
  *
  * Custom providers look up baseUrl from config; known providers
- * use OPENAI_COMPAT_ENDPOINTS; unknown falls back to groq.
+ * use COMPATIBLE_API_ENDPOINTS; unknown falls back to the default route.
  *
  * Note: when multiple custom providers share the same API key
  * (e.g. together-1 and together-deepseek both using
@@ -496,7 +496,7 @@ function extractChatMessageContent(content: unknown): string {
  * if keys overlap.
  */
 export function resolveStreamingUrl(providerName: string, apiKey: string): string {
-  if (OPENAI_COMPAT_ENDPOINTS[providerName]) return OPENAI_COMPAT_ENDPOINTS[providerName]
+  if (COMPATIBLE_API_ENDPOINTS[providerName]) return COMPATIBLE_API_ENDPOINTS[providerName]
   if (providerName === 'custom') {
     const cfg = loadConfig()
     const fromCustom = cfg.customProviders?.find((c: any) => c.enabled && c.apiKey === apiKey)?.baseUrl
@@ -510,7 +510,7 @@ export function resolveStreamingUrl(providerName: string, apiKey: string): strin
     })
     if (apiEntry?.baseUrl) return apiEntry.baseUrl
   }
-  return OPENAI_COMPAT_ENDPOINTS.groq  // last resort
+  return COMPATIBLE_API_ENDPOINTS.groq  // last resort
 }
 
 // ── Phase inference from tool steps ───────────────────────────
@@ -707,8 +707,8 @@ async function racePlannerAPIs(
       candidates.push({ provider: 'custom', model: a.model, key: k, url: a.baseUrl, tier: (a as any).tier ?? 50 })
       continue
     }
-    if (!OPENAI_COMPAT_ENDPOINTS[a.provider]) continue
-    candidates.push({ provider: a.provider, model: a.model, key: k, url: OPENAI_COMPAT_ENDPOINTS[a.provider], tier: (a as any).tier ?? 50 })
+    if (!COMPATIBLE_API_ENDPOINTS[a.provider]) continue
+    candidates.push({ provider: a.provider, model: a.model, key: k, url: COMPATIBLE_API_ENDPOINTS[a.provider], tier: (a as any).tier ?? 50 })
   }
 
   const pool = candidates.sort((a, b) => a.tier - b.tier).slice(0, topN)
@@ -2891,7 +2891,7 @@ CRITICAL RULES FOR YOUR RESPONSE:
         const capacityHint = errText.toLowerCase().includes('capacity') || errText.toLowerCase().includes('overloaded') ? ' capacity' : ''
         throw new Error(`Responder ${r.status}${capacityHint}: ${errText.slice(0, 200)}`)
       }
-      await streamOpenAIResponse(r, onToken)
+      await streamProviderResponse(r, onToken)
     }
   } catch (e: any) {
     if (e.name === 'AbortError') return
@@ -2925,7 +2925,7 @@ CRITICAL RULES FOR YOUR RESPONSE:
             body:    JSON.stringify({ model: nextCloud.model, messages, stream: true }),
             signal:  AbortSignal.timeout(30000),
           })
-          if (r.ok) { await streamOpenAIResponse(r, onToken); return }
+          if (r.ok) { await streamProviderResponse(r, onToken); return }
           if (r.status === 429 || r.status === 503) {
             try { markRateLimited(nextCloud.apiName) } catch {}
           }
@@ -2950,7 +2950,7 @@ CRITICAL RULES FOR YOUR RESPONSE:
             body:    JSON.stringify({ model: cloudFallback.model, messages, stream: true }),
             signal:  AbortSignal.timeout(15000),
           })
-          if (r.ok) { await streamOpenAIResponse(r, onToken); return }
+          if (r.ok) { await streamProviderResponse(r, onToken); return }
         } catch (fbErr: any) {
           console.error(`[Router] Cloud fallback also failed: ${fbErr.message}`)
         }
@@ -3175,7 +3175,7 @@ export async function callLLM(
 
     } else {
       // OpenAI-compatible: groq, openrouter, cerebras, nvidia, github
-      const url     = OPENAI_COMPAT_ENDPOINTS[providerName] || OPENAI_COMPAT_ENDPOINTS.groq
+      const url     = COMPATIBLE_API_ENDPOINTS[providerName] || COMPATIBLE_API_ENDPOINTS.groq
       const headers = buildHeaders(providerName, apiKey)
       const r = await fetch(url, {
         method:  'POST',

--- a/core/importers.ts
+++ b/core/importers.ts
@@ -32,7 +32,7 @@ export interface ImportResult {
 //     content: { parts: string[] }
 //   }}> }>
 
-export async function importChatGPT(filePath: string): Promise<ImportResult> {
+export async function importConversationArchive(filePath: string): Promise<ImportResult> {
   const result: ImportResult = {
     source:                'chatgpt',
     conversationsImported: 0,
@@ -73,7 +73,7 @@ export async function importChatGPT(filePath: string): Promise<ImportResult> {
 
         const content  = messages.join('\n\n').substring(0, 50000)
         const title    = String(convo.title || 'ChatGPT Import').replace(/[^a-zA-Z0-9._\- ]/g, '_').slice(0, 80)
-        const filename = `chatgpt_${title}.txt`
+        const filename = `conversation_${title}.txt`
 
         const ingestResult = knowledgeBase.ingestText(
           content,

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -1556,12 +1556,18 @@ export class AidenAgent {
         const isReadOnly = (name: string): boolean =>
           this.resolveMutates?.(name) !== true &&
           this.resolveUiOnly?.(name) !== true;
+        // These read-only tools can open an exclusive terminal prompt. Keep
+        // them on the ordered live-dispatch path instead of Promise.all.
+        const isInteractive = (name: string): boolean =>
+          name === 'clarify' || name === 'plan_approval';
+        const isParallelRead = (name: string): boolean =>
+          isReadOnly(name) && !isInteractive(name);
         let i = 0;
         while (i < toolCalls.length) {
-          if (!isReadOnly(toolCalls[i].name)) { i += 1; continue; }
+          if (!isParallelRead(toolCalls[i].name)) { i += 1; continue; }
           // Find the maximal consecutive read-only batch starting at i.
           let j = i;
-          while (j < toolCalls.length && isReadOnly(toolCalls[j].name)) j += 1;
+          while (j < toolCalls.length && isParallelRead(toolCalls[j].name)) j += 1;
           const batch = toolCalls.slice(i, j);
           // Skip the parallel path for solo batches — no benefit, and
           // keeps the live-execution path on the sequential loop where

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -501,6 +501,7 @@ const EMPTY_RETRY_NOTE =
 
 export class AidenAgent {
   private provider: ProviderAdapter;
+  private pendingRequiredClarification: { question: string } | null = null;
 
   private readonly toolExecutor:                ToolExecutor;
   private readonly tools:                       ToolSchema[];
@@ -818,6 +819,12 @@ export class AidenAgent {
       this.plannerGuard.resetActivation();
     }
     const lastUserContent = lastUserMessageContent(history);
+    if (
+      this.pendingRequiredClarification &&
+      resolvesPendingClarification(lastUserContent)
+    ) {
+      this.pendingRequiredClarification = null;
+    }
     const narrowedTools   = await this.narrowTools(lastUserContent, history);
 
     // 4. Build per-call trackers, then Stage-0 intent pre-arm.
@@ -1274,6 +1281,12 @@ export class AidenAgent {
         break;
       }
       turnCount += 1;
+      p2aDiag('agent.iteration.start', {
+        iteration: turnCount,
+        aborted: runOptions.signal?.aborted === true,
+        messageCount: messages.length,
+        lastRole: messages.length > 0 ? messages[messages.length - 1].role : null,
+      });
 
       // Budget warnings — at the threshold turn, exactly once each.
       const cautionAt = Math.ceil(this.maxTurns * CAUTION_FRACTION);
@@ -1351,6 +1364,14 @@ export class AidenAgent {
 
       let output: ProviderCallOutput;
       const _llmStartedAt = _perfDiag ? Date.now() : 0;
+      p2aDiag('provider.continuation.start', {
+        iteration: turnCount,
+        continuation: turnCount > 1,
+        messageCount: messages.length,
+        lastRole: messages.length > 0 ? messages[messages.length - 1].role : null,
+        aborted: runOptions.signal?.aborted === true,
+        pendingPromise: 'callProvider',
+      });
       try {
         // v4.9.0 Slice 6 — wrap the provider call in an LLM span when
         // the daemon foundation is up AND a runWithContext frame is
@@ -1377,6 +1398,13 @@ export class AidenAgent {
         } else {
           output = await this.callProvider(messages, effectiveTools, runOptions);
         }
+        p2aDiag('provider.continuation.complete', {
+          iteration: turnCount,
+          continuation: turnCount > 1,
+          toolCalls: output.toolCalls?.map((call) => ({ id: call.id, name: call.name })) ?? [],
+          finishReason: output.finishReason,
+          aborted: runOptions.signal?.aborted === true,
+        });
         if (_perfDiag) {
           const llmMs = Date.now() - _llmStartedAt;
           const tokIn = output.usage?.inputTokens ?? 0;
@@ -1641,6 +1669,9 @@ export class AidenAgent {
           uiClaims.push({ name: call.name, args: call.arguments });
           continue;
         }
+        const blockedByRequiredClarification =
+          this.pendingRequiredClarification !== null &&
+          this.resolveMutates?.(call.name) === true;
         this.onToolCall?.(call, 'before');
         // v4.2 Phase 4 — mark any active checkpoints as containing a
         // mutating call BEFORE dispatch. Done pre-dispatch (not post)
@@ -1652,7 +1683,11 @@ export class AidenAgent {
         // which we treat as non-mutating (leave the flag alone).
         // Plugin authors should declare `mutates` honestly on their
         // tool handlers — this is the structural enforcement point.
-        if (turnState.isEnabled() && this.resolveMutates?.(call.name) === true) {
+        if (
+          !blockedByRequiredClarification &&
+          turnState.isEnabled() &&
+          this.resolveMutates?.(call.name) === true
+        ) {
           turnState.markMutationOnLiveCheckpoint(call.name);
         }
         let result: ToolCallResult;
@@ -1688,11 +1723,31 @@ export class AidenAgent {
           for (;;) {
             attemptNo += 1;
             const _toolStartedAt = _perfDiag ? Date.now() : 0;
-            if (attemptNo === 1 && _preComputed) {
+            if (blockedByRequiredClarification) {
+              const question = this.pendingRequiredClarification?.question ?? 'required information';
+              result = {
+                id: call.id,
+                name: call.name,
+                result: null,
+                error:
+                  `Blocked: required clarification was cancelled (${question}). ` +
+                  'Do not invent the missing value. Ask again or wait for an explicit answer/override.',
+              };
+            } else if (attemptNo === 1 && _preComputed) {
               result = _preComputed;
             } else {
               try {
+                p2aDiag('tool.executor.start', {
+                  iteration: turnCount, callId: call.id, tool: call.name,
+                  attempt: attemptNo, aborted: this._currentSignal?.aborted === true,
+                  pendingPromise: 'toolExecutor',
+                });
                 result = await this.toolExecutor(call, this._currentSignal);
+                p2aDiag('tool.executor.complete', {
+                  iteration: turnCount, callId: call.id, tool: call.name,
+                  attempt: attemptNo, hasError: result.error != null,
+                  aborted: this._currentSignal?.aborted === true,
+                });
               } catch (err) {
                 result = {
                   id:     call.id,
@@ -1844,6 +1899,22 @@ export class AidenAgent {
               }
             }
           }
+          if (call.name === 'clarify') {
+            const payload = result.result;
+            const status = payload && typeof payload === 'object'
+              ? (payload as { status?: unknown }).status
+              : undefined;
+            if (status === 'cancelled') {
+              const question = typeof call.arguments.question === 'string'
+                ? call.arguments.question.trim()
+                : '';
+              this.pendingRequiredClarification = {
+                question: question || 'required information',
+              };
+            } else if (status === 'answered') {
+              this.pendingRequiredClarification = null;
+            }
+          }
           toolCallTrace.push({
             name:     call.name,
             result:   result.result,
@@ -1901,6 +1972,10 @@ export class AidenAgent {
           }
           this.onToolCall?.(call, 'after', result);
           afterFired = true;
+          p2aDiag('tool.callback.after.complete', {
+            iteration: turnCount, callId: call.id, tool: call.name,
+            hasError: result.error != null,
+          });
         } finally {
           // Guarantee the before/after pairing: every onToolCall('before') gets
           // exactly one 'after'. If the dispatch threw or exited before emitting
@@ -2116,13 +2191,28 @@ export class AidenAgent {
       }
 
       messages.push(...turnToolMessages);
+      p2aDiag('agent.tool_results.appended', {
+        iteration: turnCount,
+        appended: turnToolMessages.length,
+        messageCount: messages.length,
+        aborted: runOptions.signal?.aborted === true,
+      });
 
       // ── v4.14 — PAUSE gate at the SAME safe boundary ─────────────────
       // If the user paused mid-turn, freeze HERE (history balanced, before the
       // next provider call fires). Resumes on /resume; an abort during a pause
       // unblocks the waiter so the top-of-loop signal check stops the turn.
       if (runOptions.waitForResumeIfPaused) {
+        p2aDiag('agent.pause_gate.start', {
+          iteration: turnCount,
+          aborted: runOptions.signal?.aborted === true,
+          pendingPromise: 'waitForResumeIfPaused',
+        });
         await runOptions.waitForResumeIfPaused(runOptions.signal);
+        p2aDiag('agent.pause_gate.complete', {
+          iteration: turnCount,
+          aborted: runOptions.signal?.aborted === true,
+        });
       }
       // Loop continues — provider gets the tool results next iteration.
     }
@@ -2339,6 +2429,28 @@ function lastUserMessageContent(history: Message[]): string {
     if (m.role === 'user') return m.content;
   }
   return '';
+}
+
+function p2aDiag(event: string, data: Record<string, unknown>): void {
+  if (process.env.AIDEN_P2A_DIAG !== '1') return;
+  try {
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
+  } catch { /* diagnostics must never affect the agent loop */ }
+}
+
+function resolvesPendingClarification(content: string): boolean {
+  const text = content.trim();
+  if (!text) return false;
+  if (
+    /\b(?:use|choose|pick)\b.*\b(?:default|anything|any topic|for me|your choice)\b/i.test(text) ||
+    /\b(?:skip|proceed without|no need for)\b.*\b(?:clarification|answer|asking)\b/i.test(text)
+  ) {
+    return true;
+  }
+  // A bare continuation command does not supply the value that was missing.
+  // Any other substantive reply is treated as the user's direct answer.
+  return !/^(?:please\s+)?(?:create|make|do|write|generate|build|continue|finish|proceed|go\s+ahead)(?:\s+(?:it|this|that|the\s+report|the\s+file))?(?:\s+now)?[.!]?$/i.test(text);
 }
 
 function stringifyToolResult(result: unknown): string {

--- a/core/v4/daemon/bootstrap.ts
+++ b/core/v4/daemon/bootstrap.ts
@@ -116,6 +116,9 @@ import { insertIncarnation, markEnded } from './incarnationStore';
 // silently failed under vite-node (CJS `.ts` resolution) and the
 // `/api/runs` route never mounted in tests.
 import { mountRunsRoutes } from './api/runs';
+import { initSpawnPause } from '../subagent/spawnPause';
+import { initRecoveryStore } from '../selfimprovement/recoveryStore';
+import { setRunActionForTests } from '../cron/cronManager';
 
 export interface DaemonBootstrapHandle {
   /** True when the foundation actually initialized (AIDEN_DAEMON=1). */
@@ -372,8 +375,6 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
     // (treat as "not paused"). The daemon's startup probe below
     // is best-effort.
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { initSpawnPause } = require('../subagent/spawnPause');
       const sp = initSpawnPause({ aidenHome: aidenRoot });
       if (sp.isPaused()) {
         const s = sp.status();
@@ -401,8 +402,6 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
     // failure must not block daemon bootstrap; the TCE write-through
     // path silently no-ops when the singleton is missing.
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { initRecoveryStore } = require('../selfimprovement/recoveryStore');
       initRecoveryStore({ db });
     } catch (e) {
       log('warn', '[daemon] recovery-store init failed (non-fatal): ' +
@@ -908,12 +907,10 @@ export function bootstrapDaemon(opts: BootstrapOptions = {}): DaemonBootstrapHan
     // hot path unless the user actually runs cron. The import is
     // lazy so non-cron CLIs don't pay the cost.
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const cm = require('../cron/cronManager') as typeof import('../cron/cronManager');
       const emitter = createCronEmitter({
         triggerBus, db, log,
       });
-      cm.setRunActionForTests(emitter);
+      setRunActionForTests(emitter);
       log('info', `[cron-emitter] daemon-mode runAction installed`);
     } catch (e) {
       log('warn', `[cron-emitter] install skipped: ${e instanceof Error ? e.message : String(e)}`);

--- a/core/v4/providers/modelFetch.ts
+++ b/core/v4/providers/modelFetch.ts
@@ -120,7 +120,7 @@ function normalise(providerId: string, raws: RawModel[]): FetchedModel[] {
     .sort((a, b) => Number(b.recommended) - Number(a.recommended) || a.displayName.localeCompare(b.displayName));
 }
 
-async function fetchAnthropic(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
+async function fetchMessageApiModels(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
   const res = await withTimeout(o.fetchImpl('https://api.anthropic.com/v1/models', {
     headers: { 'x-api-key': o.apiKey, 'anthropic-version': '2023-06-01' },
   }), o.timeoutMs);
@@ -129,7 +129,7 @@ async function fetchAnthropic(o: Required<Pick<FetchOptions, 'apiKey' | 'timeout
   return body.data ?? [];
 }
 
-async function fetchOpenAICompat(url: string, o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
+async function fetchCompatibleModels(url: string, o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
   const res = await withTimeout(o.fetchImpl(url, {
     headers: { Authorization: `Bearer ${o.apiKey}` },
   }), o.timeoutMs);
@@ -138,7 +138,7 @@ async function fetchOpenAICompat(url: string, o: Required<Pick<FetchOptions, 'ap
   return body.data ?? [];
 }
 
-async function fetchGemini(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
+async function fetchGenerativeApiModels(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
   const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(o.apiKey)}`;
   const res = await withTimeout(o.fetchImpl(url), o.timeoutMs);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -151,7 +151,7 @@ async function fetchGemini(o: Required<Pick<FetchOptions, 'apiKey' | 'timeoutMs'
   }));
 }
 
-async function fetchOllama(baseUrl: string, o: Required<Pick<FetchOptions, 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
+async function fetchLocalRuntimeModels(baseUrl: string, o: Required<Pick<FetchOptions, 'timeoutMs' | 'fetchImpl'>>): Promise<RawModel[]> {
   const res = await withTimeout(o.fetchImpl(`${baseUrl.replace(/\/+$/, '')}/api/tags`), o.timeoutMs);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const body = await res.json() as { models?: Array<{ name: string; size?: number }> };
@@ -173,27 +173,27 @@ export async function fetchModels(opts: FetchOptions): Promise<FetchModelsResult
     switch (opts.providerId) {
       case 'anthropic':
         if (!apiKey) return fallbackFor('anthropic', 'no API key');
-        raws = await fetchAnthropic({ apiKey, timeoutMs, fetchImpl });
+        raws = await fetchMessageApiModels({ apiKey, timeoutMs, fetchImpl });
         break;
       case 'openai':
         if (!apiKey) return fallbackFor('openai', 'no API key');
-        raws = await fetchOpenAICompat('https://api.openai.com/v1/models', { apiKey, timeoutMs, fetchImpl });
+        raws = await fetchCompatibleModels('https://api.openai.com/v1/models', { apiKey, timeoutMs, fetchImpl });
         break;
       case 'groq':
         if (!apiKey) return fallbackFor('groq', 'no API key');
-        raws = await fetchOpenAICompat('https://api.groq.com/openai/v1/models', { apiKey, timeoutMs, fetchImpl });
+        raws = await fetchCompatibleModels('https://api.groq.com/openai/v1/models', { apiKey, timeoutMs, fetchImpl });
         break;
       case 'openrouter':
         // OpenRouter exposes /models without auth, but auth gives the user's
         // available subset — we use the public list to populate the picker.
-        raws = await fetchOpenAICompat('https://openrouter.ai/api/v1/models', { apiKey: apiKey || 'anon', timeoutMs, fetchImpl });
+        raws = await fetchCompatibleModels('https://openrouter.ai/api/v1/models', { apiKey: apiKey || 'anon', timeoutMs, fetchImpl });
         break;
       case 'gemini':
         if (!apiKey) return fallbackFor('gemini', 'no API key');
-        raws = await fetchGemini({ apiKey, timeoutMs, fetchImpl });
+        raws = await fetchGenerativeApiModels({ apiKey, timeoutMs, fetchImpl });
         break;
       case 'ollama':
-        raws = await fetchOllama(opts.baseUrl ?? 'http://localhost:11434', { timeoutMs, fetchImpl });
+        raws = await fetchLocalRuntimeModels(opts.baseUrl ?? 'http://localhost:11434', { timeoutMs, fetchImpl });
         break;
       default:
         // Every other provider — together, nvidia, deepseek, mistral, custom,

--- a/core/visionAnalyze.ts
+++ b/core/visionAnalyze.ts
@@ -128,12 +128,12 @@ async function ensureBase64(
   }
 }
 
-// ── Provider 1: Gemini ────────────────────────────────────────────────────────
+// ── Provider 1: generative-content API ────────────────────────────────────────
 
-const GEMINI_MODEL    = 'gemini-2.5-flash'
-const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`
+const GENERATIVE_VISION_MODEL    = 'gemini-2.5-flash'
+const GENERATIVE_VISION_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${GENERATIVE_VISION_MODEL}:generateContent`
 
-async function tryGemini(
+async function tryGenerativeVisionApi(
   img: ResolvedImage, prompt: string, log: Logger, http: VisionHttpClient,
 ): Promise<VisionResult | null> {
   const key = process.env.GEMINI_API_KEY
@@ -151,24 +151,24 @@ async function tryGemini(
       }],
       generationConfig: { maxOutputTokens: 1024 },
     }
-    const res = await http.post(`${GEMINI_ENDPOINT}?key=${key}`, body, {
+    const res = await http.post(`${GENERATIVE_VISION_ENDPOINT}?key=${key}`, body, {
       headers: { 'content-type': 'application/json' },
       timeout: 30_000,
     })
     const description = (res.data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '').trim()
     if (!description) return null
-    const result: VisionResult = { description, provider: 'gemini', modelUsed: GEMINI_MODEL, durationMs: Date.now() - t0 }
-    log.info('image analyzed', { provider: 'gemini', modelUsed: GEMINI_MODEL, durationMs: result.durationMs, descChars: description.length })
+    const result: VisionResult = { description, provider: 'gemini', modelUsed: GENERATIVE_VISION_MODEL, durationMs: Date.now() - t0 }
+    log.info('image analyzed', { provider: 'gemini', modelUsed: GENERATIVE_VISION_MODEL, durationMs: result.durationMs, descChars: description.length })
     return result
   } catch (e: any) {
-    log.warn('gemini vision failed', { error: e?.message ?? String(e) })
+    log.warn('generative vision request failed', { error: e?.message ?? String(e) })
     return null
   }
 }
 
-// ── Provider 2-4: OpenAI-compatible (Groq, OpenRouter, Together) ──────────────
+// ── Providers 2-4: compatible chat APIs ───────────────────────────────────────
 
-interface OpenAICompatTarget {
+interface CompatibleVisionTarget {
   /** Display name on the result. */
   provider:  string
   /** Base URL (without trailing slash). */
@@ -179,29 +179,29 @@ interface OpenAICompatTarget {
   envKey:    string
 }
 
-const GROQ_TARGET: OpenAICompatTarget = {
+const LOW_LATENCY_TARGET: CompatibleVisionTarget = {
   provider: 'groq',
   baseUrl:  'https://api.groq.com/openai/v1',
   model:    'meta-llama/llama-4-maverick-17b-128e-instruct',
   envKey:   'GROQ_API_KEY',
 }
 
-const OPENROUTER_TARGET: OpenAICompatTarget = {
+const ROUTED_TARGET: CompatibleVisionTarget = {
   provider: 'openrouter',
   baseUrl:  'https://openrouter.ai/api/v1',
   model:    'meta-llama/llama-3.2-11b-vision-instruct:free',
   envKey:   'OPENROUTER_API_KEY',
 }
 
-const TOGETHER_TARGET: OpenAICompatTarget = {
+const HOSTED_TARGET: CompatibleVisionTarget = {
   provider: 'together',
   baseUrl:  'https://api.together.xyz/v1',
   model:    'meta-llama/Llama-Vision-Free',
   envKey:   'TOGETHER_API_KEY',
 }
 
-async function tryOpenAICompat(
-  target: OpenAICompatTarget,
+async function tryCompatibleVisionApi(
+  target: CompatibleVisionTarget,
   img:    ResolvedImage,
   prompt: string,
   log:    Logger,
@@ -251,11 +251,11 @@ async function tryOpenAICompat(
   }
 }
 
-// ── Provider 5: Anthropic ─────────────────────────────────────────────────────
+// ── Provider 5: message API ───────────────────────────────────────────────────
 
-const ANTHROPIC_MODEL = 'claude-3-5-sonnet-20241022'
+const MESSAGE_VISION_MODEL = 'claude-3-5-sonnet-20241022'
 
-async function tryAnthropic(
+async function tryMessageVisionApi(
   img: ResolvedImage, prompt: string, log: Logger, http: VisionHttpClient,
 ): Promise<VisionResult | null> {
   const key = process.env.ANTHROPIC_API_KEY
@@ -266,7 +266,7 @@ async function tryAnthropic(
       ? { type: 'image', source: { type: 'url',    url: img.sourceUrl } }
       : { type: 'image', source: { type: 'base64', media_type: img.mediaType, data: img.base64 } }
     const body = {
-      model:      ANTHROPIC_MODEL,
+      model:      MESSAGE_VISION_MODEL,
       max_tokens: 1024,
       messages:   [{ role: 'user', content: [imageBlock, { type: 'text', text: prompt }] }],
     }
@@ -280,20 +280,20 @@ async function tryAnthropic(
     })
     const description = (res.data?.content?.[0]?.text ?? '').trim()
     if (!description) return null
-    const result: VisionResult = { description, provider: 'anthropic', modelUsed: ANTHROPIC_MODEL, durationMs: Date.now() - t0 }
-    log.info('image analyzed', { provider: 'anthropic', modelUsed: ANTHROPIC_MODEL, durationMs: result.durationMs, descChars: description.length })
+    const result: VisionResult = { description, provider: 'anthropic', modelUsed: MESSAGE_VISION_MODEL, durationMs: Date.now() - t0 }
+    log.info('image analyzed', { provider: 'anthropic', modelUsed: MESSAGE_VISION_MODEL, durationMs: result.durationMs, descChars: description.length })
     return result
   } catch (e: any) {
-    log.warn('anthropic vision failed', { error: e?.message ?? String(e) })
+    log.warn('message vision request failed', { error: e?.message ?? String(e) })
     return null
   }
 }
 
-// ── Provider 6: OpenAI ────────────────────────────────────────────────────────
+// ── Provider 6: response API ──────────────────────────────────────────────────
 
-const OPENAI_MODEL = 'gpt-4o'
+const RESPONSE_VISION_MODEL = 'gpt-4o'
 
-async function tryOpenAI(
+async function tryResponseVisionApi(
   img: ResolvedImage, prompt: string, log: Logger, http: VisionHttpClient,
 ): Promise<VisionResult | null> {
   const key = process.env.OPENAI_API_KEY
@@ -301,7 +301,7 @@ async function tryOpenAI(
   const t0 = Date.now()
   try {
     const body = {
-      model:      OPENAI_MODEL,
+      model:      RESPONSE_VISION_MODEL,
       max_tokens: 1024,
       messages:   [{
         role:    'user',
@@ -317,18 +317,18 @@ async function tryOpenAI(
     })
     const description = (res.data?.choices?.[0]?.message?.content ?? '').trim()
     if (!description) return null
-    const result: VisionResult = { description, provider: 'openai', modelUsed: OPENAI_MODEL, durationMs: Date.now() - t0 }
-    log.info('image analyzed', { provider: 'openai', modelUsed: OPENAI_MODEL, durationMs: result.durationMs, descChars: description.length })
+    const result: VisionResult = { description, provider: 'openai', modelUsed: RESPONSE_VISION_MODEL, durationMs: Date.now() - t0 }
+    log.info('image analyzed', { provider: 'openai', modelUsed: RESPONSE_VISION_MODEL, durationMs: result.durationMs, descChars: description.length })
     return result
   } catch (e: any) {
-    log.warn('openai vision failed', { error: e?.message ?? String(e) })
+    log.warn('response vision request failed', { error: e?.message ?? String(e) })
     return null
   }
 }
 
-// ── Provider 7: Ollama llava ──────────────────────────────────────────────────
+// ── Provider 7: local vision runtime ──────────────────────────────────────────
 
-async function tryOllama(
+async function tryLocalVisionRuntime(
   img: ResolvedImage, prompt: string, log: Logger, http: VisionHttpClient,
 ): Promise<VisionResult | null> {
   const ollamaBase = (process.env.OLLAMA_BASE_URL ?? 'http://127.0.0.1:11434').replace(/\/$/, '')
@@ -347,7 +347,7 @@ async function tryOllama(
     log.info('image analyzed', { provider: 'ollama', modelUsed: 'llava', durationMs: result.durationMs, descChars: description.length })
     return result
   } catch (e: any) {
-    log.warn('ollama vision failed', { error: e?.message ?? String(e) })
+    log.warn('local vision request failed', { error: e?.message ?? String(e) })
     return null
   }
 }
@@ -379,13 +379,13 @@ export async function analyzeImage(
   // we fall through to the next; the first one that produces a
   // non-empty description wins.
   const providers: Array<(img: ResolvedImage, prompt: string, log: Logger, http: VisionHttpClient) => Promise<VisionResult | null>> = [
-    tryGemini,
-    (i, p, l, h) => tryOpenAICompat(GROQ_TARGET,       i, p, l, h),
-    (i, p, l, h) => tryOpenAICompat(OPENROUTER_TARGET, i, p, l, h),
-    (i, p, l, h) => tryOpenAICompat(TOGETHER_TARGET,   i, p, l, h),
-    tryAnthropic,
-    tryOpenAI,
-    tryOllama,
+    tryGenerativeVisionApi,
+    (i, p, l, h) => tryCompatibleVisionApi(LOW_LATENCY_TARGET, i, p, l, h),
+    (i, p, l, h) => tryCompatibleVisionApi(ROUTED_TARGET,      i, p, l, h),
+    (i, p, l, h) => tryCompatibleVisionApi(HOSTED_TARGET,      i, p, l, h),
+    tryMessageVisionApi,
+    tryResponseVisionApi,
+    tryLocalVisionRuntime,
   ]
 
   for (const tryProvider of providers) {

--- a/integrations/computerUse/visionLoop.ts
+++ b/integrations/computerUse/visionLoop.ts
@@ -43,7 +43,7 @@ interface VisionLoopOptions {
 /**
  * Call llava (or any vision-capable Ollama model) with a base64 image.
  */
-async function callOllamaVision(prompt: string, imageB64: string): Promise<string> {
+async function callLocalVisionModel(prompt: string, imageB64: string): Promise<string> {
   const res = await axios.post(
     `${OLLAMA_BASE}/api/chat`,
     {
@@ -67,7 +67,7 @@ async function callOllamaVision(prompt: string, imageB64: string): Promise<strin
  * Call Claude via Anthropic Messages API with a base64 PNG image.
  * Requires ANTHROPIC_API_KEY env var.
  */
-async function callClaudeVision(prompt: string, imageB64: string): Promise<string> {
+async function invokeVisionProvider(prompt: string, imageB64: string): Promise<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY
   if (!apiKey) throw new Error('[VisionLoop] ANTHROPIC_API_KEY not set — use visionModel: "local"')
 
@@ -293,8 +293,8 @@ Respond ONLY with valid JSON:
 
     try {
       const raw = useLocal
-        ? await callOllamaVision(prompt, screenshotB64)
-        : await callClaudeVision(prompt, screenshotB64)
+        ? await callLocalVisionModel(prompt, screenshotB64)
+        : await invokeVisionProvider(prompt, screenshotB64)
       return this.parseAction(raw)
     } catch (err: any) {
       console.warn(`[VisionLoop] LLM call failed (${useLocal ? 'local' : 'claude'}): ${err?.message}`)
@@ -315,8 +315,8 @@ Respond ONLY with valid JSON:
 
     try {
       const raw = useLocal
-        ? await callOllamaVision(prompt, screenshotB64)
-        : await callClaudeVision(prompt, screenshotB64)
+        ? await callLocalVisionModel(prompt, screenshotB64)
+        : await invokeVisionProvider(prompt, screenshotB64)
       const cleaned = raw.replace(/```json|```/g, '').trim()
       return JSON.parse(cleaned).complete === true
     } catch {

--- a/plugins/aiden-plugin-chatgpt-plus/index.js
+++ b/plugins/aiden-plugin-chatgpt-plus/index.js
@@ -32,7 +32,7 @@
 
 'use strict';
 
-const CHATGPT_PLUS = {
+const SUBSCRIPTION_AUTH = {
   id: 'chatgpt-plus',
   displayName: 'ChatGPT Plus',
   description:
@@ -117,7 +117,7 @@ function buildPollingUa(outer, deadlineAt, now = Date.now) {
       const elapsed = now() - started;
       if (
         !reminderShown &&
-        elapsed >= CHATGPT_PLUS.REMINDER_AT_MS &&
+        elapsed >= SUBSCRIPTION_AUTH.REMINDER_AT_MS &&
         deadlineAt - now() > 0
       ) {
         reminderShown = true;
@@ -132,10 +132,10 @@ function buildPollingUa(outer, deadlineAt, now = Date.now) {
 
 function buildProvider(authHelpers) {
   return {
-    id: CHATGPT_PLUS.id,
-    displayName: CHATGPT_PLUS.displayName,
-    defaultModels: CHATGPT_PLUS.defaultModels,
-    description: CHATGPT_PLUS.description,
+    id: SUBSCRIPTION_AUTH.id,
+    displayName: SUBSCRIPTION_AUTH.displayName,
+    defaultModels: SUBSCRIPTION_AUTH.defaultModels,
+    description: SUBSCRIPTION_AUTH.description,
 
     async login(ua) {
       ua.log('');
@@ -184,8 +184,8 @@ function buildProvider(authHelpers) {
       try {
         result = await authHelpers.runDeviceCodeFlow(
           {
-            issuer: CHATGPT_PLUS.issuer,
-            clientId: CHATGPT_PLUS.clientId,
+            issuer: SUBSCRIPTION_AUTH.issuer,
+            clientId: SUBSCRIPTION_AUTH.clientId,
             extraHeaders: userAgentHeader(),
           },
           innerUa,
@@ -221,8 +221,8 @@ function buildProvider(authHelpers) {
     async refresh(refreshToken) {
       return authHelpers.refreshTokens(refreshToken, {
         // OpenAI's refresh endpoint is the same as the token-exchange one.
-        tokenUrl: `${CHATGPT_PLUS.issuer}/oauth/token`,
-        clientId: CHATGPT_PLUS.clientId,
+        tokenUrl: `${SUBSCRIPTION_AUTH.issuer}/oauth/token`,
+        clientId: SUBSCRIPTION_AUTH.clientId,
         formEncoded: true,
         extraHeaders: userAgentHeader(),
       });
@@ -230,10 +230,10 @@ function buildProvider(authHelpers) {
 
     describeRuntime() {
       return {
-        apiMode: CHATGPT_PLUS.apiMode,
-        baseUrl: CHATGPT_PLUS.baseUrl,
-        headerName: CHATGPT_PLUS.headerName,
-        headerPrefix: CHATGPT_PLUS.headerPrefix,
+        apiMode: SUBSCRIPTION_AUTH.apiMode,
+        baseUrl: SUBSCRIPTION_AUTH.baseUrl,
+        headerName: SUBSCRIPTION_AUTH.headerName,
+        headerPrefix: SUBSCRIPTION_AUTH.headerPrefix,
       };
     },
   };
@@ -251,5 +251,5 @@ module.exports = {
   buildPollingUa,
   renderUserCodeBox,
   formatRemaining,
-  CHATGPT_PLUS,
+  SUBSCRIPTION_AUTH,
 };

--- a/providers/v4/chatCompletionsAdapter.ts
+++ b/providers/v4/chatCompletionsAdapter.ts
@@ -118,9 +118,9 @@ const BACKOFF_BASE_MS     = 1000;
  * Per-call `input.maxTokens` still wins over this map — callers
  * stay in control when they need a different bound.
  */
-const GROQ_MAX_OUTPUT_TOKENS = 2048;
+const RESTRICTED_MAX_OUTPUT_TOKENS = 2048;
 const MAX_TOKENS_BY_PROVIDER: Readonly<Record<string, number>> = {
-  groq: GROQ_MAX_OUTPUT_TOKENS,
+  groq: RESTRICTED_MAX_OUTPUT_TOKENS,
 };
 
 /**

--- a/providers/v4/localPromptToolsAdapter.ts
+++ b/providers/v4/localPromptToolsAdapter.ts
@@ -5,7 +5,7 @@
  * Aiden — local-first agent.
  */
 /**
- * providers/v4/ollamaPromptToolsAdapter.ts — Aiden v4.0.0
+ * providers/v4/localPromptToolsAdapter.ts — Aiden v4.0.0
  *
  * Local Ollama adapter with prompt-based fake tool calling.
  *
@@ -45,7 +45,7 @@ import {
 } from './types';
 import { ProviderError, ProviderTimeoutError } from './errors';
 
-export interface OllamaPromptToolsAdapterOptions {
+export interface LocalPromptToolsAdapterOptions {
   /** Default 'http://localhost:11434'. No trailing slash. */
   baseUrl?: string;
   /** e.g. 'llama3.2', 'qwen2.5:7b', 'gemma2:2b'. */
@@ -98,7 +98,7 @@ const DEFAULT_MAX_RETRIES = 0;
  */
 const TOOL_CALL_PATTERN = /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>|<tool_call>\s*([\s\S]*)/g;
 
-export class OllamaPromptToolsAdapter implements ProviderAdapter {
+export class LocalPromptToolsAdapter implements ProviderAdapter {
   apiMode: ApiMode = 'ollama_prompt_tools';
   private readonly baseUrl: string;
   private readonly model: string;
@@ -106,7 +106,7 @@ export class OllamaPromptToolsAdapter implements ProviderAdapter {
   private readonly timeoutMs: number;
   private readonly maxRetries: number;
 
-  constructor(options: OllamaPromptToolsAdapterOptions) {
+  constructor(options: LocalPromptToolsAdapterOptions) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
     this.model = options.model;
     this.providerName = options.providerName;

--- a/providers/v4/messageApiAdapter.ts
+++ b/providers/v4/messageApiAdapter.ts
@@ -5,7 +5,7 @@
  * Licensed under AGPL-3.0-or-later. See LICENSE.
  */
 /**
- * providers/v4/anthropicAdapter.ts
+ * providers/v4/messageApiAdapter.ts
  *
  * Speaks Anthropic's native /v1/messages wire format on behalf of Aiden's
  * provider abstraction. Used for:
@@ -44,7 +44,7 @@ import { VERSION } from '../../core/version';
 
 // ── Public options ──────────────────────────────────────────────────────────
 
-export interface AnthropicAdapterOptions {
+export interface MessageApiAdapterOptions {
   /** Defaults to 'https://api.anthropic.com'. No trailing slash. */
   baseUrl?: string;
   /** Anthropic API key, sent as `x-api-key`. */
@@ -100,12 +100,12 @@ const DEFAULT_BASE_URL    = 'https://api.anthropic.com';
 const DEFAULT_TIMEOUT_MS  = 120_000;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_MAX_TOKENS  = 4096;
-const ANTHROPIC_VERSION   = '2023-06-01';
+const MESSAGE_API_VERSION = '2023-06-01';
 const BACKOFF_BASE_MS     = 1000;
 
 // ── Adapter ────────────────────────────────────────────────────────────────
 
-export class AnthropicAdapter implements ProviderAdapter {
+export class MessageApiAdapter implements ProviderAdapter {
   readonly apiMode: ApiMode = 'anthropic_messages';
 
   private readonly endpoint:     string;
@@ -116,7 +116,7 @@ export class AnthropicAdapter implements ProviderAdapter {
   private readonly maxRetries:   number;
   private readonly extraHeaders: Record<string, string>;
 
-  constructor(opts: AnthropicAdapterOptions) {
+  constructor(opts: MessageApiAdapterOptions) {
     const baseUrl     = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
     this.endpoint     = `${baseUrl}/v1/messages`;
     this.apiKey       = opts.apiKey;
@@ -183,7 +183,7 @@ export class AnthropicAdapter implements ProviderAdapter {
   private buildHeaders(streaming: boolean): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type':      'application/json',
-      'anthropic-version': ANTHROPIC_VERSION,
+      'anthropic-version': MESSAGE_API_VERSION,
       // Honest client identity — Aiden never masquerades as another CLI.
       'user-agent':        `aiden/${VERSION}`,
       'x-api-key':         this.apiKey,

--- a/providers/v4/responseStreamAdapter.ts
+++ b/providers/v4/responseStreamAdapter.ts
@@ -5,25 +5,22 @@
  * Licensed under AGPL-3.0-or-later. See LICENSE.
  */
 /**
- * providers/v4/codexResponsesAdapter.ts
+ * providers/v4/responseStreamAdapter.ts
  *
  * Adapter for OpenAI's Responses API (`/v1/responses`). Two backends in one
  * file:
  *
  *   1. **Plain API key path** (`baseUrl` = `https://api.openai.com/v1`).
  *      Standard JSON request and response. Used when a user supplies an
- *      ordinary OpenAI API key for a Responses-API model (gpt-5-codex,
- *      gpt-4.1-mini, etc.).
+ *      ordinary OpenAI API key for a Responses-API model.
  *
- *   2. **ChatGPT Plus / Codex backend path** (`baseUrl` =
- *      `https://chatgpt.com/backend-api/codex`). Cloudflare-fronted; the
- *      backend rejects requests that don't carry the Codex CLI fingerprint
- *      (User-Agent + originator + ChatGPT-Account-ID extracted from the
- *      OAuth JWT) and rejects requests that don't stream. We force
+ *   2. **Subscription response backend path**. The backend requires
+ *      compatibility headers derived from the OAuth JWT and rejects requests
+ *      that do not stream. We force
  *      `stream: true`, parse the SSE event stream, and aggregate it into
  *      the same `ProviderCallOutput` shape callers see from path #1.
  *
- * The Codex backend's SSE stream is unreliable on the back end's part:
+ * The subscription backend's SSE stream may return incomplete terminal data:
  * `response.completed` regularly arrives with an empty `output[]` even
  * when items WERE streamed via `response.output_item.done` events. To
  * handle that we run a three-stage recovery in `aggregateSseEvents`:
@@ -34,7 +31,7 @@
  *   Stage 3: else if any `output_text.delta` accumulated, synthesise a
  *            single `message` item with the joined text.
  *
- * `AIDEN_DEBUG_CODEX=1` surfaces unknown SSE event types via `console.warn`
+ * The compatibility debug flag surfaces unknown SSE event types via `console.warn`
  * so a future API addition shows up loudly instead of being dropped.
  */
 
@@ -57,14 +54,13 @@ import {
 // ── Public surface ──────────────────────────────────────────────────────
 
 /**
- * Pull `chatgpt_account_id` from an OpenAI OAuth JWT's
- * `https://api.openai.com/auth` claim. Returns `null` on any failure
- * (malformed bearer, no claim, parse error). The Codex backend's
- * Cloudflare layer requires this header alongside the User-Agent +
+ * Pull the response account id from an OpenAI OAuth JWT claim. Returns `null`
+ * on any failure (malformed bearer, no claim, parse error). The subscription
+ * backend requires this header alongside the User-Agent +
  * originator pair; absent values are quietly omitted so a bad token
  * surfaces as an upstream 401 instead of a crash here.
  */
-export function extractChatGptAccountId(
+export function extractResponseAccountId(
   accessToken: string | null | undefined,
 ): string | null {
   if (typeof accessToken !== 'string' || accessToken.trim().length === 0) {
@@ -88,7 +84,7 @@ export function extractChatGptAccountId(
   return null;
 }
 
-export interface CodexResponsesAdapterOptions {
+export interface ResponseStreamAdapterOptions {
   /** No trailing slash. Default `https://api.openai.com/v1`. */
   baseUrl?:       string;
   apiKey:         string;
@@ -108,9 +104,10 @@ const DEFAULT_TIMEOUT_MS  = 120_000;
 const DEFAULT_MAX_RETRIES = 2;
 const BACKOFF_BASE_MS     = 1000;
 
-const CODEX_BACKEND_HOST  = 'chatgpt.com/backend-api/codex';
-const CODEX_USER_AGENT    = 'codex_cli_rs/0.0.0 (Aiden Agent)';
-const CODEX_ORIGINATOR    = 'codex_cli_rs';
+const STREAMING_BACKEND_HOST = 'chatgpt.com/backend-api/codex';
+const STREAMING_USER_AGENT   = 'codex_cli_rs/0.0.0 (Aiden Agent)';
+const STREAMING_ORIGINATOR   = 'codex_cli_rs';
+let providerCallSequence     = 0;
 
 // ── Wire-format types (private, narrow on purpose) ──────────────────────
 
@@ -194,9 +191,15 @@ interface WireRequestBody {
   [extra: string]:        unknown;
 }
 
+interface ActiveDispatch {
+  response: Response;
+  cleanup(): void;
+  classifyError(error: unknown): unknown;
+}
+
 // ── Adapter ─────────────────────────────────────────────────────────────
 
-export class CodexResponsesAdapter implements ProviderAdapter {
+export class ResponseStreamAdapter implements ProviderAdapter {
   readonly apiMode: ApiMode = 'codex_responses';
 
   private readonly endpoint:     string;
@@ -206,10 +209,10 @@ export class CodexResponsesAdapter implements ProviderAdapter {
   private readonly timeoutMs:    number;
   private readonly maxRetries:   number;
   private readonly extraHeaders: Record<string, string>;
-  private readonly isCodexHost:  boolean;
+  private readonly usesStreamingBackend: boolean;
   private readonly accountId:    string | null;
 
-  constructor(opts: CodexResponsesAdapterOptions) {
+  constructor(opts: ResponseStreamAdapterOptions) {
     const baseUrl     = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
     this.endpoint     = `${baseUrl}/responses`;
     this.apiKey       = opts.apiKey;
@@ -218,27 +221,57 @@ export class CodexResponsesAdapter implements ProviderAdapter {
     this.timeoutMs    = opts.timeoutMs  ?? DEFAULT_TIMEOUT_MS;
     this.maxRetries   = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.extraHeaders = opts.extraHeaders ?? {};
-    this.isCodexHost  = baseUrl.includes(CODEX_BACKEND_HOST);
-    // JWT account-id is only meaningful on the Codex backend. We compute
+    this.usesStreamingBackend = baseUrl.includes(STREAMING_BACKEND_HOST);
+    // JWT account-id is only meaningful on the subscription backend. We compute
     // it eagerly so a malformed token surfaces at construction (caller's
     // chosen point) rather than mid-request.
-    this.accountId    = this.isCodexHost ? extractChatGptAccountId(opts.apiKey) : null;
+    this.accountId    = this.usesStreamingBackend ? extractResponseAccountId(opts.apiKey) : null;
   }
 
   // ── Public: non-streaming entry ─────────────────────────────────────
 
   async call(input: ProviderCallInput): Promise<ProviderCallOutput> {
-    const body  = this.buildBody(input);
-    const reply = await this.dispatch(body, input.signal);
+    const diagCallId = ++providerCallSequence;
+    p2aDiag('response.call.start', {
+      diagCallId, model: this.model, streamingBackend: this.usesStreamingBackend,
+      messageCount: input.messages.length,
+      lastRole: input.messages.length > 0 ? input.messages[input.messages.length - 1].role : null,
+      aborted: input.signal?.aborted === true,
+    });
+    const body   = this.buildBody(input);
+    const active = await this.dispatch(body, input.signal, diagCallId);
+    const reply  = active.response;
 
-    // Codex backend always streams; aggregate the SSE frames into the
+    // The subscription backend always streams; aggregate SSE frames into the
     // same shape the JSON path returns. Plain api.openai.com path returns
     // JSON directly.
-    const wire = this.isCodexHost
-      ? await aggregateSseEvents(reply)
-      : await readJsonBody(reply, this.providerName);
+    p2aDiag('response.body.start', {
+      diagCallId, streamingBackend: this.usesStreamingBackend,
+      aborted: input.signal?.aborted === true,
+      pendingPromise: this.usesStreamingBackend ? 'aggregateSseEvents' : 'readJsonBody',
+    });
+    let wire: WireResponseShape;
+    try {
+      wire = this.usesStreamingBackend
+        ? await aggregateSseEvents(reply)
+        : await readJsonBody(reply, this.providerName);
+    } catch (error) {
+      throw active.classifyError(error);
+    } finally {
+      active.cleanup();
+    }
+    p2aDiag('response.body.complete', {
+      diagCallId, status: wire.status ?? null,
+      outputItems: Array.isArray(wire.output) ? wire.output.length : 0,
+      aborted: input.signal?.aborted === true,
+    });
 
-    return decodeWireResponse(wire, this.providerName);
+    const decoded = decodeWireResponse(wire, this.providerName);
+    p2aDiag('response.call.complete', {
+      diagCallId, finishReason: decoded.finishReason,
+      toolCalls: decoded.toolCalls.map((call) => ({ id: call.id, name: call.name })),
+    });
+    return decoded;
   }
 
   // ── Streaming entry (currently bridges to non-streaming) ────────────
@@ -267,7 +300,7 @@ export class CodexResponsesAdapter implements ProviderAdapter {
     if (instructions)                  body.instructions  = instructions;
     // Phase v4.1.1-oauth-fix Phase 5: `tool_choice` and
     // `parallel_tool_calls` are only meaningful when tools are present.
-    // OpenAI Codex returns HTTP 400 (empty body) for `tool_choice: 'auto'`
+    // The streaming backend returns HTTP 400 for `tool_choice: 'auto'`
     // without a `tools` field — surfaced by `aiden doctor --providers`'s
     // no-tools liveness probe.
     if (input.tools && input.tools.length > 0) {
@@ -278,13 +311,13 @@ export class CodexResponsesAdapter implements ProviderAdapter {
     if (typeof input.temperature === 'number') {
       (body as Record<string, unknown>).temperature = input.temperature;
     }
-    // Codex backend rejects max_output_tokens; only the regular Responses
+    // The streaming backend rejects max_output_tokens; only regular Responses
     // API accepts it.
-    if (!this.isCodexHost && input.maxTokens !== undefined) {
+    if (!this.usesStreamingBackend && input.maxTokens !== undefined) {
       body.max_output_tokens = input.maxTokens;
     }
-    // Codex backend requires stream:true (returns 400 otherwise).
-    if (this.isCodexHost) {
+    // The streaming backend requires stream:true (returns 400 otherwise).
+    if (this.usesStreamingBackend) {
       body.stream = true;
     }
     if (input.extraBody) Object.assign(body, input.extraBody);
@@ -298,9 +331,9 @@ export class CodexResponsesAdapter implements ProviderAdapter {
       'Content-Type':  'application/json',
       'Authorization': `Bearer ${this.apiKey}`,
     };
-    if (this.isCodexHost) {
-      headers['User-Agent'] = CODEX_USER_AGENT;
-      headers['originator'] = CODEX_ORIGINATOR;
+    if (this.usesStreamingBackend) {
+      headers['User-Agent'] = STREAMING_USER_AGENT;
+      headers['originator'] = STREAMING_ORIGINATOR;
       headers['Accept']     = 'text/event-stream';
       if (this.accountId) {
         headers['ChatGPT-Account-ID'] = this.accountId;
@@ -312,7 +345,8 @@ export class CodexResponsesAdapter implements ProviderAdapter {
   private async dispatch(
     body: WireRequestBody,
     externalSignal?: AbortSignal,
-  ): Promise<Response> {
+    diagCallId?: number,
+  ): Promise<ActiveDispatch> {
     const headers    = this.buildHeaders();
     const serialised = JSON.stringify(body);
     const totalTries = this.maxRetries + 1;
@@ -321,39 +355,72 @@ export class CodexResponsesAdapter implements ProviderAdapter {
 
     for (let attempt = 0; attempt < totalTries; attempt++) {
       const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+      let abortCause: 'timeout' | 'external' | null = null;
+      let cleaned = false;
+      const abortFor = (cause: 'timeout' | 'external'): void => {
+        if (abortCause !== null) return;
+        abortCause = cause;
+        controller.abort();
+      };
+      const timer = setTimeout(() => abortFor('timeout'), this.timeoutMs);
       // v4.6 prep — forward external abort into the internal controller.
       // External aborts surface as raw AbortError so AidenAgent routes
       // them as 'interrupted' rather than retrying as ProviderTimeoutError.
       let externalAbortHandler: (() => void) | null = null;
       if (externalSignal) {
         if (externalSignal.aborted) {
-          controller.abort();
+          abortFor('external');
         } else {
-          externalAbortHandler = () => controller.abort();
+          externalAbortHandler = () => abortFor('external');
           externalSignal.addEventListener('abort', externalAbortHandler, { once: true });
         }
       }
 
+      const cleanup = (): void => {
+        if (cleaned) return;
+        cleaned = true;
+        clearTimeout(timer);
+        if (externalAbortHandler && externalSignal) {
+          externalSignal.removeEventListener('abort', externalAbortHandler);
+        }
+        p2aDiag('response.lifecycle.cleanup', {
+          diagCallId, attempt: attempt + 1, abortCause,
+        });
+      };
+      const classifyError = (error: unknown): unknown => {
+        if (abortCause === 'external') return asAbortError(error);
+        if (abortCause === 'timeout') {
+          return new ProviderTimeoutError(this.providerName, this.timeoutMs);
+        }
+        return error;
+      };
+
       let response: Response;
       try {
+        p2aDiag('response.fetch.start', {
+          diagCallId, attempt: attempt + 1, timeoutMs: this.timeoutMs,
+          aborted: externalSignal?.aborted === true,
+          pendingPromise: 'fetchHeaders',
+        });
         response = await fetch(this.endpoint, {
           method:  'POST',
           headers,
           body:    serialised,
           signal:  controller.signal,
         });
+        p2aDiag('response.headers.received', {
+          diagCallId, attempt: attempt + 1,
+          status: response.status, ok: response.ok,
+          aborted: externalSignal?.aborted === true,
+        });
       } catch (err: any) {
-        clearTimeout(timer);
-        if (externalAbortHandler && externalSignal) {
-          externalSignal.removeEventListener('abort', externalAbortHandler);
+        const classified = classifyError(err);
+        cleanup();
+        if ((classified as { name?: unknown })?.name === 'AbortError') {
+          throw classified;
         }
-        if (err?.name === 'AbortError') {
-          // v4.6 prep — external abort takes priority over internal timeout.
-          if (externalSignal?.aborted) {
-            throw err;
-          }
-          lastErr = new ProviderTimeoutError(this.providerName, this.timeoutMs);
+        if (classified instanceof ProviderTimeoutError) {
+          lastErr = classified;
         } else {
           lastErr = new ProviderError(
             `Network failure calling ${this.providerName}: ${err?.message ?? err}`,
@@ -369,15 +436,17 @@ export class CodexResponsesAdapter implements ProviderAdapter {
         }
         throw lastErr;
       }
-      clearTimeout(timer);
-      if (externalAbortHandler && externalSignal) {
-        externalSignal.removeEventListener('abort', externalAbortHandler);
-      }
-
-      if (response.ok) return response;
+      if (response.ok) return { response, cleanup, classifyError };
 
       const status = response.status;
-      const raw    = await safeReadBody(response);
+      let raw: unknown;
+      try {
+        raw = await safeReadBody(response);
+      } catch (error) {
+        throw classifyError(error);
+      } finally {
+        cleanup();
+      }
 
       if (status === 429) {
         if (attempt < totalTries - 1) {
@@ -417,7 +486,23 @@ export class CodexResponsesAdapter implements ProviderAdapter {
   }
 }
 
+function p2aDiag(event: string, data: Record<string, unknown>): void {
+  if (process.env.AIDEN_P2A_DIAG !== '1') return;
+  try {
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
+  } catch { /* diagnostics must never affect provider calls */ }
+}
+
 // ── Encoders ────────────────────────────────────────────────────────────
+
+function asAbortError(error: unknown): Error {
+  if (error instanceof Error && error.name === 'AbortError') return error;
+  const abort = new Error('Provider request cancelled by caller');
+  abort.name = 'AbortError';
+  (abort as Error & { cause?: unknown }).cause = error;
+  return abort;
+}
 
 function toWireTool(t: ToolSchema): WireFunctionTool {
   return {
@@ -595,14 +680,14 @@ function parseToolArgs(s: string): Record<string, unknown> {
   } catch {
     // eslint-disable-next-line no-console
     console.warn(
-      '[codexResponsesAdapter] function_call.arguments is not valid JSON; ' +
+      '[responseStreamAdapter] function_call.arguments is not valid JSON; ' +
       'falling back to {}',
     );
     return {};
   }
 }
 
-// ── SSE aggregation (Codex backend) ─────────────────────────────────────
+// ── SSE aggregation ─────────────────────────────────────────────────────
 //
 // Recognised event types:
 //
@@ -627,7 +712,7 @@ interface AggregationState {
 async function aggregateSseEvents(reply: Response): Promise<WireResponseShape> {
   if (!reply.body) {
     throw new ProviderError(
-      'Codex stream had no body',
+      'Responses stream had no body',
       'codex_responses',
       reply.status,
       undefined,
@@ -658,7 +743,7 @@ async function aggregateSseEvents(reply: Response): Promise<WireResponseShape> {
     // composeMessage appends it ONCE → "...failure: <reason>". Passing it in
     // both places is what produced the doubled "failure: failed: failed".
     throw new ProviderError(
-      'Codex stream reported failure',
+      'Responses stream reported failure',
       'codex_responses',
       undefined,
       state.failed,
@@ -715,7 +800,7 @@ async function aggregateSseEvents(reply: Response): Promise<WireResponseShape> {
 }
 
 /**
- * Pull the REAL failure reason from a Codex `response.failed` / error event.
+ * Pull the real failure reason from a `response.failed` / error event.
  * The Responses API carries the cause at `response.error.{message,code}` — a
  * bare top-level `error` or a `response.status` of "failed" is NOT a reason.
  * We dig the actual pockets in priority order, collapse an accidental self-chant
@@ -814,7 +899,7 @@ function handleSseEvent(
     default:
       if (debug) {
         // eslint-disable-next-line no-console
-        console.warn(`[codexResponsesAdapter] unknown SSE event: ${type}`);
+        console.warn(`[responseStreamAdapter] unknown SSE event: ${type}`);
       }
   }
 }

--- a/providers/v4/runtimeResolver.ts
+++ b/providers/v4/runtimeResolver.ts
@@ -44,9 +44,9 @@ import {
 } from './modelCatalog';
 import { CredentialResolver } from './credentialResolver';
 import { ChatCompletionsAdapter } from './chatCompletionsAdapter';
-import { AnthropicAdapter } from './anthropicAdapter';
-import { CodexResponsesAdapter } from './codexResponsesAdapter';
-import { OllamaPromptToolsAdapter } from './ollamaPromptToolsAdapter';
+import { MessageApiAdapter } from './messageApiAdapter';
+import { ResponseStreamAdapter } from './responseStreamAdapter';
+import { LocalPromptToolsAdapter } from './localPromptToolsAdapter';
 import { getModelDefaults } from './modelDefaults';
 // v4.14.x — every adapter the factory hands out is wrapped so a shared message
 // preflight runs before ANY provider call. The single seam; no caller can skip it.
@@ -156,7 +156,7 @@ export class RuntimeResolver {
         if (!credentials.apiKey) {
           throw missingKeyError(entry);
         }
-        return withMessagePreflight(new AnthropicAdapter({
+        return withMessagePreflight(new MessageApiAdapter({
           baseUrl,
           apiKey: credentials.apiKey,
           model: model.id,
@@ -168,7 +168,7 @@ export class RuntimeResolver {
         if (!credentials.apiKey) {
           throw missingKeyError(entry);
         }
-        return withMessagePreflight(new CodexResponsesAdapter({
+        return withMessagePreflight(new ResponseStreamAdapter({
           baseUrl,
           apiKey: credentials.apiKey,
           model: model.id,
@@ -177,7 +177,7 @@ export class RuntimeResolver {
         }));
 
       case 'ollama_prompt_tools':
-        return withMessagePreflight(new OllamaPromptToolsAdapter({
+        return withMessagePreflight(new LocalPromptToolsAdapter({
           baseUrl,
           model: model.id,
           providerName: entry.id,
@@ -326,9 +326,9 @@ export class RuntimeResolver {
         // No usable auth.json entry — surface a clearer error for OAuth-only
         // providers and fall through for paid providers that still might
         // succeed via a missing env var (handled by the missingKeyError
-        // below). Phase 21 #5: the canonical OAuth provider (chatgpt-plus)
+        // below). Phase 21 #5: the canonical subscription OAuth provider
         // hits the entry.oauth fast-path above, so this
-        // legacy branch only fires for raw anthropic_messages/codex_responses
+        // legacy branch only fires for raw protocol apiMode values
         // entries that lack oauth.providerId — i.e. nothing in the live
         // registry today, kept as a safety net for custom-config providers.
         if (entry.apiKeyEnvVar === null) {

--- a/scripts/smoke-phase16b2.ts
+++ b/scripts/smoke-phase16b2.ts
@@ -107,15 +107,15 @@ async function main(): Promise<void> {
       /NEVER emit `<function=/.test(llamaPrompt),
   );
 
-  const claudePrompt = await pb.build({
+  const providerPrompt = await pb.build({
     paths,
     modelId: 'claude-sonnet-4-7',
     skipFilesystem: true,
   });
   step(
     'PromptBuilder leaves Claude prompt untouched',
-    !/OpenAI tool_calls/.test(claudePrompt) &&
-      !/<function=/.test(claudePrompt),
+    !/OpenAI tool_calls/.test(providerPrompt) &&
+      !/<function=/.test(providerPrompt),
   );
 
   // ── 4. Legacy <function=...> recovery parse ─────────────────────────

--- a/scripts/smoke-v4.1-attribution-sweep.ts
+++ b/scripts/smoke-v4.1-attribution-sweep.ts
@@ -83,7 +83,7 @@ const ALLOWLIST: Allowlist[] = [
     reason: 'Literal NousResearch model IDs and display names',
   },
   {
-    path:   'providers/v4/ollamaPromptToolsAdapter.ts',
+    path:   'providers/v4/localPromptToolsAdapter.ts',
     reason: 'Hermes-2-Pro is the standard VLLM/Llama tool-call format name',
   },
   {

--- a/scripts/test-suite/behavioral/03-web-research.ts
+++ b/scripts/test-suite/behavioral/03-web-research.ts
@@ -37,10 +37,10 @@ export async function run(): Promise<GroupSummary> {
     const reply = await callAiden(`Search for "Anthropic Claude" and summarize the top 3 results.`)
     const lower = reply.toLowerCase()
     const hasAnthropic = lower.includes('anthropic')
-    const hasClaude    = lower.includes('claude')
+    const hasCompatibleProvider = lower.includes('claude')
     const hasNumbers   = /\b[123]\b|first|second|third|one|two|three/.test(lower)
 
-    if (!hasAnthropic && !hasClaude) return `response doesn't mention Anthropic or Claude: ${reply.slice(0, 150)}`
+    if (!hasAnthropic && !hasCompatibleProvider) return `response doesn't mention Anthropic or Claude: ${reply.slice(0, 150)}`
     if (reply.trim().split('\n').length < 2 && reply.length < 100) return `response too thin — not a summary: ${reply.slice(0, 150)}`
   }))
 

--- a/scripts/test-suite/regression/c9-responder-custom-routing.ts
+++ b/scripts/test-suite/regression/c9-responder-custom-routing.ts
@@ -5,7 +5,7 @@
 // Proves C9 fix: respondWithResults now has an explicit
 // `providerName === 'custom'` branch that resolves baseUrl
 // from config instead of falling through to
-// OPENAI_COMPAT_ENDPOINTS (which has no 'custom' entry,
+// COMPATIBLE_API_ENDPOINTS (which has no 'custom' entry,
 // causing Together API key to be sent to Groq URL → 401).
 //
 // Zero I/O — pure source-text inspection (no server, no LLM).
@@ -59,18 +59,18 @@ export async function groupU(): Promise<GroupSummary> {
       })()
     : ''
 
-  // ── U-02: custom branch uses customBaseUrl (not OPENAI_COMPAT_ENDPOINTS) ─
+  // ── U-02: custom branch uses customBaseUrl (not COMPATIBLE_API_ENDPOINTS) ─
   results.push(await runTest('U-02', 'U',
     'custom branch resolves customBaseUrl from config', () => {
       if (!src) return 'Could not read core/agentLoop.ts'
       if (!customBlock) return 'skipped — custom branch not found'
       if (!customBlock.includes('customBaseUrl'))
-        return 'custom branch does not use customBaseUrl — may still be using OPENAI_COMPAT_ENDPOINTS'
-      // Check that OPENAI_COMPAT_ENDPOINTS only appears in comments (lines starting with //), not code
+        return 'custom branch does not use customBaseUrl — may still be using COMPATIBLE_API_ENDPOINTS'
+      // Check that COMPATIBLE_API_ENDPOINTS only appears in comments (lines starting with //), not code
       const codeLines = customBlock.split('\n').filter(l => !l.trim().startsWith('//'))
       const codeOnly  = codeLines.join('\n')
-      if (codeOnly.includes('OPENAI_COMPAT_ENDPOINTS'))
-        return 'custom branch code (non-comment) references OPENAI_COMPAT_ENDPOINTS — should use customBaseUrl'
+      if (codeOnly.includes('COMPATIBLE_API_ENDPOINTS'))
+        return 'custom branch code (non-comment) references COMPATIBLE_API_ENDPOINTS — should use customBaseUrl'
     }
   ))
 
@@ -92,25 +92,25 @@ export async function groupU(): Promise<GroupSummary> {
       if (!src) return 'Could not read core/agentLoop.ts'
       if (customBranchStart === -1) return 'skipped — custom branch not found'
       const afterCustom = responderSection.slice(customBranchStart)
-      const genericElseIdx = afterCustom.indexOf('OPENAI_COMPAT_ENDPOINTS[providerName]')
+      const genericElseIdx = afterCustom.indexOf('COMPATIBLE_API_ENDPOINTS[providerName]')
       if (genericElseIdx === -1)
-        return 'Could not find generic OPENAI_COMPAT_ENDPOINTS fallback after custom branch'
+        return 'Could not find generic COMPATIBLE_API_ENDPOINTS fallback after custom branch'
       if (genericElseIdx < 50)
-        return 'OPENAI_COMPAT_ENDPOINTS fallback is too close to custom branch — custom may not be a separate block'
+        return 'COMPATIBLE_API_ENDPOINTS fallback is too close to custom branch — custom may not be a separate block'
       const between = afterCustom.slice(0, genericElseIdx)
       if (!between.includes('} else {'))
-        return 'No } else { between custom branch and OPENAI_COMPAT_ENDPOINTS — custom not properly separated'
+        return 'No } else { between custom branch and COMPATIBLE_API_ENDPOINTS — custom not properly separated'
     }
   ))
 
   // ── U-05: generic else fallback to groq still preserved ───────────────
   results.push(await runTest('U-05', 'U',
-    'generic else fallback to OPENAI_COMPAT_ENDPOINTS.groq preserved', () => {
+    'generic else fallback to COMPATIBLE_API_ENDPOINTS.groq preserved', () => {
       if (!src) return 'Could not read core/agentLoop.ts'
       if (customBranchStart === -1) return 'skipped — custom branch not found'
       const afterCustom = responderSection.slice(customBranchStart)
-      if (!afterCustom.includes('OPENAI_COMPAT_ENDPOINTS[providerName] || OPENAI_COMPAT_ENDPOINTS.groq'))
-        return 'generic else no longer has OPENAI_COMPAT_ENDPOINTS[providerName] || OPENAI_COMPAT_ENDPOINTS.groq fallback'
+      if (!afterCustom.includes('COMPATIBLE_API_ENDPOINTS[providerName] || COMPATIBLE_API_ENDPOINTS.groq'))
+        return 'generic else no longer has COMPATIBLE_API_ENDPOINTS[providerName] || COMPATIBLE_API_ENDPOINTS.groq fallback'
     }
   ))
 

--- a/scripts/test-suite/regression/c9b-streaming-url-helper.ts
+++ b/scripts/test-suite/regression/c9b-streaming-url-helper.ts
@@ -5,7 +5,7 @@
 // Proves C9b fix: resolveStreamingUrl() helper centralises
 // URL resolution for all providers. All 3 fetch sites in
 // respondWithResults now use the helper — no raw
-// OPENAI_COMPAT_ENDPOINTS lookups remain.
+// COMPATIBLE_API_ENDPOINTS lookups remain.
 //
 // Zero I/O — pure logic + source-text inspection.
 // ============================================================
@@ -51,7 +51,7 @@ export async function groupT(): Promise<GroupSummary> {
     bail('T-04', "providerName='custom' resolves baseUrl from config")
     bail('T-05', "providerName='custom' falls back to providers.apis")
     bail('T-06', 'unknown provider returns groq fallback')
-    bail('T-07', 'respondWithResults has zero raw OPENAI_COMPAT_ENDPOINTS[providerName] lookups')
+    bail('T-07', 'respondWithResults has zero raw COMPATIBLE_API_ENDPOINTS[providerName] lookups')
     results.forEach(printResult)
     return summarize('T', 'C9b streaming URL helper', results)
   }
@@ -108,9 +108,9 @@ export async function groupT(): Promise<GroupSummary> {
     }
   ))
 
-  // ── T-07: source-text — no raw OPENAI_COMPAT_ENDPOINTS[providerName] in respondWithResults ─
+  // ── T-07: source-text — no raw COMPATIBLE_API_ENDPOINTS[providerName] in respondWithResults ─
   results.push(await runTest('T-07', 'T',
-    'respondWithResults has zero raw OPENAI_COMPAT_ENDPOINTS[providerName] lookups', () => {
+    'respondWithResults has zero raw COMPATIBLE_API_ENDPOINTS[providerName] lookups', () => {
       const src = (() => {
         try { return fs.readFileSync(path.join(CWD, 'core', 'agentLoop.ts'), 'utf-8') } catch { return null }
       })()
@@ -123,18 +123,18 @@ export async function groupT(): Promise<GroupSummary> {
       // Grab a generous window covering the entire function (~800 lines)
       const fnBody = src.slice(Math.max(0, anchor - 500), anchor + 8000)
 
-      // Check for raw OPENAI_COMPAT_ENDPOINTS[providerName] or
-      // OPENAI_COMPAT_ENDPOINTS[nextCloud.providerName] or
-      // OPENAI_COMPAT_ENDPOINTS[cloudFallback.providerName]
+      // Check for raw COMPATIBLE_API_ENDPOINTS[providerName] or
+      // COMPATIBLE_API_ENDPOINTS[nextCloud.providerName] or
+      // COMPATIBLE_API_ENDPOINTS[cloudFallback.providerName]
       // These should all be replaced by resolveStreamingUrl calls.
       // Exclude comment lines (starting with //)
       const codeLines = fnBody.split('\n').filter(l => !l.trim().startsWith('//'))
       const codeOnly  = codeLines.join('\n')
 
-      const rawLookups = codeOnly.match(/OPENAI_COMPAT_ENDPOINTS\[\w+\.\w+\]/g) ||
-                         codeOnly.match(/OPENAI_COMPAT_ENDPOINTS\[providerName\]/g)
+      const rawLookups = codeOnly.match(/COMPATIBLE_API_ENDPOINTS\[\w+\.\w+\]/g) ||
+                         codeOnly.match(/COMPATIBLE_API_ENDPOINTS\[providerName\]/g)
       if (rawLookups && rawLookups.length > 0)
-        return `Found ${rawLookups.length} raw OPENAI_COMPAT_ENDPOINTS lookup(s) in respondWithResults: ${rawLookups.join(', ')}`
+        return `Found ${rawLookups.length} raw COMPATIBLE_API_ENDPOINTS lookup(s) in respondWithResults: ${rawLookups.join(', ')}`
     }
   ))
 

--- a/tests/e2e/masterTestSuite.ts
+++ b/tests/e2e/masterTestSuite.ts
@@ -909,9 +909,9 @@ async function runPart3(): Promise<PartResults> {
 
   results.push(await run('CHAT-05', '"are you ChatGPT" → identifies as Aiden, not ChatGPT', async () => {
     const r = await chat('are you ChatGPT?')
-    const isChatGPT = /yes.*chatgpt|i am chatgpt/i.test(r.response)
+    const claimsExternalIdentity = /yes.*chatgpt|i am chatgpt/i.test(r.response)
     const isAiden   = /aiden|devos|not chatgpt|no.*chatgpt/i.test(r.response)
-    const ok = !isChatGPT && isAiden
+    const ok = !claimsExternalIdentity && isAiden
     return { verdict: ok ? 'PASS' : isAiden ? 'PASS' : 'FAIL', score: ok ? 1 : 0, durationMs: r.durationMs,
       detail: `"${r.response.slice(0, 100)}"` }
   }))

--- a/tests/tier3-quality.ps1
+++ b/tests/tier3-quality.ps1
@@ -35,12 +35,12 @@ if (-not $ANTHROPIC_KEY) {
 }
 
 if (-not $ANTHROPIC_KEY) {
-    $claudeConfig = "$env:USERPROFILE\.claude\config.json"
-    if (Test-Path $claudeConfig) {
+    $externalToolConfig = "$env:USERPROFILE\.claude\config.json"
+    if (Test-Path $externalToolConfig) {
         try {
-            $cfg = Get-Content $claudeConfig -Raw | ConvertFrom-Json
+            $cfg = Get-Content $externalToolConfig -Raw | ConvertFrom-Json
             $ANTHROPIC_KEY = $cfg.anthropic_api_key
-            if ($ANTHROPIC_KEY) { Write-Host "  Found key in $claudeConfig" -ForegroundColor DarkGray }
+            if ($ANTHROPIC_KEY) { Write-Host "  Found key in $externalToolConfig" -ForegroundColor DarkGray }
         } catch { }
     }
 }

--- a/tests/v4/auth/setupWizardOAuth.test.ts
+++ b/tests/v4/auth/setupWizardOAuth.test.ts
@@ -5,7 +5,7 @@
  * OAuthProviderRuntime. These tests stub the plugin's buildProvider to
  * return a synthetic OAuthProvider so we never touch network or load
  * the real ChatGPT plugin (its OAuth fixtures are tested separately in
- * chatgptPlusPlugin.test.ts).
+ * subscriptionPlugin.test.ts).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
@@ -124,7 +124,7 @@ function scriptedPrompts(answers: {
   };
 }
 
-const chatgptPlusIdx = PROVIDERS.findIndex((p) => p.id === 'chatgpt-plus') + 1;
+const subscriptionProviderIndex = PROVIDERS.findIndex((p) => p.id === 'chatgpt-plus') + 1;
 
 describe('setup wizard — OAuth provider integration (kind: pro)', () => {
   it('46. user picks chatgpt-plus → device-code login → config + tokens persisted', async () => {
@@ -151,7 +151,7 @@ describe('setup wizard — OAuth provider integration (kind: pro)', () => {
         paths,
         display: new Display(),
         // Phase 30.2.1: chatgpt-plus moved to index [10] in the reordered list.
-        prompts: fakePrompts({ providerIndex: chatgptPlusIdx, confirm: true }),
+        prompts: fakePrompts({ providerIndex: subscriptionProviderIndex, confirm: true }),
         skipValidation: true,
       });
       expect(result.status).toBe('configured');

--- a/tests/v4/auth/subscriptionPlugin.test.ts
+++ b/tests/v4/auth/subscriptionPlugin.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { OAuthUserAgent } from '../../../core/v4/auth/providerAuth';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const chatgptPlus = require('../../../plugins/aiden-plugin-chatgpt-plus/index.js');
+const subscriptionPlugin = require('../../../plugins/aiden-plugin-chatgpt-plus/index.js');
 
 function fakeUa(): OAuthUserAgent & {
   log: ReturnType<typeof vi.fn>;
@@ -39,7 +39,7 @@ function fakeAuth(overrides: Partial<any> = {}) {
 
 describe('aiden-plugin-chatgpt-plus: provider shape', () => {
   it('33. provider exposes the right id, displayName, runtime descriptor', () => {
-    const provider = chatgptPlus.buildProvider(fakeAuth());
+    const provider = subscriptionPlugin.buildProvider(fakeAuth());
     expect(provider.id).toBe('chatgpt-plus');
     expect(provider.displayName).toBe('ChatGPT Plus');
     const desc = provider.describeRuntime!();
@@ -49,20 +49,20 @@ describe('aiden-plugin-chatgpt-plus: provider shape', () => {
   });
 
   it('34. constants match the verified upstream values', () => {
-    expect(chatgptPlus.CHATGPT_PLUS.clientId).toBe(
+    expect(subscriptionPlugin.SUBSCRIPTION_AUTH.clientId).toBe(
       'app_EMoamEEZ73f0CkXaXp7hrann',
     );
-    expect(chatgptPlus.CHATGPT_PLUS.issuer).toBe('https://auth.openai.com');
-    expect(chatgptPlus.CHATGPT_PLUS.baseUrl).toBe(
+    expect(subscriptionPlugin.SUBSCRIPTION_AUTH.issuer).toBe('https://auth.openai.com');
+    expect(subscriptionPlugin.SUBSCRIPTION_AUTH.baseUrl).toBe(
       'https://chatgpt.com/backend-api/codex',
     );
-    expect(chatgptPlus.CHATGPT_PLUS.apiMode).toBe('codex_responses');
+    expect(subscriptionPlugin.SUBSCRIPTION_AUTH.apiMode).toBe('codex_responses');
   });
 });
 
 describe('aiden-plugin-chatgpt-plus: UX helpers', () => {
   it('35. renderUserCodeBox produces a 3-line ASCII box around the code', () => {
-    const lines = chatgptPlus.renderUserCodeBox('ABCD-1234');
+    const lines = subscriptionPlugin.renderUserCodeBox('ABCD-1234');
     expect(lines).toHaveLength(3);
     expect(lines[0].startsWith('┌')).toBe(true);
     expect(lines[0].endsWith('┐')).toBe(true);
@@ -76,15 +76,15 @@ describe('aiden-plugin-chatgpt-plus: UX helpers', () => {
   });
 
   it('36. formatRemaining produces "Mm Ss"', () => {
-    expect(chatgptPlus.formatRemaining(0)).toBe('0m 0s');
-    expect(chatgptPlus.formatRemaining(330_000)).toBe('5m 30s');
-    expect(chatgptPlus.formatRemaining(60_000)).toBe('1m 0s');
+    expect(subscriptionPlugin.formatRemaining(0)).toBe('0m 0s');
+    expect(subscriptionPlugin.formatRemaining(330_000)).toBe('5m 30s');
+    expect(subscriptionPlugin.formatRemaining(60_000)).toBe('1m 0s');
   });
 
   it('37. buildPollingUa fires the "still waiting" reminder once after 5 min', async () => {
     const outer = fakeUa();
     let now = 0;
-    const wrapped = chatgptPlus.buildPollingUa(
+    const wrapped = subscriptionPlugin.buildPollingUa(
       outer,
       15 * 60 * 1000,
       () => now,
@@ -110,7 +110,7 @@ describe('aiden-plugin-chatgpt-plus: UX helpers', () => {
 describe('aiden-plugin-chatgpt-plus: login() flow', () => {
   it('38. delegates to runDeviceCodeFlow with the right config', async () => {
     const auth = fakeAuth();
-    const provider = chatgptPlus.buildProvider(auth);
+    const provider = subscriptionPlugin.buildProvider(auth);
     const ua = fakeUa();
     const r = await provider.login(ua);
     expect(r.accessToken).toBe('AT');
@@ -131,7 +131,7 @@ describe('aiden-plugin-chatgpt-plus: login() flow', () => {
         return { accessToken: 'AT', refreshToken: null, expiresInSeconds: 0 };
       }),
     });
-    const provider = chatgptPlus.buildProvider(auth);
+    const provider = subscriptionPlugin.buildProvider(auth);
     const ua = fakeUa();
     await provider.login(ua);
     const text = ua.log.mock.calls.map((c) => c[0] as string).join('\n');
@@ -148,7 +148,7 @@ describe('aiden-plugin-chatgpt-plus: login() flow', () => {
         throw new Error('Device-code login timed out (15 minutes)');
       }),
     });
-    const provider = chatgptPlus.buildProvider(auth);
+    const provider = subscriptionPlugin.buildProvider(auth);
     const ua = fakeUa();
     await expect(provider.login(ua)).rejects.toThrow(
       /Code expired.*\/auth login chatgpt-plus/,
@@ -161,7 +161,7 @@ describe('aiden-plugin-chatgpt-plus: login() flow', () => {
         throw new Error('Device-code request failed: HTTP 503');
       }),
     });
-    const provider = chatgptPlus.buildProvider(auth);
+    const provider = subscriptionPlugin.buildProvider(auth);
     const ua = fakeUa();
     await expect(provider.login(ua)).rejects.toThrow(
       /HTTP 503.*\/auth login chatgpt-plus/,
@@ -177,7 +177,7 @@ describe('aiden-plugin-chatgpt-plus: login() flow', () => {
         extras: { email: 'shiva@example.com' },
       })),
     });
-    const provider = chatgptPlus.buildProvider(auth);
+    const provider = subscriptionPlugin.buildProvider(auth);
     const ua = fakeUa();
     await provider.login(ua);
     const text = ua.log.mock.calls.map((c) => c[0] as string).join('\n');
@@ -186,7 +186,7 @@ describe('aiden-plugin-chatgpt-plus: login() flow', () => {
 
   it('43. refresh() POSTs to /oauth/token with form-encoded body', async () => {
     const auth = fakeAuth();
-    const provider = chatgptPlus.buildProvider(auth);
+    const provider = subscriptionPlugin.buildProvider(auth);
     await provider.refresh('OLD-RT');
     const cfg = auth.refreshTokens.mock.calls[0][1];
     expect(cfg.tokenUrl).toBe('https://auth.openai.com/oauth/token');

--- a/tests/v4/cli/activityLifecycle.test.ts
+++ b/tests/v4/cli/activityLifecycle.test.ts
@@ -24,6 +24,18 @@ function makeTtyDisplay(): { display: Display; output: () => string } {
   };
 }
 
+function makeTtyDisplayWithFrames(): { display: Display; frames: string[] } {
+  const frames: string[] = [];
+  const out = new Writable({
+    write(chunk, _encoding, done) { frames.push(chunk.toString()); done(); },
+  }) as unknown as NodeJS.WriteStream;
+  Object.defineProperty(out, 'isTTY', { value: true });
+  return {
+    display: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out }),
+    frames,
+  };
+}
+
 function makeRow(): ToolRowHandle {
   return {
     ok: vi.fn(), fail: vi.fn(), degraded: vi.fn(), retry: vi.fn(),
@@ -42,6 +54,25 @@ function result(id: string, name: string, payload: unknown): ToolCallResult {
 }
 
 describe('central CLI activity lifecycle', () => {
+  it('replaces each timer frame with one atomic terminal write', () => {
+    vi.useFakeTimers();
+    try {
+      const { display, frames } = makeTtyDisplayWithFrames();
+      const row = display.toolRow('file_operations', { path: 'report.md' });
+      const afterStart = frames.length;
+      vi.advanceTimersByTime(1_000);
+      expect(frames.length - afterStart).toBe(1);
+      expect(frames.at(-1)).toMatch(/^\x1b\[1A\x1b\[2K\r[^\r]*\n$/);
+
+      const beforeSettle = frames.length;
+      row.ok(1_000);
+      expect(frames.length - beforeSettle).toBe(1);
+      expect(frames.at(-1)).toMatch(/^\x1b\[1A\x1b\[2K\r[^\r]*\n$/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('stops the real row timer while a modal owns the terminal', () => {
     vi.useFakeTimers();
     try {

--- a/tests/v4/cli/activityLifecycle.test.ts
+++ b/tests/v4/cli/activityLifecycle.test.ts
@@ -1,0 +1,153 @@
+import { Writable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { CliCallbacks, type PromptApi } from '../../../cli/v4/callbacks';
+import { Display, type ToolRowHandle } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import type { ToolCallRequest, ToolCallResult } from '../../../providers/v4/types';
+
+function makeDisplay(): Display {
+  const out = new Writable({
+    write(_chunk, _encoding, done) { done(); },
+  }) as unknown as NodeJS.WriteStream;
+  return new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out });
+}
+
+function makeTtyDisplay(): { display: Display; output: () => string } {
+  const chunks: string[] = [];
+  const out = new Writable({
+    write(chunk, _encoding, done) { chunks.push(chunk.toString()); done(); },
+  }) as unknown as NodeJS.WriteStream;
+  Object.defineProperty(out, 'isTTY', { value: true });
+  return {
+    display: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: out }),
+    output: () => chunks.join(''),
+  };
+}
+
+function makeRow(): ToolRowHandle {
+  return {
+    ok: vi.fn(), fail: vi.fn(), degraded: vi.fn(), retry: vi.fn(),
+    blocked: vi.fn(), emptyRetry: vi.fn(), emptyFail: vi.fn(), cancel: vi.fn(),
+    dismiss: vi.fn(), pause: vi.fn(), resume: vi.fn(),
+    isActive: vi.fn(() => true),
+  };
+}
+
+function call(id: string, name: string): ToolCallRequest {
+  return { id, name, arguments: {} };
+}
+
+function result(id: string, name: string, payload: unknown): ToolCallResult {
+  return { id, name, result: payload };
+}
+
+describe('central CLI activity lifecycle', () => {
+  it('stops the real row timer while a modal owns the terminal', () => {
+    vi.useFakeTimers();
+    try {
+      const { display, output } = makeTtyDisplay();
+      const row = display.toolRow('clarify', { question: 'topic?' });
+      row.pause();
+      const pausedOutput = output();
+      vi.advanceTimersByTime(5_000);
+      expect(output()).toBe(pausedOutput);
+
+      row.resume();
+      const resumedOutput = output();
+      vi.advanceTimersByTime(1_000);
+      expect(output().length).toBeGreaterThan(resumedOutput.length);
+      row.dismiss();
+      const settledOutput = output();
+      vi.advanceTimersByTime(5_000);
+      expect(output()).toBe(settledOutput);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('settles completed and cancelled clarification rows by removing them', () => {
+    const display = makeDisplay();
+    const completed = makeRow();
+    const cancelled = makeRow();
+    vi.spyOn(display, 'toolRow')
+      .mockReturnValueOnce(completed)
+      .mockReturnValueOnce(cancelled);
+    const callbacks = new CliCallbacks({ display });
+
+    callbacks.onToolCall(call('q1', 'clarify'), 'before');
+    callbacks.onToolCall(call('q1', 'clarify'), 'after', result('q1', 'clarify', { status: 'answered' }));
+    callbacks.onToolCall(call('q2', 'clarify'), 'before');
+    callbacks.onToolCall(call('q2', 'clarify'), 'after', result('q2', 'clarify', { status: 'cancelled' }));
+
+    expect(completed.dismiss).toHaveBeenCalledTimes(1);
+    expect(cancelled.dismiss).toHaveBeenCalledTimes(1);
+    expect(completed.ok).not.toHaveBeenCalled();
+    expect(cancelled.cancel).not.toHaveBeenCalled();
+    expect(callbacks.activeActivityCount()).toBe(0);
+  });
+
+  it('runs one approval prompt while its activity row is paused', async () => {
+    const display = makeDisplay();
+    const row = makeRow();
+    vi.spyOn(display, 'toolRow').mockReturnValue(row);
+    const select = vi.fn(async () => 'allow');
+    const prompts: PromptApi = {
+      select,
+      confirm: vi.fn(async () => true),
+      input: vi.fn(async () => ''),
+    };
+    const callbacks = new CliCallbacks({ display, promptModule: prompts });
+    callbacks.onToolCall(call('a1', 'plan_approval'), 'before');
+
+    await expect(callbacks.promptApproval({
+      toolName: 'file_write', category: 'write', args: { path: 'report.md' },
+    })).resolves.toBe('allow');
+    callbacks.onToolCall(call('a1', 'plan_approval'), 'after', result('a1', 'plan_approval', { status: 'approved' }));
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(row.pause).toHaveBeenCalledTimes(1);
+    expect(row.resume).toHaveBeenCalledTimes(1);
+    expect(row.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles completed file work and ignores duplicate terminal callbacks', () => {
+    const display = makeDisplay();
+    const row = makeRow();
+    vi.spyOn(display, 'toolRow').mockReturnValue(row);
+    const callbacks = new CliCallbacks({ display });
+    const fileCall = call('f1', 'file_operations');
+    const done = result('f1', 'file_operations', { status: 'ok' });
+
+    callbacks.onToolCall(fileCall, 'before');
+    callbacks.onToolCall(fileCall, 'before');
+    callbacks.onToolCall(fileCall, 'after', done);
+    callbacks.onToolCall(fileCall, 'after', done);
+
+    expect(display.toolRow).toHaveBeenCalledTimes(1);
+    expect(row.ok).toHaveBeenCalledTimes(1);
+    expect(callbacks.activeActivityCount()).toBe(0);
+  });
+
+  it('sweeps orphaned rows at turn completion and stale callbacks cannot revive them', () => {
+    const display = makeDisplay();
+    const oldRow = makeRow();
+    const nextRow = makeRow();
+    vi.spyOn(display, 'toolRow')
+      .mockReturnValueOnce(oldRow)
+      .mockReturnValueOnce(nextRow);
+    const callbacks = new CliCallbacks({ display });
+
+    callbacks.onToolCall(call('old', 'file_operations'), 'before');
+    callbacks.completeActivityTurn();
+    callbacks.onToolCall(call('old', 'file_operations'), 'after', result('old', 'file_operations', {}));
+    callbacks.onToolCall(call('next', 'file_operations'), 'before');
+
+    expect(oldRow.dismiss).toHaveBeenCalledTimes(1);
+    expect(oldRow.ok).not.toHaveBeenCalled();
+    expect(display.toolRow).toHaveBeenCalledTimes(2);
+    expect(callbacks.activeActivityCount()).toBe(1);
+    callbacks.completeActivityTurn();
+    expect(nextRow.dismiss).toHaveBeenCalledTimes(1);
+    expect(callbacks.activityTimerCount()).toBe(0);
+  });
+});

--- a/tests/v4/cli/activityRegistry.test.ts
+++ b/tests/v4/cli/activityRegistry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ActivityRegistry } from '../../../cli/v4/activityRegistry';
+import type { ToolRowHandle } from '../../../cli/v4/display';
+
+function handle(): ToolRowHandle {
+  return {
+    ok: vi.fn(), fail: vi.fn(), degraded: vi.fn(), retry: vi.fn(), blocked: vi.fn(),
+    emptyRetry: vi.fn(), emptyFail: vi.fn(), cancel: vi.fn(), dismiss: vi.fn(),
+    pause: vi.fn(), resume: vi.fn(), isActive: vi.fn(() => true),
+  };
+}
+
+describe('ActivityRegistry', () => {
+  it('settles duplicate before/after callbacks idempotently', () => {
+    const row = handle();
+    const create = vi.fn(() => row);
+    const registry = new ActivityRegistry(create, () => 50);
+    expect(registry.start('c1', 'file_operations', {})).toBe(true);
+    expect(registry.start('c1', 'file_operations', {})).toBe(false);
+    expect(registry.settle('c1', { state: 'completed' })).toBe(true);
+    expect(registry.settle('c1', { state: 'failed' })).toBe(false);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(row.ok).toHaveBeenCalledTimes(1);
+    expect(row.fail).not.toHaveBeenCalled();
+    expect(registry.timerCount()).toBe(0);
+  });
+
+  it('pauses repainting for a modal and redraws once afterward', async () => {
+    const row = handle();
+    const registry = new ActivityRegistry(() => row);
+    registry.start('c1', 'clarify', {});
+    await registry.runModal(async () => undefined);
+    expect(row.pause).toHaveBeenCalledTimes(1);
+    expect(row.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('turn completion dismisses orphaned rows and empties timers', () => {
+    const first = handle();
+    const second = handle();
+    const rows = [first, second];
+    const registry = new ActivityRegistry(() => rows.shift()!);
+    registry.start('old', 'clarify', {});
+    registry.start('file', 'file_operations', {});
+    registry.sweep();
+    expect(first.dismiss).toHaveBeenCalledTimes(1);
+    expect(second.dismiss).toHaveBeenCalledTimes(1);
+    expect(registry.activeCount()).toBe(0);
+    expect(registry.timerCount()).toBe(0);
+    expect(registry.start('old', 'clarify', {})).toBe(false);
+  });
+
+  it('completed interactive activity can disappear while file work settles', () => {
+    const clarify = handle();
+    const file = handle();
+    const rows = [clarify, file];
+    const registry = new ActivityRegistry(() => rows.shift()!, () => 100);
+    registry.start('q', 'clarify', {});
+    registry.settle('q', { state: 'completed', dismiss: true });
+    registry.start('f', 'file_operations', {});
+    registry.settle('f', { state: 'completed' });
+    expect(clarify.dismiss).toHaveBeenCalledTimes(1);
+    expect(file.ok).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/v4/cli/activityTimer.pty.test.ts
+++ b/tests/v4/cli/activityTimer.pty.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import * as pty from 'node-pty';
+
+function stripAnsi(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+}
+
+describe.skipIf(process.platform !== 'win32')('activity timer ConPTY rendering', () => {
+  it('keeps every replacement within one terminal row and stops after settlement', async () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const child = pty.spawn(process.execPath, [
+      '-r', 'ts-node/register/transpile-only',
+      path.join(repoRoot, 'tests/v4/harness/activityTimerPtyFixture.ts'),
+    ], {
+      cwd: repoRoot,
+      cols: 48,
+      rows: 20,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1', AIDEN_UI_ICONS: '0' },
+    });
+    let raw = '';
+    child.onData((chunk) => { raw += chunk; });
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error(`activity fixture timeout:\n${JSON.stringify(raw)}`));
+      }, 9_000);
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout);
+        if (exitCode === 0) resolve();
+        else reject(new Error(`activity fixture exited ${exitCode}:\n${JSON.stringify(raw)}`));
+      });
+    });
+
+    const frames = [...raw.matchAll(/\x1b\[(?:H|\d+;1H)([^\r\n]*)/g)]
+      .map((match) => stripAnsi(match[1]))
+      .filter((line) => line.includes('calling') || line.includes('running'));
+    expect(frames.length, JSON.stringify(raw)).toBeGreaterThanOrEqual(5);
+    for (const frame of frames) {
+      expect(frame.length, JSON.stringify({ frame, raw })).toBeLessThanOrEqual(48);
+      expect((frame.match(/running/g) ?? []).length).toBeLessThanOrEqual(1);
+    }
+    expect(frames.filter((frame) => frame.includes('running')).length).toBeGreaterThanOrEqual(4);
+    const activityCursorRows = [...raw.matchAll(/\x1b\[(H|(\d+);1H)([^\r\n]*(?:calling|running)[^\r\n]*)/g)]
+      .map((match) => match[2] === undefined ? 1 : Number(match[2]));
+    expect(activityCursorRows.every((row) => row === 1), JSON.stringify(raw)).toBe(true);
+    const settledAt = raw.indexOf('__ACTIVITY_SETTLED__');
+    expect(settledAt).toBeGreaterThan(0);
+    expect(raw.slice(settledAt)).not.toContain('running');
+  }, 12_000);
+});

--- a/tests/v4/cli/activityTimer.pty.test.ts
+++ b/tests/v4/cli/activityTimer.pty.test.ts
@@ -26,7 +26,7 @@ describe.skipIf(process.platform !== 'win32')('activity timer ConPTY rendering',
       const timeout = setTimeout(() => {
         child.kill();
         reject(new Error(`activity fixture timeout:\n${JSON.stringify(raw)}`));
-      }, 9_000);
+      }, 20_000);
       child.onExit(({ exitCode }) => {
         clearTimeout(timeout);
         if (exitCode === 0) resolve();
@@ -49,5 +49,5 @@ describe.skipIf(process.platform !== 'win32')('activity timer ConPTY rendering',
     const settledAt = raw.indexOf('__ACTIVITY_SETTLED__');
     expect(settledAt).toBeGreaterThan(0);
     expect(raw.slice(settledAt)).not.toContain('running');
-  }, 12_000);
+  }, 25_000);
 });

--- a/tests/v4/cli/builtCliAcceptance.pty.test.ts
+++ b/tests/v4/cli/builtCliAcceptance.pty.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as pty from 'node-pty';
+import { startMockProvider, type MockProvider } from '../harness/mockProvider';
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+let child: RunningPty | null = null;
+let provider: MockProvider | null = null;
+const cleanup: string[] = [];
+
+function stripAnsi(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '');
+}
+
+function typeLikeKeyboard(terminal: RunningPty, text: string, submit = true): void {
+  let index = 0;
+  const next = (): void => {
+    if (index < text.length) {
+      terminal.write(text[index++]);
+      setTimeout(next, 10);
+    } else if (submit) {
+      setTimeout(() => terminal.write('\r'), 100);
+    }
+  };
+  next();
+}
+
+function pressDownThenEnter(terminal: RunningPty, count: number): void {
+  let remaining = count;
+  const next = (): void => {
+    if (remaining-- > 0) {
+      terminal.write('\x1b[B');
+      setTimeout(next, 120);
+    } else {
+      setTimeout(() => terminal.write('\r'), 200);
+    }
+  };
+  next();
+}
+
+afterEach(async () => {
+  if (child) {
+    try { child.kill(); } catch { /* already exited */ }
+    child = null;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 750));
+  if (provider) {
+    await provider.stop();
+    provider = null;
+  }
+  await Promise.all(cleanup.splice(0).map(
+    (dir) => fs.rm(dir, { recursive: true, force: true }).catch(() => undefined),
+  ));
+});
+
+describe.skipIf(process.platform !== 'win32')('built CLI P2A/P2C acceptance', () => {
+  it.each([
+    { label: '600 ms', secondPromptDelayMs: 600 },
+    { label: '10 seconds', secondPromptDelayMs: 10_000 },
+  ])('isolates consecutive clarification with second-prompt input after $label', async ({ secondPromptDelayMs }) => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-built-accept-home-'));
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-built-accept-cwd-'));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-built-accept-outside-'));
+    cleanup.push(aidenHome, cwd, outside);
+    const deniedPath = path.join(outside, 'must-not-exist.txt');
+
+    provider = await startMockProvider({
+      modelId: 'custom-default',
+      chunkDelayMs: 5,
+      script: [
+        { toolCalls: [{
+          id: 'q-format', name: 'clarify',
+          arguments: { question: 'Which format?', options: ['Markdown', 'PDF'] },
+        }] },
+        { toolCalls: [{
+          id: 'q-topic', name: 'clarify',
+          arguments: { question: 'What topic?' },
+        }] },
+        { content: 'clarifications complete: PDF | P2A terminal ownership' },
+      ],
+    });
+
+    await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'acceptance\n', 'utf8');
+    await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+      'model:',
+      '  provider: custom_openai',
+      '  modelId: custom-default',
+      'providers:',
+      '  custom_openai:',
+      '    apiKey: acceptance-key',
+      'display:',
+      '  streaming: true',
+      '  renderer: legacy',
+    ].join('\n') + '\n', 'utf8');
+
+    const entry = path.join(repoRoot, 'dist/cli/v4/aidenCLI.js');
+    const preload = path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs');
+    child = pty.spawn(process.execPath, [
+      '-r', preload, entry,
+    ], {
+      cwd,
+      cols: 240,
+      rows: 40,
+      env: {
+        ...process.env,
+        AIDEN_HOME: aidenHome,
+        AIDEN_TEST_REPO_ROOT: repoRoot,
+        AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl,
+        CUSTOM_OPENAI_API_KEY: 'acceptance-key',
+        AIDEN_NO_UPDATE_CHECK: '1',
+        AIDEN_TEST_COMPOSER_READY: '1',
+        TELEGRAM_BOT_TOKEN: '',
+        FORCE_COLOR: '0',
+        NO_COLOR: '1',
+      },
+    });
+
+    let output = '';
+    let state = 'boot';
+    let queueChecks = 0;
+    let queueCommandSent = false;
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `built acceptance timeout (${state}, providerCalls=${provider?.callCount() ?? -1}):\n` +
+        stripAnsi(output).slice(-12000),
+      )), 75_000);
+      child!.onData((chunk) => {
+        output += chunk;
+        const plain = stripAnsi(output);
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (state === 'boot' && readyCount >= 1) {
+          state = 'first-select';
+          setTimeout(() => typeLikeKeyboard(child!, 'Run consecutive clarification acceptance'), 500);
+        }
+        if (state === 'first-select' && plain.includes('Which format?')) {
+          state = 'second-text';
+          setTimeout(() => pressDownThenEnter(child!, 1), 500);
+        }
+        if (state === 'second-text' && plain.includes('What topic?')) {
+          state = 'clarify-final';
+          setTimeout(() => typeLikeKeyboard(child!, 'P2A terminal ownership'), secondPromptDelayMs);
+        }
+        if (state === 'clarify-final' && plain.includes('clarifications complete: PDF | P2A terminal ownership')) {
+          state = 'queue-ready';
+        }
+        if (state === 'queue-ready' && readyCount >= 2) {
+          state = 'queue-1';
+          queueCommandSent = true;
+          typeLikeKeyboard(child!, '/queue');
+        }
+        const emptyQueueCount = plain.match(/queue is empty/gi)?.length ?? 0;
+        if (state === 'queue-1' && emptyQueueCount >= 1) {
+          queueChecks += 1;
+          state = 'done';
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+      child!.onExit(({ exitCode }) => {
+        clearTimeout(timeout);
+        if (state === 'done') return;
+        if (exitCode === 0) resolve();
+        else reject(new Error(`built acceptance exited ${exitCode} in ${state}:\n${stripAnsi(output).slice(-12000)}`));
+      });
+    });
+
+    await completion;
+    const plain = stripAnsi(output);
+    expect(provider.callCount()).toBe(3);
+    expect(queueCommandSent).toBe(true);
+    expect(queueChecks).toBe(1);
+    expect(plain).toContain('Which format? PDF');
+    expect(plain).toContain('What topic? P2A terminal ownership');
+    expect(plain).not.toMatch(/▲\s+partial text/);
+    await expect(fs.access(deniedPath)).rejects.toThrow();
+  }, 120_000);
+});

--- a/tests/v4/cli/composerHandoff.pty.test.ts
+++ b/tests/v4/cli/composerHandoff.pty.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as pty from 'node-pty';
+import { startMockProvider, type MockProvider, type MockProviderTurn } from '../harness/mockProvider';
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+let child: RunningPty | null = null;
+let provider: MockProvider | null = null;
+const cleanup: string[] = [];
+
+async function spawnBuiltCli(
+  script: MockProviderTurn[],
+  chunkDelayMs = 5,
+  headerDelayMs = 0,
+): Promise<{
+  terminal: RunningPty;
+  output: () => string;
+  cwd: string;
+}> {
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const aidenHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-handoff-home-'));
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-handoff-cwd-'));
+  cleanup.push(aidenHome, cwd);
+  provider = await startMockProvider({ modelId: 'custom-default', chunkDelayMs, headerDelayMs, script });
+  await fs.writeFile(path.join(aidenHome, '.onboarding-shown'), 'handoff\n', 'utf8');
+  await fs.writeFile(path.join(aidenHome, 'config.yaml'), [
+    'model:',
+    '  provider: custom_openai',
+    '  modelId: custom-default',
+    'providers:',
+    '  custom_openai:',
+    '    apiKey: handoff-key',
+    'display:',
+    '  streaming: true',
+    '  renderer: legacy',
+  ].join('\n') + '\n', 'utf8');
+  child = pty.spawn(process.execPath, [
+    '-r', path.join(repoRoot, 'tests/v4/harness/builtProviderPreload.cjs'),
+    path.join(repoRoot, 'dist/cli/v4/aidenCLI.js'),
+  ], {
+    cwd,
+    cols: 200,
+    rows: 40,
+    env: {
+      ...process.env,
+      AIDEN_HOME: aidenHome,
+      AIDEN_TEST_REPO_ROOT: repoRoot,
+      AIDEN_TEST_PROVIDER_BASE_URL: provider.baseUrl,
+      CUSTOM_OPENAI_API_KEY: 'handoff-key',
+      AIDEN_NO_UPDATE_CHECK: '1',
+      AIDEN_TEST_COMPOSER_READY: '1',
+      AIDEN_TEST_TURN_IDLE_DIAG: '1',
+      TELEGRAM_BOT_TOKEN: '',
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+    },
+  });
+  let output = '';
+  child.onData((chunk) => { output += chunk; });
+  return { terminal: child, output: () => output, cwd };
+}
+
+function typeLikeKeyboard(terminal: RunningPty, text: string, submitDelayMs = 100): void {
+  let index = 0;
+  const writeNext = (): void => {
+    if (index < text.length) {
+      terminal.write(text[index++]);
+      setTimeout(writeNext, 12);
+    } else {
+      setTimeout(() => terminal.write('\r'), submitDelayMs);
+    }
+  };
+  writeNext();
+}
+
+function pressDownThenEnter(terminal: RunningPty, count: number): void {
+  let remaining = count;
+  const next = (): void => {
+    if (remaining > 0) {
+      remaining -= 1;
+      terminal.write('\x1b[B');
+      setTimeout(next, 80);
+    } else {
+      terminal.write('\r');
+    }
+  };
+  next();
+}
+
+function stripAnsi(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '');
+}
+
+afterEach(async () => {
+  if (child) {
+    try { child.kill(); } catch { /* already exited */ }
+    child = null;
+  }
+  if (provider) {
+    await provider.stop();
+    provider = null;
+  }
+  await Promise.all(cleanup.splice(0).map(
+    (dir) => fs.rm(dir, { recursive: true, force: true }).catch(() => undefined),
+  ));
+});
+
+describe.skipIf(process.platform !== 'win32')('built CLI turn-to-composer handoff', () => {
+  it('accepts three consecutive immediate submissions without a wake-up Enter', async () => {
+    const runtime = await spawnBuiltCli([
+      { content: 'FIRST' },
+      { content: 'SECOND' },
+      { content: 'THIRD' },
+    ]);
+    let firstSent = false;
+    let secondSent = false;
+    let thirdSent = false;
+    let queueSent = false;
+    const completion = new Promise<void>((resolve, reject) => {
+      let checker: ReturnType<typeof setInterval>;
+      let timeout: ReturnType<typeof setTimeout>;
+      const finish = (error?: Error): void => {
+        clearInterval(checker);
+        clearTimeout(timeout);
+        if (error) reject(error);
+        else resolve();
+      };
+      timeout = setTimeout(() => finish(new Error(
+        `handoff timeout (calls=${provider?.callCount() ?? -1}):\n${stripAnsi(runtime.output()).slice(-8000)}`,
+      )), 20_000);
+      const check = (): void => {
+        const output = runtime.output();
+        const markerReadyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        const diagnosticReadyCount = output.split('"event":"composer.ready"').length - 1;
+        const readyCount = Math.max(markerReadyCount, diagnosticReadyCount);
+        const plain = stripAnsi(output);
+        if (!firstSent && readyCount >= 1) {
+          firstSent = true;
+          typeLikeKeyboard(child!, 'Reply with exactly: FIRST');
+        }
+        if (!secondSent && readyCount >= 2 && plain.includes('FIRST')) {
+          secondSent = true;
+          // Deliberately send the printable key with no wake-up Enter.
+          typeLikeKeyboard(child!, 'Reply with exactly: SECOND', 0);
+        }
+        if (!thirdSent && readyCount >= 3 && plain.includes('SECOND')) {
+          thirdSent = true;
+          typeLikeKeyboard(child!, 'Reply with exactly: THIRD', 0);
+        }
+        if (!queueSent && readyCount >= 4 && plain.includes('THIRD') && provider?.callCount() === 3) {
+          queueSent = true;
+          typeLikeKeyboard(child!, '/queue', 0);
+        }
+        if (queueSent && /queue is empty/i.test(plain) && provider?.callCount() === 3) {
+          finish();
+        }
+      };
+      checker = setInterval(check, 10);
+      child!.onData(check);
+      child!.onExit(({ exitCode }) => {
+        finish(new Error(`handoff child exited ${exitCode}:\n${stripAnsi(runtime.output()).slice(-8000)}`));
+      });
+    });
+
+    await completion;
+    expect(provider.callCount()).toBe(3);
+    const plain = stripAnsi(runtime.output());
+    expect(plain).toContain('Reply with exactly: SECOND');
+    expect(plain).toContain('Reply with exactly: THIRD');
+    expect(plain).toMatch(/queue is empty/i);
+    const flattened = plain.replace(/\n/g, '');
+    const generations = [...flattened.matchAll(/"event":"composer\.ready".{0,700}?"generation":(\d+)/g)]
+      .map((match) => Number(match[1]));
+    expect(generations.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(generations).size).toBe(generations.length);
+    const thirdReadyAt = flattened.search(/"event":"composer\.ready".{0,700}"generation":3/);
+    const thirdKeyAt = flattened.indexOf('"generation":3,"key":"r"');
+    const thirdEnterAt = flattened.indexOf('"generation":3,"key":"enter"');
+    expect(thirdReadyAt).toBeGreaterThanOrEqual(0);
+    expect(thirdKeyAt).toBeGreaterThan(thirdReadyAt);
+    expect(thirdEnterAt).toBeGreaterThan(thirdKeyAt);
+  }, 30_000);
+
+  it('treats the first empty Enter as a real submission boundary', async () => {
+    const runtime = await spawnBuiltCli([{ content: 'AFTER EMPTY' }]);
+    let emptySent = false;
+    let promptSent = false;
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `empty-enter timeout (calls=${provider?.callCount() ?? -1}):\n${stripAnsi(runtime.output()).slice(-8000)}`,
+      )), 20_000);
+      child!.onData(() => {
+        const output = runtime.output();
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        const plain = stripAnsi(output);
+        if (!emptySent && readyCount >= 1) {
+          emptySent = true;
+          child!.write('\r');
+        }
+        if (!promptSent && readyCount >= 2) {
+          expect(provider?.callCount()).toBe(0);
+          promptSent = true;
+          typeLikeKeyboard(child!, 'Reply after empty Enter', 0);
+        }
+        if (plain.includes('AFTER EMPTY') && provider?.callCount() === 1) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+    await completion;
+    expect(provider.callCount()).toBe(1);
+  }, 30_000);
+
+  it('hands off immediately after a tool turn with no stale activity timer', async () => {
+    const runtime = await spawnBuiltCli([
+      { toolCalls: [{
+        id: 'read-one', name: 'file_read', arguments: { path: 'fixture.txt' },
+      }] },
+      { content: 'TOOL COMPLETE' },
+      { content: 'NEXT COMPLETE' },
+    ]);
+    await fs.writeFile(path.join(runtime.cwd, 'fixture.txt'), 'fixture\n', 'utf8');
+
+    let firstSent = false;
+    let nextSent = false;
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `tool handoff timeout (calls=${provider?.callCount() ?? -1}):\n${stripAnsi(runtime.output()).slice(-10000)}`,
+      )), 25_000);
+      child!.onData(() => {
+        const output = runtime.output();
+        const plain = stripAnsi(output);
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (!firstSent && readyCount >= 1) {
+          firstSent = true;
+          typeLikeKeyboard(child!, 'Read fixture.txt and report completion');
+        }
+        if (!nextSent && readyCount >= 2 && plain.includes('TOOL COMPLETE')) {
+          nextSent = true;
+          typeLikeKeyboard(child!, 'Reply with exactly: NEXT COMPLETE', 0);
+        }
+        if (provider?.callCount() === 3 && plain.includes('NEXT COMPLETE')) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+
+    await completion;
+    const diagnosticOutput = stripAnsi(runtime.output()).replace(/\n/g, '');
+    const finalReadyIndex = diagnosticOutput.lastIndexOf('"event":"composer.ready"');
+    expect(finalReadyIndex).toBeGreaterThan(0);
+    expect(diagnosticOutput.slice(finalReadyIndex).includes('"event":"activity.row.timer"')).toBe(false);
+    const readStartIndex = diagnosticOutput.lastIndexOf('"event":"composer.read.start"');
+    expect(readStartIndex).toBeGreaterThan(0);
+    const readStart = diagnosticOutput.slice(readStartIndex, readStartIndex + 1_000);
+    expect(readStart).toContain('"activityCount":0');
+    expect(readStart).toContain('"activityTimers":0');
+  }, 35_000);
+
+  it('hands off immediately after an interrupted provider turn', async () => {
+    const runtime = await spawnBuiltCli([
+      { content: 'SLOW RESPONSE' },
+      { content: 'AFTER INTERRUPT' },
+    ], 5, 5_000);
+    let firstSent = false;
+    let interrupted = false;
+    let nextSent = false;
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `interrupt handoff timeout (calls=${provider?.callCount() ?? -1}):\n${stripAnsi(runtime.output()).slice(-10000)}`,
+      )), 30_000);
+      child!.onData(() => {
+        const output = runtime.output();
+        const plain = stripAnsi(output);
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (!firstSent && readyCount >= 1) {
+          firstSent = true;
+          typeLikeKeyboard(child!, 'Start a slow response');
+        }
+        if (!interrupted && provider?.callCount() === 1) {
+          interrupted = true;
+          setTimeout(() => child!.write('\x03'), 200);
+        }
+        if (!nextSent && readyCount >= 2 && plain.includes('(turn interrupted)')) {
+          nextSent = true;
+          typeLikeKeyboard(child!, 'Reply with exactly: AFTER INTERRUPT', 0);
+        }
+        if (provider?.callCount() === 2 && plain.includes('AFTER INTERRUPT')) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+
+    await completion;
+    expect(stripAnsi(runtime.output())).toContain('(turn interrupted)');
+    expect(provider.callCount()).toBe(2);
+  }, 40_000);
+
+  it('hands off immediately after a denied approval without key leakage', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-handoff-outside-'));
+    cleanup.push(outside);
+    const deniedPath = path.join(outside, 'must-not-exist.txt');
+    const runtime = await spawnBuiltCli([
+      { toolCalls: [{
+        id: 'write-one', name: 'file_write',
+        arguments: { path: deniedPath, content: 'must not be written' },
+      }] },
+      { content: 'DENIAL COMPLETE' },
+      { content: 'AFTER APPROVAL' },
+    ]);
+    let firstSent = false;
+    let denied = false;
+    let nextSent = false;
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(
+        `approval handoff timeout (calls=${provider?.callCount() ?? -1}):\n${stripAnsi(runtime.output()).slice(-10000)}`,
+      )), 30_000);
+      child!.onData(() => {
+        const output = runtime.output();
+        const plain = stripAnsi(output);
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (!firstSent && readyCount >= 1) {
+          firstSent = true;
+          typeLikeKeyboard(child!, 'Write the requested file');
+        }
+        if (!denied && plain.includes('Decision')) {
+          denied = true;
+          setTimeout(() => pressDownThenEnter(child!, 3), 200);
+        }
+        if (!nextSent && readyCount >= 2 && plain.includes('DENIAL COMPLETE')) {
+          nextSent = true;
+          typeLikeKeyboard(child!, 'Reply with exactly: AFTER APPROVAL', 0);
+        }
+        if (provider?.callCount() === 3 && plain.includes('AFTER APPROVAL')) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+
+    await completion;
+    await expect(fs.access(deniedPath)).rejects.toThrow();
+    expect(provider.callCount()).toBe(3);
+  }, 40_000);
+});

--- a/tests/v4/cli/frame/framePty.test.ts
+++ b/tests/v4/cli/frame/framePty.test.ts
@@ -22,7 +22,7 @@
  *       'idle' and the heartbeat row does NOT render. The string
  *       "thinking…" must be absent until submit.
  *   T3: busy-at-submit          — pressing Enter flips status.phase
- *       to 'busy' and paints "thinking… 0s" BEFORE the legacy
+ *       to 'busy' and paints "thinking 0s" BEFORE the legacy
  *       stream handoff. With AIDEN_FRAME_BUSY_TICK_MS=300 the busy
  *       row is reliably observable in the captured byte stream.
  *   T4: Ctrl+C clean exit       — composer's onCancel rejects with
@@ -176,7 +176,7 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('frame mode — PTY gate tests (v4.11 Slic
     await term.waitForExit({ timeoutMs: 15_000 });
   }, 60_000);
 
-  it('T3: pressing Enter paints "thinking… 0s" BEFORE the legacy stream handoff', async () => {
+  it('T3: pressing Enter paints "thinking 0s" BEFORE the legacy stream handoff', async () => {
     // 600ms busy tick — comfortably wider than the 50ms harness poll
     // interval so the heartbeat lands in the buffer before unmount.
     term = await spawnFrameAiden(600);
@@ -187,10 +187,10 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('frame mode — PTY gate tests (v4.11 Slic
     term.typeLine('');
     // After submit the legacy turn picks up. We expect the busy
     // row painted by the composer BEFORE that handoff — i.e. the
-    // string "thinking…" must appear quickly.
+    // current status-bar text "thinking 0s" must appear quickly.
     await term.waitFor(
-      (plain) => plain.includes('thinking…'),
-      { timeoutMs: 8_000, label: 'busy heartbeat "thinking…"' },
+      (plain) => plain.includes('thinking 0s'),
+      { timeoutMs: 8_000, label: 'busy heartbeat "thinking 0s"' },
     );
     // Cleanup — the legacy turn will fail (fake API key); we don't
     // care about exit code but we DO need to wait for the child to

--- a/tests/v4/cli/fullRuntimeInput.pty.test.ts
+++ b/tests/v4/cli/fullRuntimeInput.pty.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import * as pty from 'node-pty';
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+const children = new Set<RunningPty>();
+const fixture = path.resolve(__dirname, '../harness/fullRuntimeInputPtyFixture.ts');
+
+function typeLikeKeyboard(child: RunningPty, text: string, submit = true): void {
+  let index = 0;
+  const writeNext = (): void => {
+    if (index < text.length) {
+      child.write(text[index]);
+      index += 1;
+      setTimeout(writeNext, 12);
+    } else if (submit) {
+      setTimeout(() => child.write('\r'), 100);
+    }
+  };
+  writeNext();
+}
+
+function stripAnsi(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '');
+}
+
+afterEach(async () => {
+  for (const child of children) {
+    try { child.kill(); } catch { /* already exited */ }
+  }
+  children.clear();
+  await new Promise((resolve) => setTimeout(resolve, 300));
+});
+
+describe.skipIf(process.platform !== 'win32')('full-runtime consecutive clarification PTY', () => {
+  it('delivers delayed ordinary text to the second real prompt without queue leakage', async () => {
+    const child = pty.spawn(process.execPath, [
+      '-r', 'ts-node/register/transpile-only', fixture,
+    ], {
+      cwd: path.resolve(__dirname, '../../..'),
+      env: {
+        ...process.env,
+        AIDEN_HOME: path.join(os.tmpdir(), `aiden-p2a-full-${Date.now()}`),
+        FORCE_COLOR: '0', NO_COLOR: '1', AIDEN_NO_UPDATE_CHECK: '1',
+        AIDEN_TEST_COMPOSER_READY: '1',
+      },
+      cols: 300,
+      rows: 30,
+    });
+    children.add(child);
+    let output = '';
+    let started = false;
+    let formatAnswered = false;
+    let topicAnswered = false;
+    let finishSent = false;
+    let result: Record<string, unknown> | null = null;
+
+    const completion = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`full runtime PTY timeout:\n${stripAnsi(output).slice(-10000)}`)), 30_000);
+      child.onData((chunk) => {
+        output += chunk;
+        const plain = stripAnsi(output);
+        const readyCount = output.split(COMPOSER_READY_TOKEN).length - 1;
+        if (!started && readyCount >= 1) {
+          started = true;
+          setTimeout(() => typeLikeKeyboard(child, 'Create a report after asking format and topic'), 600);
+        }
+        if (!formatAnswered && plain.includes('Which format would you like for the report?')) {
+          formatAnswered = true;
+          setTimeout(() => child.write('\r'), 600);
+        }
+        if (!topicAnswered && plain.includes('What topic should the Markdown report cover?')) {
+          topicAnswered = true;
+          setTimeout(() => typeLikeKeyboard(child, 'P2A terminal ownership'), 1_500);
+        }
+        if (!finishSent && plain.includes('Clarifications completed.') && readyCount >= 2) {
+          finishSent = true;
+          setTimeout(() => typeLikeKeyboard(child, '/p2a-result'), 600);
+        }
+        const match = plain.match(/\[P2A_FULL:RESULT\](\{[^\n]+\})/);
+        if (match) result = JSON.parse(match[1]) as Record<string, unknown>;
+      });
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout);
+        children.delete(child);
+        if (exitCode !== 0 || !result) {
+          reject(new Error(`full runtime PTY exited ${exitCode}:\n${stripAnsi(output).slice(-3000)}`));
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    await completion;
+    expect(stripAnsi(output)).toContain('P2A terminal ownership');
+    expect(result?.providerCalls).toBe(3);
+    expect(result?.queue).toEqual([]);
+    expect(result?.activityCount).toBe(0);
+    expect(result?.activityTimers).toBe(0);
+  }, 40_000);
+});

--- a/tests/v4/cli/inputAuthority.pty.test.ts
+++ b/tests/v4/cli/inputAuthority.pty.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import * as pty from 'node-pty';
+
+type RunningPty = ReturnType<typeof pty.spawn>;
+
+const fixture = path.resolve(__dirname, '../harness/inputAuthorityPtyFixture.ts');
+const children = new Set<RunningPty>();
+
+afterEach(async () => {
+  for (const child of children) {
+    try { child.kill(); } catch { /* already exited */ }
+  }
+  children.clear();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+});
+
+function stripAnsi(value: string): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+}
+
+async function runScenario(
+  scenario: 'complete' | 'cancel' | 'approval-clarify' | 'skill-normal',
+): Promise<Record<string, unknown>> {
+  const child = pty.spawn(process.execPath, [
+    '-r',
+    'ts-node/register/transpile-only',
+    fixture,
+    scenario,
+  ], {
+    cwd: path.resolve(__dirname, '../../..'),
+    env: { ...process.env, FORCE_COLOR: '0' },
+    cols: 120,
+    rows: 30,
+  });
+  children.add(child);
+
+  let output = '';
+  let firstAnswered = false;
+  let secondAnswered = false;
+  let normalAnswered = false;
+  let result: Record<string, unknown> | undefined;
+
+  const completion = new Promise<Record<string, unknown>>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`PTY regression timed out. Output:\n${stripAnsi(output)}`));
+    }, 20_000);
+
+    child.onData((chunk) => {
+      output += chunk;
+      const plain = stripAnsi(output);
+      if (!firstAnswered && plain.includes('Which format would you like for the report?')) {
+        firstAnswered = true;
+        setTimeout(() => child.write('\r'), 600);
+      }
+      if (!firstAnswered && plain.includes('Decision')) {
+        firstAnswered = true;
+        setTimeout(() => child.write('\x1b[B\r'), 600);
+      }
+      if (!firstAnswered && plain.includes('Save this as a reusable skill?')) {
+        firstAnswered = true;
+        setTimeout(() => child.write('n\r'), 600);
+      }
+      if (!secondAnswered && plain.includes('What topic should the Markdown report cover?')) {
+        secondAnswered = true;
+        setTimeout(() => child.write(scenario === 'complete' ? 'P2A terminal ownership\r' : '\x03'), 600);
+      }
+      if (!secondAnswered && plain.includes('Clarification after approval')) {
+        secondAnswered = true;
+        setTimeout(() => child.write('approval isolated\r'), 600);
+      }
+      if (!normalAnswered && plain.includes('[P2A:NORMAL_READY]')) {
+        normalAnswered = true;
+        setTimeout(() => child.write('NORMAL_INPUT_OK\r'), 150);
+      }
+      const match = plain.match(/\[P2A:RESULT\](\{[^\r\n]+\})/);
+      if (match) {
+        result = JSON.parse(match[1]) as Record<string, unknown>;
+      }
+    });
+    child.onExit(({ exitCode }) => {
+      clearTimeout(timeout);
+      children.delete(child);
+      if (exitCode !== 0 || !result) {
+        reject(new Error(`PTY child exited ${exitCode}. Output:\n${stripAnsi(output)}`));
+      } else {
+        resolve(result);
+      }
+    });
+  });
+
+  return completion;
+}
+
+function expectRestored(result: Record<string, unknown>): void {
+  const baseline = result.baseline as Record<string, unknown>;
+  for (const key of ['firstCleanup', 'secondCleanup'] as const) {
+    const cleanup = result[key] as Record<string, unknown>;
+    expect(cleanup.paused).toBe(false);
+    expect(cleanup.flowing).toBe(true);
+    expect(cleanup.raw).toBe(true);
+  }
+  for (const key of ['firstRestored', 'secondRestored'] as const) {
+    const restored = result[key] as Record<string, unknown>;
+    expect(restored.paused).toBe(false);
+    expect(restored.flowing).toBe(true);
+    expect(restored.raw).toBe(true);
+    expect(restored.data).toBe(baseline.data);
+    expect(restored.keypress).toBe(baseline.keypress);
+    expect(restored.readable).toBe(baseline.readable);
+    expect(restored.sigint).toBe(baseline.sigint);
+  }
+  expect(result.leakedBeforeNormal).toEqual(['']);
+  expect(result.typedAfterward).toBe('NORMAL_INPUT_OK');
+  expect(result.rawLines).toEqual(['NORMAL_INPUT_OK']);
+  expect(result.owner).toBe('during_turn');
+  expect(result.restoreCount).toBe(2);
+  expect(result.turnAborted).toBe(false);
+}
+
+describe.skipIf(process.platform !== 'win32')('InputAuthority real Inquirer Windows PTY regression', () => {
+  it('restores stdin flow between a select and a separate free-text prompt', async () => {
+    const result = await runScenario('complete');
+    expect(result.first).toBe('Markdown');
+    expect(result.second).toBe('P2A terminal ownership');
+    expectRestored(result);
+  }, 30_000);
+
+  it('keeps Ctrl+C inside the second prompt and restores normal input', async () => {
+    const result = await runScenario('cancel');
+    expect(result.first).toBe('Markdown');
+    expect(result.second).toBeNull();
+    expectRestored(result);
+  }, 30_000);
+
+  it('isolates approval cleanup before a separate clarification lease', async () => {
+    const result = await runScenario('approval-clarify');
+    expect(result.first).toBe('deny');
+    expect(result.second).toBe('approval isolated');
+    expectRestored(result);
+  }, 30_000);
+
+  it('isolates skill-save n and restores ordinary raw input', async () => {
+    const result = await runScenario('skill-normal');
+    expect(result.first).toBe(false);
+    const cleanup = result.firstCleanup as Record<string, unknown>;
+    const restored = result.firstRestored as Record<string, unknown>;
+    const baseline = result.baseline as Record<string, unknown>;
+    expect(cleanup).toMatchObject({ paused: false, flowing: true, raw: true });
+    expect(restored).toMatchObject({ paused: false, flowing: true, raw: true });
+    expect(restored.data).toBe(baseline.data);
+    expect(restored.keypress).toBe(baseline.keypress);
+    expect(result.leakedBeforeNormal).toEqual(['']);
+    expect(result.typedAfterward).toBe('NORMAL_INPUT_OK');
+    expect(result.rawLines).toEqual(['NORMAL_INPUT_OK']);
+    expect(result.owner).toBe('during_turn');
+    expect(result.restoreCount).toBe(1);
+  }, 30_000);
+});

--- a/tests/v4/cli/inputAuthority.test.ts
+++ b/tests/v4/cli/inputAuthority.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InputAuthority, type RawStdinLike } from '../../../cli/v4/inputAuthority';
+import { CliCallbacks } from '../../../cli/v4/callbacks';
+import { attachTurnInputListener } from '../../../cli/v4/turnInputListener';
+import { DuringTurnInput } from '../../../cli/v4/duringTurnInput';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { Writable } from 'node:stream';
+
+function fakeStdin(initialRaw = false, initialPaused = false) {
+  let raw = initialRaw;
+  let paused = initialPaused;
+  const listeners = new Set<(s: string | undefined, k: { name?: string; sequence?: string }) => void>();
+  const stdin: RawStdinLike & { emitKey(s?: string, k?: { name?: string; sequence?: string }): void; count(): number } = {
+    isTTY: true,
+    get isRaw() { return raw; },
+    get readableFlowing() { return paused ? false : true; },
+    isPaused() { return paused; },
+    resume: vi.fn(() => { paused = false; }),
+    pause: vi.fn(() => { paused = true; }),
+    setRawMode: vi.fn((value: boolean) => { raw = value; }),
+    on(_event, handler) { listeners.add(handler); },
+    removeListener(_event, handler) { listeners.delete(handler); },
+    emitKey(s, k = {}) { for (const handler of [...listeners]) handler(s, k); },
+    count() { return listeners.size; },
+  };
+  return stdin;
+}
+
+describe('InputAuthority exclusive leases', () => {
+  it('lends modal prompts a non-owning facade that suppresses readline cleanup mutations', async () => {
+    const stdin = fakeStdin(false, true);
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const releaseRaw = authority.mountRawOwner('during_turn', vi.fn());
+    const pauseCallsBefore = vi.mocked(stdin.pause!).mock.calls.length;
+    const rawCallsBefore = vi.mocked(stdin.setRawMode!).mock.calls.length;
+
+    await authority.runExclusive('clarify', async (modal: RawStdinLike) => {
+      expect(modal).not.toBe(stdin);
+      expect(stdin.isRaw).toBe(true);
+      expect(stdin.isPaused?.()).toBe(false);
+      modal.pause?.();
+      modal.setRawMode?.(false);
+      expect(stdin.isRaw).toBe(true);
+      expect(stdin.isPaused?.()).toBe(false);
+    });
+
+    expect(vi.mocked(stdin.pause!).mock.calls.length).toBe(pauseCallsBefore);
+    expect(vi.mocked(stdin.setRawMode!).mock.calls.length).toBe(rawCallsBefore);
+    expect(authority.currentOwner()).toBe('during_turn');
+    expect(stdin.isRaw).toBe(true);
+    expect(stdin.isPaused?.()).toBe(false);
+
+    releaseRaw();
+    expect(stdin.isRaw).toBe(false);
+    expect(stdin.isPaused?.()).toBe(true);
+  });
+
+  it('ignores stale facade cleanup after a newer modal lease acquires stdin', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    authority.mountRawOwner('during_turn', vi.fn());
+    let staleFacade!: RawStdinLike;
+    await authority.runExclusive('clarify', async (modal: RawStdinLike) => {
+      staleFacade = modal;
+      return 'first';
+    });
+
+    await authority.runExclusive('approval', async (modal: RawStdinLike) => {
+      expect(modal).not.toBe(staleFacade);
+      const pauseCalls = vi.mocked(stdin.pause!).mock.calls.length;
+      const rawCalls = vi.mocked(stdin.setRawMode!).mock.calls.length;
+      staleFacade.pause?.();
+      staleFacade.setRawMode?.(false);
+      expect(vi.mocked(stdin.pause!).mock.calls.length).toBe(pauseCalls);
+      expect(vi.mocked(stdin.setRawMode!).mock.calls.length).toBe(rawCalls);
+      expect(stdin.isRaw).toBe(true);
+      expect(stdin.isPaused?.()).toBe(false);
+      return 'second';
+    });
+  });
+
+  it.each([
+    { initialRaw: true, initialPaused: false },
+    { initialRaw: false, initialPaused: false },
+    { initialRaw: false, initialPaused: true },
+  ])('restores exact pre-lease state without a raw owner ($initialRaw/$initialPaused)', async ({ initialRaw, initialPaused }) => {
+    const stdin = fakeStdin(initialRaw, initialPaused);
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    await authority.runExclusive('approval', async (modal: RawStdinLike) => {
+      expect(stdin.isRaw).toBe(true);
+      expect(stdin.isPaused?.()).toBe(false);
+      modal.pause?.();
+      modal.setRawMode?.(false);
+      return 'deny';
+    });
+    expect(stdin.isRaw).toBe(initialRaw);
+    expect(stdin.isPaused?.()).toBe(initialPaused);
+    expect(authority.currentOwner()).toBeNull();
+  });
+
+  it('uses unique leases and stale/double releases cannot remove a newer mount', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const first = authority.mountRawOwner('during_turn', vi.fn());
+    const firstId = authority.currentLeaseId();
+    const secondHandler = vi.fn();
+    const second = authority.mountRawOwner('during_turn', secondHandler);
+    expect(authority.currentLeaseId()).not.toBe(firstId);
+    await first();
+    stdin.emitKey('x', { name: 'x', sequence: 'x' });
+    expect(secondHandler).toHaveBeenCalledOnce();
+    await first();
+    expect(stdin.count()).toBe(1);
+    await second();
+    expect(stdin.count()).toBe(0);
+  });
+
+  it('restores the exact handler, excludes overlap, and replays no modal input', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const handler = vi.fn();
+    authority.mountRawOwner('during_turn', handler);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const modal = authority.runExclusive('skill_prompt', async () => {
+      expect(stdin.count()).toBe(0);
+      stdin.emitKey('n', { name: 'n', sequence: 'n' });
+      await expect(authority.runExclusive('approval', async () => true)).rejects.toThrow(/exclusive input lease/i);
+      await gate;
+      return false;
+    });
+    release();
+    await expect(modal).resolves.toBe(false);
+    expect(authority.currentOwner()).toBe('during_turn');
+    expect(handler).not.toHaveBeenCalled();
+    stdin.emitKey('z', { name: 'z', sequence: 'z' });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it.each([false, true])('restores raw mode and ownership after throw (initial=%s)', async (initial) => {
+    const stdin = fakeStdin(initial);
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    authority.mountRawOwner('during_turn', vi.fn());
+    await expect(authority.runExclusive('clarify', async () => { throw new Error('cancel'); })).rejects.toThrow('cancel');
+    expect(authority.currentOwner()).toBe('during_turn');
+    expect(stdin.isRaw).toBe(true);
+  });
+
+  it('preserves pre-modal type-ahead in the same handler and queues no modal answer', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const queue = new DuringTurnInput();
+    attachTurnInputListener({
+      authority,
+      cb: { onLine: (text) => { queue.onBusyEnter(text); }, onEscape: vi.fn(), onCtrlC: vi.fn() },
+    });
+    stdin.emitKey('a', { name: 'a', sequence: 'a' });
+    await authority.runExclusive('skill_prompt', async () => {
+      stdin.emitKey('n', { name: 'n', sequence: 'n' });
+      stdin.emitKey('\r', { name: 'return', sequence: '\r' });
+      return false;
+    });
+    expect(queue.dequeue()).toBeNull();
+    stdin.emitKey('b', { name: 'b', sequence: 'b' });
+    stdin.emitKey('\r', { name: 'return', sequence: '\r' });
+    expect(queue.dequeue()).toBe('ab');
+    expect(queue.dequeue()).toBeNull();
+  });
+
+  it('resumes stdin when restoring a raw owner after prompt cleanup paused it', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    authority.mountRawOwner('during_turn', vi.fn());
+    await authority.runExclusive('clarify', async () => { stdin.pause?.(); return 'answer'; });
+    expect(stdin.isPaused?.()).toBe(false);
+    expect(stdin.readableFlowing).toBe(true);
+    expect(stdin.resume).toHaveBeenCalledOnce();
+  });
+
+  it('restores only flow state changed by the exact registration', () => {
+    const stdin = fakeStdin(false, true);
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const first = authority.mountRawOwner('during_turn', vi.fn());
+    expect(stdin.isPaused?.()).toBe(false);
+    const second = authority.mountRawOwner('during_turn', vi.fn());
+    first();
+    expect(stdin.isPaused?.()).toBe(false);
+    second();
+    expect(stdin.isPaused?.()).toBe(true);
+  });
+});
+
+describe('interactive callback lease wiring', () => {
+  it('leases approval, clarification, and skill-save and passes the lease facade only to modal prompts', async () => {
+    const owners: string[] = [];
+    const modalInput = fakeStdin();
+    const contexts: unknown[] = [];
+    const prompts = {
+      select: vi.fn(async ({ message }: { message: string }, context?: unknown) => {
+        contexts.push(context);
+        return message === 'Decision' ? 'deny' : 'one';
+      }),
+      confirm: vi.fn(async (_opts: unknown, context?: unknown) => { contexts.push(context); return false; }),
+      input: vi.fn(async (_opts: unknown, context?: unknown) => { contexts.push(context); return 'answer'; }),
+    };
+    const sink = new Writable({ write(_chunk, _enc, done) { done(); } }) as NodeJS.WriteStream;
+    const display = new Display({ skin: new SkinEngine({ forceMono: true }), stdout: sink, stderr: sink });
+    const callbacks = new CliCallbacks({ display, promptModule: prompts });
+    callbacks.setExclusiveInputRunner(async (owner, run) => { owners.push(owner); return run(modalInput); });
+    await callbacks.promptApproval({ toolName: 'shell_exec', category: 'execute', args: {}, reason: 'test' } as never);
+    await callbacks.promptClarify('Question?');
+    await callbacks.promptSkillProposal({ proposedName: 'test', description: 'test', toolsUsed: [], confidence: 0.8 } as never);
+    expect(owners).toEqual(['approval', 'clarify', 'skill_prompt']);
+    expect(contexts).toEqual([
+      { input: modalInput },
+      { input: modalInput },
+      { input: modalInput },
+    ]);
+  });
+
+  it('releases and reacquires unique leases for consecutive clarification calls', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const rawHandler = vi.fn();
+    authority.mountRawOwner('during_turn', rawHandler);
+    const answers = ['first answer', 'second answer'];
+    const prompts = { select: vi.fn(), confirm: vi.fn(), input: vi.fn(async () => {
+      expect(authority.currentOwner()).toBe('clarify');
+      stdin.emitKey('x', { name: 'x', sequence: 'x' });
+      return answers.shift()!;
+    }) };
+    const sink = new Writable({ write(_chunk, _enc, done) { done(); } }) as NodeJS.WriteStream;
+    const callbacks = new CliCallbacks({ display: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: sink, stderr: sink }), promptModule: prompts });
+    const acquisitions: Array<{ leaseId: number | null; epoch: number }> = [];
+    callbacks.setExclusiveInputRunner((owner, run) => authority.runExclusive(owner, async () => {
+      acquisitions.push({ leaseId: authority.currentLeaseId(), epoch: authority.currentEpoch() });
+      return run();
+    }));
+    await expect(callbacks.promptClarify('first?')).resolves.toBe('first answer');
+    expect(authority.currentOwner()).toBe('during_turn');
+    await expect(callbacks.promptClarify('second?')).resolves.toBe('second answer');
+    expect(acquisitions[0].leaseId).not.toBe(acquisitions[1].leaseId);
+    expect(acquisitions[1].epoch).toBeGreaterThan(acquisitions[0].epoch);
+    expect(rawHandler).not.toHaveBeenCalled();
+  });
+
+  it('keeps select then Other free-text inside one lease', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    authority.mountRawOwner('during_turn', vi.fn());
+    const owners: Array<string | null> = [];
+    const prompts = {
+      select: vi.fn(async () => { owners.push(authority.currentOwner()); return '__clarify_other__'; }),
+      confirm: vi.fn(),
+      input: vi.fn(async () => { owners.push(authority.currentOwner()); return 'custom'; }),
+    };
+    const sink = new Writable({ write(_chunk, _enc, done) { done(); } }) as NodeJS.WriteStream;
+    const callbacks = new CliCallbacks({ display: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: sink, stderr: sink }), promptModule: prompts });
+    let leases = 0;
+    callbacks.setExclusiveInputRunner((owner, run) => { leases += 1; return authority.runExclusive(owner, run); });
+    await expect(callbacks.promptClarify('pick?', ['A'])).resolves.toBe('custom');
+    expect(leases).toBe(1);
+    expect(owners).toEqual(['clarify', 'clarify']);
+    expect(authority.currentOwner()).toBe('during_turn');
+  });
+
+  it('cancelling the second clarification returns null without aborting the turn', async () => {
+    const stdin = fakeStdin();
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    authority.mountRawOwner('during_turn', vi.fn());
+    let calls = 0;
+    const prompts = { select: vi.fn(), confirm: vi.fn(), input: vi.fn(async () => {
+      calls += 1;
+      if (calls === 2) throw new Error('ExitPromptError');
+      return 'first';
+    }) };
+    const sink = new Writable({ write(_chunk, _enc, done) { done(); } }) as NodeJS.WriteStream;
+    const callbacks = new CliCallbacks({ display: new Display({ skin: new SkinEngine({ forceMono: true }), stdout: sink, stderr: sink }), promptModule: prompts });
+    callbacks.setExclusiveInputRunner((owner, run) => authority.runExclusive(owner, run));
+    const turn = new AbortController();
+    await expect(callbacks.promptClarify('first?')).resolves.toBe('first');
+    await expect(callbacks.promptClarify('second?')).resolves.toBeNull();
+    expect(turn.signal.aborted).toBe(false);
+    expect(authority.currentOwner()).toBe('during_turn');
+  });
+});

--- a/tests/v4/cli/inputAuthority.test.ts
+++ b/tests/v4/cli/inputAuthority.test.ts
@@ -189,6 +189,22 @@ describe('InputAuthority exclusive leases', () => {
     second();
     expect(stdin.isPaused?.()).toBe(true);
   });
+
+  it('hands the live raw and flowing state to the next composer without a console-reader restart', () => {
+    const stdin = fakeStdin(false, true);
+    const authority = new InputAuthority({ stdin, emitKeypressEvents: vi.fn(), onProcessExit: vi.fn(), offProcessExit: vi.fn() });
+    const release = authority.mountRawOwner('during_turn', vi.fn());
+    const rawCallsBefore = vi.mocked(stdin.setRawMode!).mock.calls.length;
+    const pauseCallsBefore = vi.mocked(stdin.pause!).mock.calls.length;
+
+    release('handoff');
+
+    expect(authority.currentOwner()).toBeNull();
+    expect(stdin.isRaw).toBe(true);
+    expect(stdin.isPaused?.()).toBe(false);
+    expect(vi.mocked(stdin.setRawMode!).mock.calls.length).toBe(rawCallsBefore);
+    expect(vi.mocked(stdin.pause!).mock.calls.length).toBe(pauseCallsBefore);
+  });
 });
 
 describe('interactive callback lease wiring', () => {

--- a/tests/v4/cli/setupWizard.test.ts
+++ b/tests/v4/cli/setupWizard.test.ts
@@ -225,7 +225,7 @@ describe('SetupWizard', () => {
   });
 
   it('Pro option ChatGPT Plus prints OAuth explainer + beta note then waits for confirm', async () => {
-    const chatgptPlusIdx = PROVIDERS.findIndex((p) => p.id === 'chatgpt-plus') + 1;
+    const subscriptionProviderIndex = PROVIDERS.findIndex((p) => p.id === 'chatgpt-plus') + 1;
     const ollamaIdx = PROVIDERS.findIndex((p) => p.id === 'ollama') + 1;
     const fetchImpl = (async () => ({ ok: true } as Response)) as unknown as typeof fetch;
     const { display, chunks } = sinkDisplay();
@@ -233,7 +233,7 @@ describe('SetupWizard', () => {
       paths,
       display,
       prompts: scriptedPrompts({
-        choose: [chatgptPlusIdx, ollamaIdx],
+        choose: [subscriptionProviderIndex, ollamaIdx],
         confirm: [false],
         input: ['llama3.1:8b'],
       }),

--- a/tests/v4/core/aidenAgent.clarificationContract.test.ts
+++ b/tests/v4/core/aidenAgent.clarificationContract.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AidenAgent, type ToolExecutor } from '../../../core/v4/aidenAgent';
+import type {
+  Message,
+  ProviderAdapter,
+  ProviderCallInput,
+  ProviderCallOutput,
+  ToolCallRequest,
+} from '../../../providers/v4/types';
+
+const usage = { inputTokens: 1, outputTokens: 1 };
+
+function tools(...calls: ToolCallRequest[]): ProviderCallOutput {
+  return { content: '', toolCalls: calls, usage, finishReason: 'tool_calls' };
+}
+
+function done(content = 'done'): ProviderCallOutput {
+  return { content, toolCalls: [], usage, finishReason: 'stop' };
+}
+
+class ScriptedAdapter implements ProviderAdapter {
+  apiMode = 'chat_completions' as const;
+  constructor(private readonly outputs: ProviderCallOutput[]) {}
+  async call(_input: ProviderCallInput): Promise<ProviderCallOutput> {
+    const next = this.outputs.shift();
+    if (!next) throw new Error('script exhausted');
+    return next;
+  }
+}
+
+const user = (content: string): Message => ({ role: 'user', content });
+
+describe('cancelled required clarification contract', () => {
+  it('blocks invented mutations until the user supplies or explicitly overrides the missing value', async () => {
+    const adapter = new ScriptedAdapter([
+      tools({
+        id: 'clarify-1', name: 'clarify',
+        arguments: { question: 'What topic should the Markdown report cover?' },
+      }),
+      tools({
+        id: 'write-1', name: 'file_write',
+        arguments: { path: 'report.md', content: 'invented topic' },
+      }),
+      done('I still need the topic.'),
+      tools({
+        id: 'write-2', name: 'file_write',
+        arguments: { path: 'report.md', content: 'invented after create it' },
+      }),
+      done('I still need the topic.'),
+      tools({
+        id: 'write-3', name: 'file_write',
+        arguments: { path: 'report.md', content: 'explicitly authorized default' },
+      }),
+      done('created'),
+    ]);
+    const executor = vi.fn<ToolExecutor>(async (call) => {
+      if (call.name === 'clarify') {
+        return {
+          id: call.id,
+          name: call.name,
+          result: { ok: false, status: 'cancelled', answer: null },
+        };
+      }
+      return { id: call.id, name: call.name, result: { ok: true } };
+    });
+    const agent = new AidenAgent({
+      provider: adapter,
+      tools: [],
+      toolExecutor: executor,
+      resolveMutates: (name) => name === 'file_write',
+    });
+
+    const first = await agent.runConversation([user('Create a Markdown report after asking for format and topic.')]);
+    expect(executor.mock.calls.map(([call]) => call.name)).toEqual(['clarify']);
+    expect(first.messages.some(
+      (message) => message.role === 'tool' && message.content.includes('required clarification was cancelled'),
+    )).toBe(true);
+
+    const second = await agent.runConversation([user('create it')]);
+    expect(executor.mock.calls.map(([call]) => call.name)).toEqual(['clarify']);
+    expect(second.messages.some(
+      (message) => message.role === 'tool' && message.content.includes('Do not invent the missing value'),
+    )).toBe(true);
+
+    await agent.runConversation([user('Use any topic; choose for me and proceed without asking again.')]);
+    expect(executor.mock.calls.map(([call]) => call.name)).toEqual(['clarify', 'file_write']);
+  });
+});

--- a/tests/v4/core/aidenAgent.parallel.test.ts
+++ b/tests/v4/core/aidenAgent.parallel.test.ts
@@ -250,6 +250,42 @@ describe('AidenAgent — parallel pure-read tool dispatch (v4.11 perf)', () => {
     await agent.runConversation([userMsg('one')]);
     expect(events).toHaveLength(1);
   });
+
+  it.each(['clarify', 'plan_approval'])('%s calls execute sequentially in provider order', async (interactiveName) => {
+    const adapter = new ScriptedAdapter([{
+      content: '',
+      toolCalls: [tc('first', interactiveName), tc('second', interactiveName)],
+      usage: { inputTokens: 1, outputTokens: 1 }, finishReason: 'tool_calls',
+    }]);
+    let active = 0;
+    let peak = 0;
+    const order: string[] = [];
+    const exec: ToolExecutor = async (call) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      order.push(call.id);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      active -= 1;
+      return { id: call.id, name: call.name, result: 'ok' };
+    };
+    const agent = new AidenAgent({ provider: adapter, tools: NO_TOOLS, toolExecutor: exec });
+    await agent.runConversation([userMsg('ask twice')]);
+    expect(peak).toBe(1);
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('clarify does not overlap an adjacent normal read-only call', async () => {
+    const adapter = new ScriptedAdapter([{
+      content: '',
+      toolCalls: [tc('search', 'web_search'), tc('ask', 'clarify')],
+      usage: { inputTokens: 1, outputTokens: 1 }, finishReason: 'tool_calls',
+    }]);
+    const { exec, events } = makeTimedExecutor(30);
+    const agent = new AidenAgent({ provider: adapter, tools: NO_TOOLS, toolExecutor: exec });
+    await agent.runConversation([userMsg('search then ask')]);
+    expect(maxOverlap(events)).toBe(1);
+    expect(events.map((event) => event.id)).toEqual(['search', 'ask']);
+  });
 });
 
 describe('AidenAgent — AIDEN_PERF_DIAG instrumentation (v4.11 perf)', () => {

--- a/tests/v4/core/classifier-integration.test.ts
+++ b/tests/v4/core/classifier-integration.test.ts
@@ -52,8 +52,16 @@ function alternatingOkFailExecutor(): (call: ToolCallRequest) => Promise<ToolCal
 }
 
 describe('v4.2 Phase 2 — classifier integration', () => {
-  beforeEach(() => { delete process.env.AIDEN_TCE; });
-  afterEach(()  => { delete process.env.AIDEN_TCE; });
+  beforeEach(() => {
+    delete process.env.AIDEN_TCE;
+    // Classification is the subject of this suite. Runtime retry/backoff is
+    // covered separately and would make transient-failure cases wait seconds.
+    process.env.AIDEN_RETRY_OFF = '1';
+  });
+  afterEach(()  => {
+    delete process.env.AIDEN_TCE;
+    delete process.env.AIDEN_RETRY_OFF;
+  });
 
   it('AIDEN_TCE=0 opt-out: zero classification surface on trace', async () => {
     // v4.2 Phase 6 — TCE is ON by default; explicit `=0` opts out.

--- a/tests/v4/daemon/install/cliDaemon.test.ts
+++ b/tests/v4/daemon/install/cliDaemon.test.ts
@@ -31,17 +31,24 @@ import {
 } from '../../../../cli/v4/commands/daemon';
 
 let homeOverride: string;
-let prevHome: string | undefined;
+let previousPaths: Record<'AIDEN_HOME' | 'HOME' | 'USERPROFILE', string | undefined>;
 
 beforeEach(() => {
   homeOverride = fs.mkdtempSync(path.join(os.tmpdir(), 'aiden-cli-d-'));
-  prevHome = process.env.HOME;
+  previousPaths = {
+    AIDEN_HOME: process.env.AIDEN_HOME,
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
+  process.env.AIDEN_HOME = homeOverride;
   process.env.HOME = homeOverride;
   process.env.USERPROFILE = homeOverride;
 });
 afterEach(() => {
-  if (prevHome === undefined) delete process.env.HOME;
-  else process.env.HOME = prevHome;
+  for (const [key, value] of Object.entries(previousPaths)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   try { fs.rmSync(homeOverride, { recursive: true, force: true }); }
   catch { /* noop */ }
 });
@@ -70,7 +77,7 @@ describe('runDaemonSubcommand — stop with no daemon', () => {
 
   it('handles stale lock file (dead PID) gracefully', async () => {
     // Pre-create a stale lock file pointing at a definitely-dead PID.
-    const lockPath = path.join(homeOverride, '.config', 'aiden', 'daemon', 'runtime.lock');
+    const lockPath = path.join(homeOverride, 'daemon', 'runtime.lock');
     fs.mkdirSync(path.dirname(lockPath), { recursive: true });
     fs.writeFileSync(lockPath, 'stale-instance\n999999\n12345\n');
     const o = out(); const e = out();

--- a/tests/v4/fsSnapshot.test.ts
+++ b/tests/v4/fsSnapshot.test.ts
@@ -17,7 +17,7 @@ import type { ToolCallRequest, ToolSchema } from '../../providers/v4/types';
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(os.tmpdir(), 'aiden-snap-')); });
-afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }); });
 const p = (name: string): string => path.join(dir, name);
 
 // ── the capture layer ────────────────────────────────────────────────────

--- a/tests/v4/fsSnapshotFailsafe.test.ts
+++ b/tests/v4/fsSnapshotFailsafe.test.ts
@@ -31,7 +31,7 @@ import type { ToolCallRequest, ToolSchema } from '../../providers/v4/types';
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(os.tmpdir(), 'aiden-snapfail-')); state.calls = 0; });
-afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }); });
 
 const schema = (name: string): ToolSchema => ({ name, description: name, inputSchema: { type: 'object', properties: {} } });
 const call = (name: string, args: Record<string, unknown>): ToolCallRequest => ({ id: `call-${name}`, name, arguments: args });

--- a/tests/v4/harness/activityTimerPtyFixture.ts
+++ b/tests/v4/harness/activityTimerPtyFixture.ts
@@ -1,0 +1,17 @@
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+
+const display = new Display({
+  skin: new SkinEngine({ forceMono: true }),
+  stdout: process.stdout,
+});
+
+const row = display.toolRow('terminal', {
+  command: 'Start-Sleep -Seconds 5; Write-Output repeated-handoff-activity-frame',
+});
+
+setTimeout(() => {
+  row.ok(4_250);
+  process.stdout.write('__ACTIVITY_SETTLED__\n');
+  setTimeout(() => process.exit(0), 1_250);
+}, 4_250);

--- a/tests/v4/harness/aidenTerm.ts
+++ b/tests/v4/harness/aidenTerm.ts
@@ -35,6 +35,7 @@ import * as pty from 'node-pty';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { COMPOSER_READY_TOKEN } from '../../../cli/v4/composerReadiness';
 
 export interface SpawnAidenTermOptions {
   /** Columns. Default 120 — wide enough for full-density status footer. */
@@ -135,6 +136,18 @@ export async function spawnAidenTerm(
   const aidenHome = opts.aidenHome ?? await fs.mkdtemp(path.join(os.tmpdir(), 'aiden-term-home-'));
   const entry = opts.entry ?? defaultEntry();
 
+  // This harness exercises the interactive REPL, not first-run onboarding.
+  // Keep every PTY suite on the same deterministic boot boundary even when a
+  // caller supplies a freshly-created home directory.
+  await fs.mkdir(aidenHome, { recursive: true });
+  await fs.writeFile(
+    path.join(aidenHome, '.onboarding-shown'),
+    'pty-harness\n',
+    { encoding: 'utf8', flag: 'wx' },
+  ).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== 'EEXIST') throw error;
+  });
+
   // Verify the entry exists — fail loud rather than spawn a broken child.
   try {
     await fs.access(entry);
@@ -155,6 +168,7 @@ export async function spawnAidenTerm(
     ...process.env as Record<string, string>,
     AIDEN_HOME:                aidenHome,
     AIDEN_NO_UPDATE_CHECK:     '1',
+    AIDEN_TEST_COMPOSER_READY: '1',
     TELEGRAM_BOT_TOKEN:        '',
     NO_COLOR:                  '0',     // keep ANSI so the harness can see escapes
     FORCE_COLOR:               '1',
@@ -176,6 +190,7 @@ export async function spawnAidenTerm(
 
   let buffer = '';
   let exitCode: number | null = null;
+  let readinessSeen = 0;
   child.onData((data: string) => {
     buffer += data;
   });
@@ -213,12 +228,12 @@ export async function spawnAidenTerm(
   };
 
   const waitForPrompt = async (waitOpts?: { timeoutMs?: number }): Promise<void> => {
-    // The chat prompt always renders the brand-orange `▲ ` glyph.
-    // Strip ANSI first so we just look at the literal char.
+    const target = readinessSeen + 1;
     await waitFor(
-      (plain) => plain.includes('▲'),
-      { ...waitOpts, label: '▲ prompt' },
+      () => buffer.split(COMPOSER_READY_TOKEN).length - 1 >= target,
+      { ...waitOpts, label: 'composer readiness marker' },
     );
+    readinessSeen = target;
   };
 
   const waitForExit = async (waitOpts?: { timeoutMs?: number }): Promise<number> => {

--- a/tests/v4/harness/aidenTermSmoke.test.ts
+++ b/tests/v4/harness/aidenTermSmoke.test.ts
@@ -105,6 +105,11 @@ describe.skipIf(SKIP_INTERACTIVE_PTY)('aidenTerm harness — PTY smoke (Slice 10
       ].join('\n') + '\n',
       'utf8',
     );
+    await fs.writeFile(
+      path.join(aidenHome, '.onboarding-shown'),
+      new Date().toISOString() + '\n',
+      'utf8',
+    );
 
     term = await spawnAidenTerm({
       cwd,

--- a/tests/v4/harness/builtProviderPreload.cjs
+++ b/tests/v4/harness/builtProviderPreload.cjs
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('node:path');
+const baseUrl = process.env.AIDEN_TEST_PROVIDER_BASE_URL;
+if (!baseUrl) throw new Error('AIDEN_TEST_PROVIDER_BASE_URL is required');
+const repoRoot = process.env.AIDEN_TEST_REPO_ROOT || process.cwd();
+const registry = require(path.resolve(repoRoot, 'dist/providers/v4/registry.js'));
+registry.PROVIDER_REGISTRY.custom_openai.baseUrl = baseUrl;

--- a/tests/v4/harness/fullRuntimeInputPtyFixture.ts
+++ b/tests/v4/harness/fullRuntimeInputPtyFixture.ts
@@ -1,0 +1,167 @@
+import { AidenAgent, type ToolExecutor } from '../../../core/v4/aidenAgent';
+import { CommandRegistry } from '../../../cli/v4/commandRegistry';
+import { CliCallbacks } from '../../../cli/v4/callbacks';
+import { ChatSession, type ChatSessionOptions } from '../../../cli/v4/chatSession';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { CLARIFY_SCHEMA, makeClarifyTool } from '../../../tools/v4/clarify/clarifyTool';
+import type {
+  ProviderAdapter,
+  ProviderCallInput,
+  ProviderCallOutput,
+  ToolCallRequest,
+} from '../../../providers/v4/types';
+
+const usage = { inputTokens: 1, outputTokens: 1 };
+
+class ScriptedProvider implements ProviderAdapter {
+  apiMode = 'chat_completions' as const;
+  callCount = 0;
+  private readonly outputs: ProviderCallOutput[] = [
+    {
+      content: '', finishReason: 'tool_calls', usage,
+      toolCalls: [{
+        id: 'clarify-format', name: 'clarify',
+        arguments: {
+          question: 'Which format would you like for the report?',
+          options: ['Markdown', 'Plain text'],
+        },
+      }],
+    },
+    {
+      content: '', finishReason: 'tool_calls', usage,
+      toolCalls: [{
+        id: 'clarify-topic', name: 'clarify',
+        arguments: { question: 'What topic should the Markdown report cover?' },
+      }],
+    },
+    { content: 'Clarifications completed.', toolCalls: [], finishReason: 'stop', usage },
+    { content: 'Normal input completed.', toolCalls: [], finishReason: 'stop', usage },
+  ];
+
+  async call(_input: ProviderCallInput): Promise<ProviderCallOutput> {
+    this.callCount += 1;
+    diagnostic('PROVIDER_CALL', { count: this.callCount });
+    const output = this.outputs.shift();
+    if (!output) throw new Error('scripted provider exhausted');
+    return output;
+  }
+}
+
+function diagnostic(name: string, value: unknown): void {
+  process.stdout.write(`\n[P2A_FULL:${name}]${JSON.stringify(value)}\n`);
+}
+
+async function main(): Promise<void> {
+  if (!process.stdin.isTTY || typeof process.stdin.setRawMode !== 'function') {
+    throw new Error('full-runtime input regression requires a TTY');
+  }
+
+  const skin = new SkinEngine({ forceMono: true });
+  const display = new Display({ skin, stdout: process.stdout, stderr: process.stderr });
+  const callbacks = new CliCallbacks({ display });
+  const provider = new ScriptedProvider();
+  const clarify = makeClarifyTool();
+  const executor: ToolExecutor = async (call: ToolCallRequest) => {
+    diagnostic('TOOL_EXECUTE', { id: call.id, name: call.name });
+    if (call.name !== 'clarify') {
+      return { id: call.id, name: call.name, result: { ok: true } };
+    }
+    const result = await clarify.execute(call.arguments, {
+      clarify: callbacks.promptClarify,
+    } as never);
+    return { id: call.id, name: call.name, result };
+  };
+  const agent = new AidenAgent({
+    provider,
+    tools: [CLARIFY_SCHEMA],
+    toolExecutor: executor,
+    onToolCall: callbacks.onToolCall,
+    resolveMutates: () => false,
+    resolveUiOnly: () => false,
+  });
+
+  const sessionManager = {
+    startSession: () => ({ id: 'p2a-full-runtime', title: null, providerId: 'scripted', modelId: 'scripted' }),
+    recordTurn: () => undefined,
+    resumeLatest: () => undefined,
+    resumeById: () => undefined,
+    listSessions: () => [],
+    setSessionTitle: () => undefined,
+    search: () => [],
+  };
+  const approvalEngine = {
+    setMode: () => undefined,
+    getMode: () => 'manual',
+    checkApproval: async () => true,
+    allowForSession: () => undefined,
+    allowAlways: () => undefined,
+    resetSession: () => undefined,
+  };
+  const toolRegistry = {
+    list: () => ['clarify'],
+    get: () => ({ schema: CLARIFY_SCHEMA, mutates: false, category: 'read', toolset: 'clarify' }),
+    getSchemas: () => [CLARIFY_SCHEMA],
+    register: () => undefined,
+    unregister: () => undefined,
+    byCategory: () => [],
+    buildExecutor: () => executor,
+  };
+  const commands = new CommandRegistry();
+  commands.register({
+    name: 'p2a-result',
+    description: 'Finish the P2A runtime fixture.',
+    category: 'system',
+    hidden: true,
+    handler: async () => ({ exit: true }),
+  });
+  const options: ChatSessionOptions = {
+    agent,
+    display,
+    commandRegistry: commands,
+    callbacks,
+    sessionManager: sessionManager as never,
+    approvalEngine: approvalEngine as never,
+    skin,
+    toolRegistry: toolRegistry as never,
+    skillLoader: {
+      list: async () => [], load: async () => undefined,
+      loadAll: async () => [], readSkillFile: async () => undefined,
+    } as never,
+    resolver: {
+      resolve: async () => provider,
+      describe: () => undefined,
+      listProviders: () => [],
+      listModels: () => [],
+    } as never,
+    config: {} as never,
+    initialProviderId: 'scripted',
+    initialModelId: 'scripted',
+    installSignalHandler: false,
+  };
+
+  const session = new ChatSession(options);
+  await session.run();
+  diagnostic('RESULT', {
+    providerCalls: provider.callCount,
+    queue: session.listQueue(),
+    activityCount: callbacks.activeActivityCount(),
+    activityTimers: callbacks.activityTimerCount(),
+    stdin: {
+      paused: process.stdin.isPaused(),
+      flowing: process.stdin.readableFlowing,
+      raw: process.stdin.isRaw === true,
+      data: process.stdin.listenerCount('data'),
+      keypress: process.stdin.listenerCount('keypress'),
+      readable: process.stdin.listenerCount('readable'),
+    },
+  });
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    diagnostic('ERROR', { message: error instanceof Error ? error.message : String(error) });
+    process.exit(1);
+  },
+);

--- a/tests/v4/harness/inputAuthorityPtyFixture.ts
+++ b/tests/v4/harness/inputAuthorityPtyFixture.ts
@@ -1,0 +1,154 @@
+import { confirm, select, input } from '@inquirer/prompts';
+import { InputAuthority, type RawStdinLike } from '../../../cli/v4/inputAuthority';
+
+type Snapshot = {
+  paused: boolean;
+  flowing: boolean | null;
+  raw: boolean;
+  data: number;
+  keypress: number;
+  readable: number;
+  sigint: number;
+};
+
+const scenario = process.argv[2] ?? 'complete';
+const stdin = process.stdin as unknown as RawStdinLike & NodeJS.ReadStream;
+
+function snapshot(): Snapshot {
+  return {
+    paused: stdin.isPaused(),
+    flowing: stdin.readableFlowing,
+    raw: stdin.isRaw === true,
+    data: stdin.listenerCount('data'),
+    keypress: stdin.listenerCount('keypress'),
+    readable: stdin.listenerCount('readable'),
+    sigint: stdin.listenerCount('SIGINT'),
+  };
+}
+
+function diagnostic(name: string, value: unknown): void {
+  process.stdout.write(`\n[P2A:${name}]${JSON.stringify(value)}\n`);
+}
+
+async function main(): Promise<void> {
+  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
+    throw new Error('The input-authority regression requires a real TTY');
+  }
+
+  const authority = new InputAuthority({ stdin });
+  let rawLine = '';
+  const rawLines: string[] = [];
+  let normalResolve!: (line: string) => void;
+  const normalLine = new Promise<string>((resolve) => { normalResolve = resolve; });
+  let restoreCount = 0;
+
+  const unmount = authority.mountRawOwner('during_turn', (str, key) => {
+    if (key.name === 'return') {
+      rawLines.push(rawLine);
+      normalResolve(rawLine);
+      rawLine = '';
+      return;
+    }
+    if (typeof str === 'string' && !key.ctrl && !key.meta) rawLine += str;
+  });
+  const baseline = snapshot();
+  let firstCleanup!: Snapshot;
+  let secondCleanup!: Snapshot;
+
+  if (scenario === 'skill-normal') {
+    const first = await authority.runExclusive('skill_prompt', async (modalInput) => {
+      const answer = await confirm(
+        { message: 'Save this as a reusable skill?', default: false },
+        { input: modalInput },
+      );
+      firstCleanup = snapshot();
+      diagnostic('FIRST_CLEANUP', firstCleanup);
+      return answer;
+    });
+    restoreCount += 1;
+    const firstRestored = snapshot();
+    diagnostic('FIRST_RESTORED', firstRestored);
+    const leakedBeforeNormal = [...rawLines, rawLine];
+    diagnostic('NORMAL_READY', { owner: authority.currentOwner() });
+    const typedAfterward = await normalLine;
+    diagnostic('RESULT', {
+      scenario, first, baseline, firstCleanup, firstRestored,
+      leakedBeforeNormal, typedAfterward, rawLines,
+      owner: authority.currentOwner(), restoreCount,
+    });
+    unmount();
+    return;
+  }
+
+  const first = await authority.runExclusive(
+    scenario === 'approval-clarify' ? 'approval' : 'clarify',
+    async (modalInput) => {
+    const answer = await select({
+      message: scenario === 'approval-clarify'
+        ? 'Decision'
+        : 'Which format would you like for the report?',
+      choices: scenario === 'approval-clarify'
+        ? [{ name: 'Allow', value: 'allow' }, { name: 'Deny', value: 'deny' }]
+        : [{ name: 'Markdown', value: 'Markdown' }, { name: 'Plain text', value: 'Plain text' }],
+    }, { input: modalInput });
+    firstCleanup = snapshot();
+    diagnostic('FIRST_CLEANUP', firstCleanup);
+    return answer;
+    },
+  );
+  restoreCount += 1;
+  const firstRestored = snapshot();
+  diagnostic('FIRST_RESTORED', firstRestored);
+
+  const turn = new AbortController();
+  const second = await authority.runExclusive('clarify', async (modalInput) => {
+    try {
+      const answer = await input(
+        { message: scenario === 'approval-clarify'
+          ? 'Clarification after approval'
+          : 'What topic should the Markdown report cover?' },
+        { input: modalInput },
+      );
+      secondCleanup = snapshot();
+      diagnostic('SECOND_CLEANUP', secondCleanup);
+      return answer;
+    } catch {
+      secondCleanup = snapshot();
+      diagnostic('SECOND_CLEANUP', secondCleanup);
+      return null;
+    }
+  });
+  restoreCount += 1;
+  const secondRestored = snapshot();
+  diagnostic('SECOND_RESTORED', secondRestored);
+  const leakedBeforeNormal = [...rawLines, rawLine];
+
+  diagnostic('NORMAL_READY', { owner: authority.currentOwner() });
+  const typedAfterward = await normalLine;
+
+  diagnostic('RESULT', {
+    scenario,
+    first,
+    second,
+    baseline,
+    firstCleanup,
+    secondCleanup,
+    firstRestored,
+    secondRestored,
+    leakedBeforeNormal,
+    typedAfterward,
+    rawLines,
+    owner: authority.currentOwner(),
+    restoreCount,
+    turnAborted: turn.signal.aborted,
+  });
+  unmount();
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    diagnostic('ERROR', { message: error instanceof Error ? error.message : String(error) });
+    process.exit(1);
+  },
+);

--- a/tests/v4/harness/mockProvider.ts
+++ b/tests/v4/harness/mockProvider.ts
@@ -43,6 +43,13 @@ export interface MockProviderOptions {
   chunkDelayMs?: number;
   /** Model id served + accepted. Default: "mock-model". */
   modelId?: string;
+  /** Optional deterministic response per provider call. */
+  script?: MockProviderTurn[];
+}
+
+export interface MockProviderTurn {
+  content?: string;
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
 }
 
 export interface MockProvider {
@@ -67,6 +74,7 @@ export async function startMockProvider(
   const chunkCount   = Math.max(1, opts.chunkCount ?? 4);
   const chunkDelay   = opts.chunkDelayMs ?? 10;
   const modelId      = opts.modelId ?? 'mock-model';
+  const script       = opts.script;
 
   let callCount = 0;
   let lastRequest: unknown | null = null;
@@ -94,6 +102,7 @@ export async function startMockProvider(
     } catch {
       lastRequest = body;
     }
+    const scriptedTurn = script?.[callCount];
     callCount += 1;
 
     res.writeHead(200, {
@@ -101,13 +110,6 @@ export async function startMockProvider(
       'Cache-Control': 'no-cache',
       'Connection':    'keep-alive',
     });
-
-    // Split responseText into N approximately-equal chunks.
-    const chunks: string[] = [];
-    const chunkSize = Math.ceil(responseText.length / chunkCount);
-    for (let i = 0; i < responseText.length; i += chunkSize) {
-      chunks.push(responseText.slice(i, i + chunkSize));
-    }
 
     // Opening frame: role announcement.
     res.write(`data: ${JSON.stringify({
@@ -117,15 +119,41 @@ export async function startMockProvider(
       choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
     })}\n\n`);
 
-    // Content frames.
-    for (const c of chunks) {
+    if (scriptedTurn?.toolCalls?.length) {
       await sleep(chunkDelay);
       res.write(`data: ${JSON.stringify({
-        id: 'mock-completion-1',
+        id: `mock-completion-${callCount}`,
         object: 'chat.completion.chunk',
         model: modelId,
-        choices: [{ index: 0, delta: { content: c }, finish_reason: null }],
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: scriptedTurn.toolCalls.map((call, index) => ({
+              index,
+              id: call.id,
+              type: 'function',
+              function: { name: call.name, arguments: JSON.stringify(call.arguments) },
+            })),
+          },
+          finish_reason: null,
+        }],
       })}\n\n`);
+    } else {
+      const scriptedText = scriptedTurn?.content ?? responseText;
+      const scriptedChunks: string[] = [];
+      const scriptedChunkSize = Math.max(1, Math.ceil(scriptedText.length / chunkCount));
+      for (let i = 0; i < scriptedText.length; i += scriptedChunkSize) {
+        scriptedChunks.push(scriptedText.slice(i, i + scriptedChunkSize));
+      }
+      for (const c of scriptedChunks) {
+        await sleep(chunkDelay);
+        res.write(`data: ${JSON.stringify({
+          id: `mock-completion-${callCount}`,
+          object: 'chat.completion.chunk',
+          model: modelId,
+          choices: [{ index: 0, delta: { content: c }, finish_reason: null }],
+        })}\n\n`);
+      }
     }
 
     // Finish frame.
@@ -134,7 +162,11 @@ export async function startMockProvider(
       id: 'mock-completion-1',
       object: 'chat.completion.chunk',
       model: modelId,
-      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      choices: [{
+        index: 0,
+        delta: {},
+        finish_reason: scriptedTurn?.toolCalls?.length ? 'tool_calls' : 'stop',
+      }],
     })}\n\n`);
     res.write('data: [DONE]\n\n');
     res.end();

--- a/tests/v4/harness/mockProvider.ts
+++ b/tests/v4/harness/mockProvider.ts
@@ -41,6 +41,8 @@ export interface MockProviderOptions {
   chunkCount?: number;
   /** Delay between chunks in ms. Default: 10. */
   chunkDelayMs?: number;
+  /** Optional delay before response headers, for cancellation tests. */
+  headerDelayMs?: number;
   /** Model id served + accepted. Default: "mock-model". */
   modelId?: string;
   /** Optional deterministic response per provider call. */
@@ -73,6 +75,7 @@ export async function startMockProvider(
   const responseText = opts.responseText ?? 'hello from mock';
   const chunkCount   = Math.max(1, opts.chunkCount ?? 4);
   const chunkDelay   = opts.chunkDelayMs ?? 10;
+  const headerDelay  = opts.headerDelayMs ?? 0;
   const modelId      = opts.modelId ?? 'mock-model';
   const script       = opts.script;
 
@@ -105,6 +108,7 @@ export async function startMockProvider(
     const scriptedTurn = script?.[callCount];
     callCount += 1;
 
+    if (headerDelay > 0) await sleep(headerDelay);
     res.writeHead(200, {
       'Content-Type':  'text/event-stream',
       'Cache-Control': 'no-cache',

--- a/tests/v4/integration/localPromptTools.real.test.ts
+++ b/tests/v4/integration/localPromptTools.real.test.ts
@@ -1,5 +1,5 @@
 /**
- * Real-network integration test for OllamaPromptToolsAdapter.
+ * Real-network integration test for LocalPromptToolsAdapter.
  *
  * Skips automatically when Ollama is not reachable on http://localhost:11434.
  * Skipping is decided ONCE at module load using a 2s reachability probe so we
@@ -13,7 +13,7 @@
  * always; the tool-calling test is gated on a slightly larger default model.
  */
 import { describe, it, expect } from 'vitest';
-import { OllamaPromptToolsAdapter } from '../../../providers/v4/ollamaPromptToolsAdapter';
+import { LocalPromptToolsAdapter } from '../../../providers/v4/localPromptToolsAdapter';
 import { AidenAgent } from '../../../core/v4/aidenAgent';
 import type { ToolSchema } from '../../../providers/v4/types';
 
@@ -33,9 +33,9 @@ async function probeOllama(): Promise<boolean> {
 
 const ollamaUp = await probeOllama();
 
-describe.skipIf(!ollamaUp)('OllamaPromptToolsAdapter — real Ollama integration', () => {
+describe.skipIf(!ollamaUp)('LocalPromptToolsAdapter — real local-runtime integration', () => {
   it('completes a simple conversation (no tools)', async () => {
-    const adapter = new OllamaPromptToolsAdapter({
+    const adapter = new LocalPromptToolsAdapter({
       baseUrl: OLLAMA_BASE,
       model: OLLAMA_MODEL,
       providerName: 'ollama',
@@ -52,7 +52,7 @@ describe.skipIf(!ollamaUp)('OllamaPromptToolsAdapter — real Ollama integration
   }, 60_000);
 
   it('completes a tool-calling conversation end-to-end (best-effort)', async () => {
-    const adapter = new OllamaPromptToolsAdapter({
+    const adapter = new LocalPromptToolsAdapter({
       baseUrl: OLLAMA_BASE,
       model: OLLAMA_MODEL,
       providerName: 'ollama',

--- a/tests/v4/integration/messageApiAdapter.real.test.ts
+++ b/tests/v4/integration/messageApiAdapter.real.test.ts
@@ -1,5 +1,5 @@
 /**
- * Real-network integration test for AnthropicAdapter.
+ * Real-network integration test for MessageApiAdapter.
  *
  * Skips automatically when ANTHROPIC_API_KEY is not set.
  *
@@ -8,16 +8,16 @@
  * Combined run should burn well under 3k tokens.
  */
 import { describe, it, expect } from 'vitest';
-import { AnthropicAdapter } from '../../../providers/v4/anthropicAdapter';
+import { MessageApiAdapter } from '../../../providers/v4/messageApiAdapter';
 import { AidenAgent } from '../../../core/v4/aidenAgent';
 import type { ToolSchema } from '../../../providers/v4/types';
 
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_TEST_MODEL || 'claude-haiku-4-5-20251001';
 
-describe.skipIf(!ANTHROPIC_KEY)('AnthropicAdapter — real Anthropic integration', () => {
+describe.skipIf(!ANTHROPIC_KEY)('MessageApiAdapter — real message-API integration', () => {
   it('completes a simple conversation (no tools)', async () => {
-    const adapter = new AnthropicAdapter({
+    const adapter = new MessageApiAdapter({
       apiKey: ANTHROPIC_KEY!,
       authMode: 'api_key',
       model: ANTHROPIC_MODEL,
@@ -37,7 +37,7 @@ describe.skipIf(!ANTHROPIC_KEY)('AnthropicAdapter — real Anthropic integration
   }, 30_000);
 
   it('completes a tool-calling conversation end-to-end via AidenAgent', async () => {
-    const adapter = new AnthropicAdapter({
+    const adapter = new MessageApiAdapter({
       apiKey: ANTHROPIC_KEY!,
       authMode: 'api_key',
       model: ANTHROPIC_MODEL,

--- a/tests/v4/localPromptToolsAdapter.test.ts
+++ b/tests/v4/localPromptToolsAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { OllamaPromptToolsAdapter } from '../../providers/v4/ollamaPromptToolsAdapter';
+import { LocalPromptToolsAdapter } from '../../providers/v4/localPromptToolsAdapter';
 import { ProviderError } from '../../providers/v4/errors';
 import type { Message, ToolSchema } from '../../providers/v4/types';
 
@@ -38,7 +38,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('OllamaPromptToolsAdapter', () => {
+describe('LocalPromptToolsAdapter', () => {
   it('1. builds correct request body (no tools field, /api/chat, stream:false)', async () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({
@@ -48,7 +48,7 @@ describe('OllamaPromptToolsAdapter', () => {
         done: true,
       }),
     );
-    await new OllamaPromptToolsAdapter(baseOptions).call({
+    await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -65,7 +65,7 @@ describe('OllamaPromptToolsAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ message: { role: 'assistant', content: 'ok' }, done: true }),
     );
-    await new OllamaPromptToolsAdapter(baseOptions).call({
+    await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [sysMsg('be brief'), userMsg('hi')],
       tools,
     });
@@ -80,7 +80,7 @@ describe('OllamaPromptToolsAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ message: { role: 'assistant', content: 'ok' }, done: true }),
     );
-    await new OllamaPromptToolsAdapter(baseOptions).call({
+    await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools,
     });
@@ -102,7 +102,7 @@ describe('OllamaPromptToolsAdapter', () => {
         done: true,
       }),
     );
-    const result = await new OllamaPromptToolsAdapter(baseOptions).call({
+    const result = await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('what time?')],
       tools,
     });
@@ -126,7 +126,7 @@ describe('OllamaPromptToolsAdapter', () => {
         done: true,
       }),
     );
-    const result = await new OllamaPromptToolsAdapter(baseOptions).call({
+    const result = await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('q')],
       tools,
     });
@@ -150,7 +150,7 @@ describe('OllamaPromptToolsAdapter', () => {
         done: true,
       }),
     );
-    const result = await new OllamaPromptToolsAdapter(baseOptions).call({
+    const result = await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('q')],
       tools,
     });
@@ -167,7 +167,7 @@ describe('OllamaPromptToolsAdapter', () => {
         done: true,
       }),
     );
-    const result = await new OllamaPromptToolsAdapter(baseOptions).call({
+    const result = await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -185,7 +185,7 @@ describe('OllamaPromptToolsAdapter', () => {
         done: true,
       }),
     );
-    const result = await new OllamaPromptToolsAdapter(baseOptions).call({
+    const result = await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [userMsg('q')],
       tools: [],
     });
@@ -194,7 +194,7 @@ describe('OllamaPromptToolsAdapter', () => {
 
   it('9. connection error → ProviderError with "Ollama not reachable"', async () => {
     fetchMock.mockRejectedValueOnce(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }));
-    const adapter = new OllamaPromptToolsAdapter({ ...baseOptions, maxRetries: 0 });
+    const adapter = new LocalPromptToolsAdapter({ ...baseOptions, maxRetries: 0 });
     await expect(adapter.call({ messages: [userMsg('hi')], tools: [] })).rejects.toThrow(
       /Ollama not reachable/,
     );
@@ -204,7 +204,7 @@ describe('OllamaPromptToolsAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ message: { role: 'assistant', content: 'done' }, done: true }),
     );
-    await new OllamaPromptToolsAdapter(baseOptions).call({
+    await new LocalPromptToolsAdapter(baseOptions).call({
       messages: [
         userMsg('what time?'),
         {
@@ -239,7 +239,7 @@ describe('OllamaPromptToolsAdapter', () => {
           });
         }),
     );
-    const adapter = new OllamaPromptToolsAdapter({
+    const adapter = new LocalPromptToolsAdapter({
       ...baseOptions,
       timeoutMs: 10,
       maxRetries: 0,

--- a/tests/v4/messageApiAdapter.test.ts
+++ b/tests/v4/messageApiAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AnthropicAdapter } from '../../providers/v4/anthropicAdapter';
+import { MessageApiAdapter } from '../../providers/v4/messageApiAdapter';
 import { ProviderError, ProviderRateLimitError } from '../../providers/v4/errors';
 import type { Message, ToolSchema } from '../../providers/v4/types';
 
@@ -37,7 +37,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('AnthropicAdapter', () => {
+describe('MessageApiAdapter', () => {
   it('1. builds correct request body (system separated, tools as input_schema)', async () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({
@@ -46,7 +46,7 @@ describe('AnthropicAdapter', () => {
         usage: { input_tokens: 5, output_tokens: 1 },
       }),
     );
-    const adapter = new AnthropicAdapter(apiKeyOptions);
+    const adapter = new MessageApiAdapter(apiKeyOptions);
     const tools: ToolSchema[] = [
       {
         name: 'echo',
@@ -86,7 +86,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({ messages: [userMsg('hi')], tools: [] });
+    await new MessageApiAdapter(apiKeyOptions).call({ messages: [userMsg('hi')], tools: [] });
     const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
     expect(headers['x-api-key']).toBe('sk-ant-test');
     expect(headers['Authorization']).toBeUndefined();
@@ -101,7 +101,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({ messages: [userMsg('hi')], tools: [] });
+    await new MessageApiAdapter(apiKeyOptions).call({ messages: [userMsg('hi')], tools: [] });
     const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
     expect(headers['anthropic-beta']).toBeUndefined();
   });
@@ -110,7 +110,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({
+    await new MessageApiAdapter(apiKeyOptions).call({
       messages: [{ role: 'system', content: 'be brief' }, userMsg('hi')],
       tools: [],
     });
@@ -123,7 +123,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({
+    await new MessageApiAdapter(apiKeyOptions).call({
       messages: [{ role: 'system', content: 'You are Aiden, built by Taracod.' }, userMsg('hi')],
       tools: [],
     });
@@ -143,7 +143,7 @@ describe('AnthropicAdapter', () => {
         inputSchema: { type: 'object', properties: {} },
       },
     ];
-    await new AnthropicAdapter(apiKeyOptions).call({ messages: [userMsg('hi')], tools });
+    await new MessageApiAdapter(apiKeyOptions).call({ messages: [userMsg('hi')], tools });
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.tools[0].name).toBe('web_search');
   });
@@ -156,7 +156,7 @@ describe('AnthropicAdapter', () => {
         usage: { input_tokens: 7, output_tokens: 2 },
       }),
     );
-    const result = await new AnthropicAdapter(apiKeyOptions).call({
+    const result = await new MessageApiAdapter(apiKeyOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -175,7 +175,7 @@ describe('AnthropicAdapter', () => {
         stop_reason: 'tool_use',
       }),
     );
-    const result = await new AnthropicAdapter(apiKeyOptions).call({
+    const result = await new MessageApiAdapter(apiKeyOptions).call({
       messages: [userMsg('echo hi')],
       tools: [],
     });
@@ -197,7 +197,7 @@ describe('AnthropicAdapter', () => {
         stop_reason: 'tool_use',
       }),
     );
-    const result = await new AnthropicAdapter(apiKeyOptions).call({
+    const result = await new MessageApiAdapter(apiKeyOptions).call({
       messages: [userMsg('q')],
       tools: [],
     });
@@ -210,7 +210,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [], stop_reason: 'end_turn', usage: { input_tokens: 1, output_tokens: 0 } }),
     );
-    const result = await new AnthropicAdapter(apiKeyOptions).call({
+    const result = await new MessageApiAdapter(apiKeyOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -227,7 +227,7 @@ describe('AnthropicAdapter', () => {
       .mockResolvedValueOnce(
         makeResponse({ content: [{ type: 'text', text: 'b' }], stop_reason: 'stop_sequence' }),
       );
-    const adapter = new AnthropicAdapter({ ...apiKeyOptions, maxRetries: 0 });
+    const adapter = new MessageApiAdapter({ ...apiKeyOptions, maxRetries: 0 });
     const r1 = await adapter.call({ messages: [userMsg('1')], tools: [] });
     const r2 = await adapter.call({ messages: [userMsg('2')], tools: [] });
     expect(r1.finishReason).toBe('length');
@@ -247,7 +247,7 @@ describe('AnthropicAdapter', () => {
         },
       }),
     );
-    const result = await new AnthropicAdapter(apiKeyOptions).call({
+    const result = await new MessageApiAdapter(apiKeyOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -263,7 +263,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({
+    await new MessageApiAdapter(apiKeyOptions).call({
       messages: [
         userMsg('echo hi'),
         { role: 'assistant', content: '', toolCalls: [{ id: 'tc1', name: 'echo', arguments: { text: 'hi' } }] },
@@ -287,7 +287,7 @@ describe('AnthropicAdapter', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({
+    await new MessageApiAdapter(apiKeyOptions).call({
       messages: [
         userMsg('search'),
         {
@@ -312,7 +312,7 @@ describe('AnthropicAdapter', () => {
       .mockResolvedValueOnce(
         makeResponse({ content: [{ type: 'text', text: 'finally' }], stop_reason: 'end_turn' }),
       );
-    const adapter = new AnthropicAdapter({ ...apiKeyOptions, maxRetries: 1 });
+    const adapter = new MessageApiAdapter({ ...apiKeyOptions, maxRetries: 1 });
     const promise = adapter.call({ messages: [userMsg('hi')], tools: [] });
     await vi.advanceTimersByTimeAsync(1500);
     const result = await promise;
@@ -323,7 +323,7 @@ describe('AnthropicAdapter', () => {
   it('15. exhausted retries on 429 throws ProviderRateLimitError', async () => {
     vi.useFakeTimers();
     fetchMock.mockResolvedValue(makeResponse({ error: 'rate' }, { status: 429 }));
-    const adapter = new AnthropicAdapter({ ...apiKeyOptions, maxRetries: 1 });
+    const adapter = new MessageApiAdapter({ ...apiKeyOptions, maxRetries: 1 });
     const promise = adapter.call({ messages: [userMsg('hi')], tools: [] });
     promise.catch(() => undefined); // suppress unhandled
     await vi.advanceTimersByTimeAsync(2500);
@@ -333,7 +333,7 @@ describe('AnthropicAdapter', () => {
 
   it('16. 401 fails fast, no retry', async () => {
     fetchMock.mockResolvedValueOnce(makeResponse('unauthorized', { status: 401 }));
-    const adapter = new AnthropicAdapter({ ...apiKeyOptions, maxRetries: 2 });
+    const adapter = new MessageApiAdapter({ ...apiKeyOptions, maxRetries: 2 });
     await expect(adapter.call({ messages: [userMsg('hi')], tools: [] })).rejects.toBeInstanceOf(
       ProviderError,
     );
@@ -341,12 +341,12 @@ describe('AnthropicAdapter', () => {
   });
 });
 
-describe('AnthropicAdapter — image content (B2.2a)', () => {
+describe('MessageApiAdapter — image content (B2.2a)', () => {
   it('maps user images to base64 image blocks alongside the text block', async () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'a red square' }], stop_reason: 'end_turn', usage: { input_tokens: 9, output_tokens: 3 } }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({
+    await new MessageApiAdapter(apiKeyOptions).call({
       messages: [{ role: 'user', content: 'what is in this image?', images: ['data:image/png;base64,iVBORabc'] }],
       tools: [],
     });
@@ -364,7 +364,7 @@ describe('AnthropicAdapter — image content (B2.2a)', () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOptions).call({ messages: [userMsg('plain text')], tools: [] });
+    await new MessageApiAdapter(apiKeyOptions).call({ messages: [userMsg('plain text')], tools: [] });
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.messages).toEqual([{ role: 'user', content: 'plain text' }]);
   });

--- a/tests/v4/messageApiIdentity.test.ts
+++ b/tests/v4/messageApiIdentity.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { AnthropicAdapter } from '../../providers/v4/anthropicAdapter';
+import { MessageApiAdapter } from '../../providers/v4/messageApiAdapter';
 import { VERSION } from '../../core/version';
 import { getProviderEntry } from '../../providers/v4/registry';
 import { findModel } from '../../providers/v4/modelCatalog';
@@ -28,7 +28,7 @@ const apiKeyOpts = {
   model: 'claude-haiku-4-5-20251001',
   providerName: 'anthropic',
   maxRetries: 1,
-} as unknown as ConstructorParameters<typeof AnthropicAdapter>[0];
+} as unknown as ConstructorParameters<typeof MessageApiAdapter>[0];
 
 const userMsg = (content: string): { role: 'user'; content: string } => ({ role: 'user', content });
 
@@ -49,7 +49,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] });
+    await new MessageApiAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] });
     const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
     expect(headers['user-agent']).toBe(`aiden/${VERSION}`);
     expect(headers['user-agent']).toMatch(/^aiden\/\d+\.\d+\.\d+/);
@@ -59,7 +59,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] });
+    await new MessageApiAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] });
     const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
     expect(headers['x-app']).toBeUndefined();
   });
@@ -70,7 +70,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] });
+    await new MessageApiAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] });
     const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
     expect(headers['user-agent']).toBe(`aiden/${VERSION}`);   // dynamic, from core/version
     expect(headers['x-app']).toBeUndefined();                  // no billing fingerprint
@@ -86,7 +86,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
     fetchMock.mockResolvedValueOnce(
       makeResponse({ content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' }),
     );
-    await new AnthropicAdapter(apiKeyOpts).call({
+    await new MessageApiAdapter(apiKeyOpts).call({
       messages: [{ role: 'system', content: 'be brief' }, userMsg('hi')],
       tools: [],
     });
@@ -104,7 +104,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
         stop_reason: 'tool_use',
       }),
     );
-    const result = await new AnthropicAdapter(apiKeyOpts).call({
+    const result = await new MessageApiAdapter(apiKeyOpts).call({
       messages: [userMsg('go')],
       tools: [{ name: 'web_search', description: 's', inputSchema: { type: 'object', properties: {} } }],
     });
@@ -122,7 +122,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
       new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
     );
     const evts: Array<{ type: string }> = [];
-    for await (const e of new AnthropicAdapter(apiKeyOpts).callStream({ messages: [userMsg('hi')], tools: [] })) {
+    for await (const e of new MessageApiAdapter(apiKeyOpts).callStream({ messages: [userMsg('hi')], tools: [] })) {
       evts.push(e);
     }
     expect(evts.some((e) => e.type === 'delta')).toBe(true);
@@ -132,7 +132,7 @@ describe('Anthropic API-key requests carry an honest Aiden identity (no CLI impe
   it('regression: still reports a 401 as a fail-fast error', async () => {
     fetchMock.mockResolvedValueOnce(makeResponse('unauthorized', { status: 401 }));
     await expect(
-      new AnthropicAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] }),
+      new MessageApiAdapter(apiKeyOpts).call({ messages: [userMsg('hi')], tools: [] }),
     ).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/tests/v4/providers/responseStreamBehavior.test.ts
+++ b/tests/v4/providers/responseStreamBehavior.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { CodexResponsesAdapter } from '../../../providers/v4/codexResponsesAdapter';
+import { ResponseStreamAdapter } from '../../../providers/v4/responseStreamAdapter';
 
 /**
- * Phase 21 #6c — chatgpt.com/backend-api/codex requires `stream: true`.
+ * Phase 21 #6c — the subscription response endpoint requires `stream: true`.
  * Sending stream:false (or omitting it) returns HTTP 400
- * "Stream must be set to true." Aiden always streams the Codex backend
+ * "Stream must be set to true." Aiden always streams this backend
  * and aggregates SSE frames internally so callers see the same JSON
  * shape they get from non-streaming providers.
  */
@@ -42,7 +42,7 @@ function jsonResponse(obj: object): Response {
 }
 
 function adapter(baseUrl: string) {
-  return new CodexResponsesAdapter({
+  return new ResponseStreamAdapter({
     baseUrl,
     apiKey: 'sk-test',
     model: 'gpt-5.3-codex',
@@ -51,8 +51,8 @@ function adapter(baseUrl: string) {
   });
 }
 
-describe('Phase 21 #6c — Codex backend always streams', () => {
-  it('1. request body sets stream:true when baseUrl is the Codex backend', async () => {
+describe('Phase 21 #6c — subscription response backend always streams', () => {
+  it('1. request body sets stream:true for the subscription response backend', async () => {
     globalThis.fetch = vi.fn(async (url, init) => {
       captured.url = String(url);
       captured.body = JSON.parse(String(init?.body ?? '{}'));
@@ -84,10 +84,10 @@ describe('Phase 21 #6c — Codex backend always streams', () => {
     expect(r.finishReason).toBe('stop');
   });
 
-  it('2. non-Codex baseUrl does NOT set stream:true (regular Responses API path uses JSON)', async () => {
+  it('2. regular baseUrl does NOT set stream:true (standard Responses API path uses JSON)', async () => {
     globalThis.fetch = vi.fn(async (url, init) => {
       captured.body = JSON.parse(String(init?.body ?? '{}'));
-      // Non-Codex path expects JSON response — adapter calls response.json().
+      // Standard path expects JSON response — adapter calls response.json().
       return jsonResponse({
         status: 'completed',
         output: [

--- a/tests/v4/providers/responseStreamHeaders.test.ts
+++ b/tests/v4/providers/responseStreamHeaders.test.ts
@@ -1,22 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
-  CodexResponsesAdapter,
-  extractChatGptAccountId,
-} from '../../../providers/v4/codexResponsesAdapter';
+  ResponseStreamAdapter,
+  extractResponseAccountId,
+} from '../../../providers/v4/responseStreamAdapter';
 
 /**
- * Phase 21 #6 reopen — Cloudflare-bypass headers required by
- * chatgpt.com/backend-api/codex. verbatim from
- * agent/auxiliary_client.py:_codex_cloudflare_headers.
+ * Phase 21 #6 reopen — compatibility headers required by the
+ * subscription response endpoint.
  *
- * Without these headers the Codex backend returns
- *   400 "model not supported when using Codex with a ChatGPT account"
- * regardless of slug or account entitlement. These tests pin the
- * adapter to the Codex-CLI header shape so a future "cleanup" doesn't strip them.
+ * Without these headers the backend rejects otherwise entitled models.
+ * These tests pin the required wire contract so a future cleanup does not
+ * strip compatibility fields.
  */
 
-// Build a minimal JWT (header.payload.signature) with a chatgpt_account_id
+// Build a minimal JWT (header.payload.signature) with the account-id
 // claim. We never verify signatures — adapter just decodes the payload.
 function makeJwt(payload: object): string {
   const b64 = (s: string) =>
@@ -24,24 +22,24 @@ function makeJwt(payload: object): string {
   return `${b64('{"alg":"HS256"}')}.${b64(JSON.stringify(payload))}.sig`;
 }
 
-describe('extractChatGptAccountId', () => {
-  it('1. extracts chatgpt_account_id from the auth claim', () => {
+describe('extractResponseAccountId', () => {
+  it('1. extracts the account id from the auth claim', () => {
     const token = makeJwt({
       'https://api.openai.com/auth': { chatgpt_account_id: 'acct_abc123' },
     });
-    expect(extractChatGptAccountId(token)).toBe('acct_abc123');
+    expect(extractResponseAccountId(token)).toBe('acct_abc123');
   });
 
   it('2. returns null on malformed JWT (no crash)', () => {
-    expect(extractChatGptAccountId('')).toBeNull();
-    expect(extractChatGptAccountId(null)).toBeNull();
-    expect(extractChatGptAccountId('not-a-jwt')).toBeNull();
-    expect(extractChatGptAccountId('a.b.c')).toBeNull(); // valid shape, garbage payload
-    expect(extractChatGptAccountId(makeJwt({ unrelated: 'claim' }))).toBeNull();
+    expect(extractResponseAccountId('')).toBeNull();
+    expect(extractResponseAccountId(null)).toBeNull();
+    expect(extractResponseAccountId('not-a-jwt')).toBeNull();
+    expect(extractResponseAccountId('a.b.c')).toBeNull(); // valid shape, garbage payload
+    expect(extractResponseAccountId(makeJwt({ unrelated: 'claim' }))).toBeNull();
   });
 });
 
-describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => {
+describe('ResponseStreamAdapter — subscription backend headers (Phase 21 #6)', () => {
   let originalFetch: typeof globalThis.fetch;
   let captured: { url?: string; headers?: any; body?: any };
 
@@ -52,10 +50,10 @@ describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => 
       captured.url = String(url);
       captured.headers = init?.headers ?? {};
       captured.body = JSON.parse(String(init?.body ?? '{}'));
-      // Minimal response. Codex backend → SSE (Phase 21 #6c always-stream
-      // contract). Non-Codex baseUrl → plain JSON. Tests below pass the
+      // Minimal response. Subscription backend → SSE (Phase 21 #6c
+      // always-stream contract). Standard baseUrl → plain JSON. Tests pass the
       // baseUrl through callWith() so we route on captured.url.
-      const isCodex = String(url).includes('chatgpt.com/backend-api/codex');
+      const isStreamingEndpoint = String(url).includes('chatgpt.com/backend-api/codex');
       const finalShape = {
         id: 'resp_1',
         status: 'completed',
@@ -68,7 +66,7 @@ describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => 
         ],
         usage: { input_tokens: 1, output_tokens: 1 },
       };
-      if (isCodex) {
+      if (isStreamingEndpoint) {
         const evt = { type: 'response.completed', response: finalShape };
         return new Response(
           `data: ${JSON.stringify(evt)}\n\ndata: [DONE]\n\n`,
@@ -88,7 +86,7 @@ describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => 
   });
 
   function callWith(baseUrl: string, token: string) {
-    const adapter = new CodexResponsesAdapter({
+    const adapter = new ResponseStreamAdapter({
       baseUrl,
       apiKey: token,
       model: 'gpt-5.3-codex',
@@ -102,7 +100,7 @@ describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => 
     });
   }
 
-  it('3. sends User-Agent + originator + ChatGPT-Account-ID when baseUrl is the Codex backend', async () => {
+  it('3. sends required compatibility headers for the subscription backend', async () => {
     const token = makeJwt({
       'https://api.openai.com/auth': { chatgpt_account_id: 'acct_xyz' },
     });
@@ -112,7 +110,7 @@ describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => 
     expect(captured.headers['ChatGPT-Account-ID']).toBe('acct_xyz');
   });
 
-  it('4. omits max_output_tokens when talking to the Codex backend', async () => {
+  it('4. omits max_output_tokens for the subscription backend', async () => {
     const token = makeJwt({
       'https://api.openai.com/auth': { chatgpt_account_id: 'acct_xyz' },
     });
@@ -120,15 +118,15 @@ describe('CodexResponsesAdapter — Codex backend headers (Phase 21 #6)', () => 
     expect(captured.body.max_output_tokens).toBeUndefined();
   });
 
-  it('5. does NOT send Cloudflare headers for non-Codex backends (api.openai.com/v1)', async () => {
+  it('5. does not send compatibility headers to the standard API backend', async () => {
     await callWith('https://api.openai.com/v1', 'sk-test-not-a-jwt');
-    // No special UA/originator/account-id when not the Codex backend —
+    // No special UA/originator/account-id on the standard backend —
     // a regular OpenAI API call uses the standard SDK contract.
     expect(captured.headers['originator']).toBeUndefined();
     expect(captured.headers['ChatGPT-Account-ID']).toBeUndefined();
     // Default User-Agent is fine here (whatever fetch sends, we don't override).
     expect(captured.headers['User-Agent']).toBeUndefined();
-    // max_output_tokens is sent for non-Codex backends.
+    // max_output_tokens is sent for standard backends.
     expect(captured.body.max_output_tokens).toBe(1024);
   });
 });

--- a/tests/v4/providers/responseStreamLifecycle.test.ts
+++ b/tests/v4/providers/responseStreamLifecycle.test.ts
@@ -36,7 +36,7 @@ async function startStallServer(stage: StallStage | 'complete'): Promise<{
     requests += 1;
     if (stage === 'before_headers') {
       markReady();
-      setTimeout(() => res.socket?.destroy(), 350).unref();
+      setTimeout(() => res.socket?.destroy(), 2_000).unref();
       return;
     }
 
@@ -58,7 +58,7 @@ async function startStallServer(stage: StallStage | 'complete'): Promise<{
     // Test watchdog only: a broken adapter must eventually settle so the RED
     // suite cannot leave an open reader forever. Correct timeout/abort paths
     // finish well before this socket destruction.
-    setTimeout(() => res.socket?.destroy(), 350).unref();
+    setTimeout(() => res.socket?.destroy(), 2_000).unref();
   });
   server.on('connection', (socket) => {
     sockets.add(socket);
@@ -94,8 +94,8 @@ describe('ResponseStreamAdapter full-lifecycle timeout and abort', () => {
     async (stage) => {
       const fixture = await startStallServer(stage);
       const started = Date.now();
-      await expect(call(adapter(fixture.baseUrl, 60))).rejects.toBeInstanceOf(ProviderTimeoutError);
-      expect(Date.now() - started).toBeLessThan(250);
+      await expect(call(adapter(fixture.baseUrl, 500))).rejects.toBeInstanceOf(ProviderTimeoutError);
+      expect(Date.now() - started).toBeLessThan(1_500);
       expect(fixture.requestCount()).toBe(1);
     },
   );

--- a/tests/v4/providers/responseStreamLifecycle.test.ts
+++ b/tests/v4/providers/responseStreamLifecycle.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+
+import { ResponseStreamAdapter } from '../../../providers/v4/responseStreamAdapter';
+import { ProviderTimeoutError } from '../../../providers/v4/errors';
+
+type StallStage = 'before_headers' | 'after_headers' | 'after_event';
+
+let server: Server | null = null;
+const sockets = new Set<Socket>();
+const nativeFetch = globalThis.fetch;
+
+afterEach(async () => {
+  globalThis.fetch = nativeFetch;
+  vi.restoreAllMocks();
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+});
+
+async function startStallServer(stage: StallStage | 'complete'): Promise<{
+  baseUrl: string;
+  stageReady: Promise<void>;
+  requestCount: () => number;
+}> {
+  let markReady!: () => void;
+  const stageReady = new Promise<void>((resolve) => { markReady = resolve; });
+  let requests = 0;
+
+  server = createServer((_req, res) => {
+    requests += 1;
+    if (stage === 'before_headers') {
+      markReady();
+      setTimeout(() => res.socket?.destroy(), 350).unref();
+      return;
+    }
+
+    res.writeHead(200, { 'content-type': 'text/event-stream' });
+    res.flushHeaders();
+    if (stage === 'after_event') {
+      res.write('data: {"type":"response.output_text.delta","delta":"partial"}\n\n');
+    }
+    markReady();
+
+    if (stage === 'complete') {
+      res.end(
+        'data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1}}}\n\n' +
+        'data: [DONE]\n\n',
+      );
+      return;
+    }
+
+    // Test watchdog only: a broken adapter must eventually settle so the RED
+    // suite cannot leave an open reader forever. Correct timeout/abort paths
+    // finish well before this socket destruction.
+    setTimeout(() => res.socket?.destroy(), 350).unref();
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, stageReady, requestCount: () => requests };
+}
+
+function adapter(baseUrl: string, timeoutMs: number, maxRetries = 0): ResponseStreamAdapter {
+  globalThis.fetch = ((_: string | URL | Request, init?: RequestInit) =>
+    nativeFetch(`${baseUrl}/responses`, init)) as typeof fetch;
+  return new ResponseStreamAdapter({
+    // Select the production streaming path. The fetch wrapper above redirects
+    // only the transport destination to the real local HTTP fixture.
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    apiKey: 'test-key',
+    model: 'test-model',
+    providerName: 'chatgpt-plus',
+    timeoutMs,
+    maxRetries,
+  });
+}
+
+function call(a: ResponseStreamAdapter, signal?: AbortSignal) {
+  return a.call({ messages: [{ role: 'user', content: 'continue' }], tools: [], signal });
+}
+
+describe('ResponseStreamAdapter full-lifecycle timeout and abort', () => {
+  it.each<StallStage>(['before_headers', 'after_headers', 'after_event'])(
+    'times out while stalled at %s',
+    async (stage) => {
+      const fixture = await startStallServer(stage);
+      const started = Date.now();
+      await expect(call(adapter(fixture.baseUrl, 60))).rejects.toBeInstanceOf(ProviderTimeoutError);
+      expect(Date.now() - started).toBeLessThan(250);
+      expect(fixture.requestCount()).toBe(1);
+    },
+  );
+
+  it.each<StallStage>(['before_headers', 'after_headers', 'after_event'])(
+    'honours external cancellation while stalled at %s',
+    async (stage) => {
+      const fixture = await startStallServer(stage);
+      const abort = new AbortController();
+      const pending = call(adapter(fixture.baseUrl, 2_000), abort.signal);
+      await fixture.stageReady;
+      // Ensure fetch has observed the flushed response headers and entered
+      // body consumption for the post-header cases.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      abort.abort();
+      const started = Date.now();
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+      expect(Date.now() - started).toBeLessThan(250);
+      expect(fixture.requestCount()).toBe(1);
+    },
+  );
+
+  it('still consumes a normal complete SSE response', async () => {
+    const fixture = await startStallServer('complete');
+    const result = await call(adapter(fixture.baseUrl, 500));
+    expect(result.content).toBe('ok');
+    expect(fixture.requestCount()).toBe(1);
+  });
+
+  it('cleans its one timer and abort listener exactly once after body completion', async () => {
+    const fixture = await startStallServer('complete');
+    const abort = new AbortController();
+    const add = vi.spyOn(abort.signal, 'addEventListener');
+    const remove = vi.spyOn(abort.signal, 'removeEventListener');
+    const setTimer = vi.spyOn(globalThis, 'setTimeout');
+    const clearTimer = vi.spyOn(globalThis, 'clearTimeout');
+
+    await call(adapter(fixture.baseUrl, 987_654), abort.signal);
+
+    const lifecycleTimer = setTimer.mock.results[
+      setTimer.mock.calls.findIndex((args) => args[1] === 987_654)
+    ]?.value;
+    expect(lifecycleTimer).toBeDefined();
+    expect(clearTimer.mock.calls.filter(([handle]) => handle === lifecycleTimer)).toHaveLength(1);
+    expect(add.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+    expect(remove.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+  });
+
+  it('cleans its timer and abort listener exactly once after body timeout', async () => {
+    const fixture = await startStallServer('after_event');
+    const abort = new AbortController();
+    const add = vi.spyOn(abort.signal, 'addEventListener');
+    const remove = vi.spyOn(abort.signal, 'removeEventListener');
+    const setTimer = vi.spyOn(globalThis, 'setTimeout');
+    const clearTimer = vi.spyOn(globalThis, 'clearTimeout');
+
+    await expect(call(adapter(fixture.baseUrl, 73), abort.signal))
+      .rejects.toBeInstanceOf(ProviderTimeoutError);
+
+    const lifecycleTimer = setTimer.mock.results[
+      setTimer.mock.calls.findIndex((args) => args[1] === 73)
+    ]?.value;
+    expect(lifecycleTimer).toBeDefined();
+    expect(clearTimer.mock.calls.filter(([handle]) => handle === lifecycleTimer)).toHaveLength(1);
+    expect(add.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+    expect(remove.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+  });
+
+  it('cleans its timer and abort listener exactly once after body cancellation', async () => {
+    const fixture = await startStallServer('after_event');
+    const abort = new AbortController();
+    const add = vi.spyOn(abort.signal, 'addEventListener');
+    const remove = vi.spyOn(abort.signal, 'removeEventListener');
+    const setTimer = vi.spyOn(globalThis, 'setTimeout');
+    const clearTimer = vi.spyOn(globalThis, 'clearTimeout');
+
+    const pending = call(adapter(fixture.baseUrl, 876_543), abort.signal);
+    await fixture.stageReady;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    abort.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+
+    const lifecycleTimer = setTimer.mock.results[
+      setTimer.mock.calls.findIndex((args) => args[1] === 876_543)
+    ]?.value;
+    expect(lifecycleTimer).toBeDefined();
+    expect(clearTimer.mock.calls.filter(([handle]) => handle === lifecycleTimer)).toHaveLength(1);
+    expect(add.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+    expect(remove.mock.calls.filter(([type]) => type === 'abort')).toHaveLength(1);
+  });
+
+  it('does not retry a request whose SSE body already started', async () => {
+    const fixture = await startStallServer('after_event');
+    await expect(call(adapter(fixture.baseUrl, 60, 2))).rejects.toBeInstanceOf(ProviderTimeoutError);
+    expect(fixture.requestCount()).toBe(1);
+  });
+});

--- a/tests/v4/providers/responseStreamRecovery.test.ts
+++ b/tests/v4/providers/responseStreamRecovery.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { CodexResponsesAdapter } from '../../../providers/v4/codexResponsesAdapter';
+import { ResponseStreamAdapter } from '../../../providers/v4/responseStreamAdapter';
 
 /**
- * Phase 21 #6d — Codex SSE three-stage recovery. The Codex backend regularly emits
+ * Phase 21 #6d — Responses SSE three-stage recovery. The streaming backend may emit
  * `response.completed` with an empty output[] even when items were
  * streamed. Aiden must backfill from output_item.done events OR
  * synthesize from output_text.delta accumulation, not trust the empty
@@ -32,7 +32,7 @@ function sse(events: object[]): Response {
 }
 
 function adapter() {
-  return new CodexResponsesAdapter({
+  return new ResponseStreamAdapter({
     baseUrl: 'https://chatgpt.com/backend-api/codex',
     apiKey: 'sk-test',
     model: 'gpt-5.3-codex',
@@ -41,7 +41,7 @@ function adapter() {
   });
 }
 
-describe('Phase 21 #6d — Codex SSE recovery', () => {
+describe('Phase 21 #6d — Responses SSE recovery', () => {
   it('1. text-only response with output_item.added + output_item.done parses cleanly', async () => {
     globalThis.fetch = vi.fn(async () =>
       sse([
@@ -100,7 +100,7 @@ describe('Phase 21 #6d — Codex SSE recovery', () => {
         },
         {
           type: 'response.completed',
-          // ← Codex bug shape: completed event but output[] is empty.
+          // Upstream bug shape: completed event but output[] is empty.
           response: {
             status: 'completed',
             output: [],
@@ -215,7 +215,7 @@ describe('Phase 21 #6d — Codex SSE recovery', () => {
 });
 
 // ── Bug B — a stream failure must say WHY, never bare/repeated "failed" ────────
-describe('Codex stream failure surfaces the REAL reason', () => {
+describe('Responses stream failure surfaces the REAL reason', () => {
   const callIt = async () => {
     let msg = '';
     try {
@@ -241,7 +241,7 @@ describe('Codex stream failure surfaces the REAL reason', () => {
       sse([{ type: 'response.failed', response: { status: 'failed' } }]),   // no error object
     ) as never;
     const msg = await callIt();
-    expect(msg).toContain('Codex stream reported failure:');
+    expect(msg).toContain('Responses stream reported failure:');
     expect(msg).not.toMatch(/failure:\s*failed\s*$/i);   // not just the bare status word
     expect(msg).not.toMatch(/failed:\s*failed/i);        // never the chant
     expect(msg).toMatch(/status=failed/);                // honest: surfaces the actual shape

--- a/tests/v4/providers/subscriptionModelIds.test.ts
+++ b/tests/v4/providers/subscriptionModelIds.test.ts
@@ -4,25 +4,23 @@ import { PROVIDER_REGISTRY } from '../../../providers/v4/registry';
 import { listModelsForProvider } from '../../../providers/v4/modelCatalog';
 
 /**
- * Phase 21 #6 — Codex model ID parity with the canonical Codex backend list.
+ * Phase 21 #6 — subscription model ID parity with the canonical backend list.
  *
- * The bug: ChatGPT Plus inference returned 400 "model is not supported
- * when using Codex with a ChatGPT account" because Aiden's catalog
- * listed direct-OpenAI-API names (`gpt-5-mini`, `gpt-5-codex`) that
- * the Codex OAuth backend doesn't accept. The canonical list below was
- * verified Apr 2026 via live /codex/models probe.
+ * The bug: subscription inference returned 400 because the catalog listed
+ * direct-API names that the subscription backend does not accept. The
+ * canonical list below was verified Apr 2026 through the live model endpoint.
  *
  * These tests pin the Aiden catalog to the verified verbatim list so a
  * future "improvement" doesn't re-introduce invalid slugs.
  */
 
-const VERIFIED_CODEX_SLUGS = [
+const VERIFIED_SUBSCRIPTION_SLUGS = [
   'gpt-5.1-codex-max',
   'gpt-5.1-codex-mini',
   'gpt-5.3-codex',
   'gpt-5.2-codex',
   'gpt-5.5',
-  // GPT-5.6 variants — confirmed via live /codex/responses probe (each streams;
+  // GPT-5.6 variants — confirmed via the live response endpoint (each streams;
   // bare `gpt-5.6` is rejected 400). Tool-calling live-verified before shipping.
   'gpt-5.6-sol',
   'gpt-5.6-terra',
@@ -33,17 +31,17 @@ const VERIFIED_CODEX_SLUGS = [
   'gpt-5',
 ] as const;
 
-describe('Phase 21 #6 — Codex OAuth model IDs', () => {
+describe('Phase 21 #6 — subscription model IDs', () => {
   it('1. modelCatalog chatgpt-plus entries match verified slug list verbatim', () => {
     const ids = listModelsForProvider('chatgpt-plus').map((m) => m.id);
     // Same set (order may differ in catalog ordering).
-    expect(new Set(ids)).toEqual(new Set(VERIFIED_CODEX_SLUGS));
+    expect(new Set(ids)).toEqual(new Set(VERIFIED_SUBSCRIPTION_SLUGS));
   });
 
   it('2. modelCatalog chatgpt-plus excludes the historically-invalid direct-API slugs', () => {
     const ids = listModelsForProvider('chatgpt-plus').map((m) => m.id);
-    // These names appear in the OpenAI Python SDK's typed list but the
-    // Codex backend rejects them for ChatGPT-account auth.
+    // These names appear in the public SDK's typed list but the subscription
+    // backend rejects them for account-based authentication.
     expect(ids).not.toContain('gpt-5-mini');
     expect(ids).not.toContain('gpt-5-codex');
   });

--- a/tests/v4/responseStreamAdapter.test.ts
+++ b/tests/v4/responseStreamAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { CodexResponsesAdapter } from '../../providers/v4/codexResponsesAdapter';
+import { ResponseStreamAdapter } from '../../providers/v4/responseStreamAdapter';
 import { ProviderError, ProviderRateLimitError } from '../../providers/v4/errors';
 import type { Message } from '../../providers/v4/types';
 
@@ -14,9 +14,9 @@ function makeResponse(
 }
 
 const baseOptions = {
-  apiKey: 'sk-codex-test',
-  model: 'gpt-5-codex',
-  providerName: 'codex',
+  apiKey: 'sk-test',
+  model: 'gpt-test',
+  providerName: 'openai-responses',
   maxRetries: 1,
 };
 
@@ -34,7 +34,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('CodexResponsesAdapter', () => {
+describe('ResponseStreamAdapter', () => {
   it('1. builds correct request body for /v1/responses (instructions, input items, flat tools)', async () => {
     fetchMock.mockResolvedValueOnce(
       makeResponse({
@@ -50,10 +50,10 @@ describe('CodexResponsesAdapter', () => {
         usage: { input_tokens: 5, output_tokens: 1 },
       }),
     );
-    const adapter = new CodexResponsesAdapter(baseOptions);
+    const adapter = new ResponseStreamAdapter(baseOptions);
     await adapter.call({
       messages: [
-        { role: 'system', content: 'you are codex' },
+        { role: 'system', content: 'you are helpful' },
         userMsg('hi'),
       ],
       tools: [
@@ -69,8 +69,8 @@ describe('CodexResponsesAdapter', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://api.openai.com/v1/responses');
     const body = JSON.parse(init.body);
-    expect(body.model).toBe('gpt-5-codex');
-    expect(body.instructions).toBe('you are codex');
+    expect(body.model).toBe('gpt-test');
+    expect(body.instructions).toBe('you are helpful');
     expect(body.tool_choice).toBe('auto');
     expect(body.parallel_tool_calls).toBe(true);
     expect(body.store).toBe(false);
@@ -104,7 +104,7 @@ describe('CodexResponsesAdapter', () => {
         usage: { input_tokens: 4, output_tokens: 2 },
       }),
     );
-    const result = await new CodexResponsesAdapter(baseOptions).call({
+    const result = await new ResponseStreamAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -130,7 +130,7 @@ describe('CodexResponsesAdapter', () => {
         status: 'completed',
       }),
     );
-    const result = await new CodexResponsesAdapter(baseOptions).call({
+    const result = await new ResponseStreamAdapter(baseOptions).call({
       messages: [userMsg('echo hi')],
       tools: [],
     });
@@ -156,7 +156,7 @@ describe('CodexResponsesAdapter', () => {
         status: 'completed',
       }),
     );
-    const result = await new CodexResponsesAdapter(baseOptions).call({
+    const result = await new ResponseStreamAdapter(baseOptions).call({
       messages: [userMsg('q')],
       tools: [],
     });
@@ -174,7 +174,7 @@ describe('CodexResponsesAdapter', () => {
         usage: { input_tokens: 3, output_tokens: 2 },
       }),
     );
-    const result = await new CodexResponsesAdapter(baseOptions).call({
+    const result = await new ResponseStreamAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -197,7 +197,7 @@ describe('CodexResponsesAdapter', () => {
         incomplete_details: { reason: 'max_output_tokens' },
       }),
     );
-    const result = await new CodexResponsesAdapter(baseOptions).call({
+    const result = await new ResponseStreamAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });
@@ -207,7 +207,7 @@ describe('CodexResponsesAdapter', () => {
   it('7. status=failed throws ProviderError', async () => {
     fetchMock.mockResolvedValueOnce(makeResponse({ output: [], status: 'failed' }));
     await expect(
-      new CodexResponsesAdapter(baseOptions).call({ messages: [userMsg('hi')], tools: [] }),
+      new ResponseStreamAdapter(baseOptions).call({ messages: [userMsg('hi')], tools: [] }),
     ).rejects.toBeInstanceOf(ProviderError);
   });
 
@@ -228,7 +228,7 @@ describe('CodexResponsesAdapter', () => {
           status: 'completed',
         }),
       );
-    const adapter = new CodexResponsesAdapter({ ...baseOptions, maxRetries: 1 });
+    const adapter = new ResponseStreamAdapter({ ...baseOptions, maxRetries: 1 });
     const promise = adapter.call({ messages: [userMsg('hi')], tools: [] });
     await vi.advanceTimersByTimeAsync(1500);
     const result = await promise;
@@ -239,7 +239,7 @@ describe('CodexResponsesAdapter', () => {
   it('9. exhausted 429 throws ProviderRateLimitError', async () => {
     vi.useFakeTimers();
     fetchMock.mockResolvedValue(makeResponse({ error: 'rate' }, { status: 429 }));
-    const adapter = new CodexResponsesAdapter({ ...baseOptions, maxRetries: 1 });
+    const adapter = new ResponseStreamAdapter({ ...baseOptions, maxRetries: 1 });
     const promise = adapter.call({ messages: [userMsg('hi')], tools: [] });
     promise.catch(() => undefined);
     await vi.advanceTimersByTimeAsync(2500);
@@ -249,7 +249,7 @@ describe('CodexResponsesAdapter', () => {
   it('10. 401 fails fast', async () => {
     fetchMock.mockResolvedValueOnce(makeResponse('unauthorized', { status: 401 }));
     await expect(
-      new CodexResponsesAdapter(baseOptions).call({ messages: [userMsg('hi')], tools: [] }),
+      new ResponseStreamAdapter(baseOptions).call({ messages: [userMsg('hi')], tools: [] }),
     ).rejects.toBeInstanceOf(ProviderError);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -268,7 +268,7 @@ describe('CodexResponsesAdapter', () => {
         status: 'completed',
       }),
     );
-    await new CodexResponsesAdapter(baseOptions).call({
+    await new ResponseStreamAdapter(baseOptions).call({
       messages: [
         userMsg('q'),
         {
@@ -311,7 +311,7 @@ describe('CodexResponsesAdapter', () => {
         usage: { input_tokens: 100, output_tokens: 5, cached_tokens: 80 },
       }),
     );
-    const result = await new CodexResponsesAdapter(baseOptions).call({
+    const result = await new ResponseStreamAdapter(baseOptions).call({
       messages: [userMsg('hi')],
       tools: [],
     });

--- a/tests/v4/runtimeResolver.test.ts
+++ b/tests/v4/runtimeResolver.test.ts
@@ -58,7 +58,7 @@ describe('RuntimeResolver.resolve', () => {
     expect(adapter.apiMode).toBe('chat_completions');
   });
 
-  it('2. resolves anthropic + claude-opus → AnthropicAdapter', async () => {
+  it('2. resolves message-API mode to MessageApiAdapter', async () => {
     process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
     const adapter = await makeResolver().resolve({
       providerId: 'anthropic',
@@ -68,7 +68,7 @@ describe('RuntimeResolver.resolve', () => {
     expect(adapter.apiMode).toBe('anthropic_messages');
   });
 
-  it('3. resolves openai → CodexResponsesAdapter', async () => {
+  it('3. resolves response-stream mode to the streaming adapter', async () => {
     process.env.OPENAI_API_KEY = 'sk-openai-test';
     const adapter = await makeResolver().resolve({
       providerId: 'openai',
@@ -78,7 +78,7 @@ describe('RuntimeResolver.resolve', () => {
     expect(adapter.apiMode).toBe('codex_responses');
   });
 
-  it('4. resolves ollama → OllamaPromptToolsAdapter (no creds needed)', async () => {
+  it('4. resolves local prompt-tools mode to LocalPromptToolsAdapter (no creds needed)', async () => {
     const adapter = await makeResolver().resolve({
       providerId: 'ollama',
       modelId: 'llama3.2',

--- a/tests/v4/streaming.test.ts
+++ b/tests/v4/streaming.test.ts
@@ -16,8 +16,8 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ChatCompletionsAdapter } from '../../providers/v4/chatCompletionsAdapter';
-import { AnthropicAdapter } from '../../providers/v4/anthropicAdapter';
-import { OllamaPromptToolsAdapter } from '../../providers/v4/ollamaPromptToolsAdapter';
+import { MessageApiAdapter } from '../../providers/v4/messageApiAdapter';
+import { LocalPromptToolsAdapter } from '../../providers/v4/localPromptToolsAdapter';
 import { AidenAgent } from '../../core/v4/aidenAgent';
 import { FallbackAdapter } from '../../core/v4/providerFallback';
 import { ProviderRateLimitError } from '../../providers/v4/errors';
@@ -178,7 +178,7 @@ describe('ChatCompletionsAdapter.callStream', () => {
 // anthropic streaming
 // ──────────────────────────────────────────────────────────────────────
 
-describe('AnthropicAdapter.callStream', () => {
+describe('MessageApiAdapter.callStream', () => {
   it('parses content_block_delta text_delta events into delta events', async () => {
     fetchMock.mockResolvedValue(
       sseStreamFromLines([
@@ -198,7 +198,7 @@ describe('AnthropicAdapter.callStream', () => {
         'data: {"type":"message_stop"}',
       ]),
     );
-    const adapter = new AnthropicAdapter({
+    const adapter = new MessageApiAdapter({
       apiKey: 'k',
       authMode: 'api_key',
       model: 'claude-haiku-4-5',
@@ -233,7 +233,7 @@ describe('AnthropicAdapter.callStream', () => {
         'data: {"type":"message_stop"}',
       ]),
     );
-    const adapter = new AnthropicAdapter({
+    const adapter = new MessageApiAdapter({
       apiKey: 'k',
       authMode: 'api_key',
       model: 'claude-haiku-4-5',
@@ -265,7 +265,7 @@ describe('AnthropicAdapter.callStream', () => {
 // ollama streaming
 // ──────────────────────────────────────────────────────────────────────
 
-describe('OllamaPromptToolsAdapter.callStream', () => {
+describe('LocalPromptToolsAdapter.callStream', () => {
   it('relays NDJSON deltas and emits done with parsed totals', async () => {
     fetchMock.mockResolvedValue(
       ndjsonResponse([
@@ -279,7 +279,7 @@ describe('OllamaPromptToolsAdapter.callStream', () => {
         },
       ]),
     );
-    const adapter = new OllamaPromptToolsAdapter({
+    const adapter = new LocalPromptToolsAdapter({
       model: 'llama3.2',
       providerName: 'ollama',
     });

--- a/tests/v4/tools/clarifyTool.test.ts
+++ b/tests/v4/tools/clarifyTool.test.ts
@@ -61,13 +61,14 @@ describe('clarify tool — degrade paths (never hang)', () => {
     expect(r.note).toMatch(/reasonable default/i);
   });
 
-  it('user cancels (callback returns null) → cancelled, proceed', async () => {
+  it('user cancellation forbids inventing the required value', async () => {
     const clarify = vi.fn(async () => null);
     const r = await tool.execute({ question: 'Which env?' }, ctx({ clarify })) as any;
     expect(r.ok).toBe(false);
     expect(r.status).toBe('cancelled');
     expect(r.answer).toBeNull();
-    expect(r.note).toMatch(/reasonable default/i);
+    expect(r.note).toMatch(/do not invent/i);
+    expect(r.note).toMatch(/explicitly authorizes/i);
   });
 
   it('empty answer is treated as cancelled', async () => {

--- a/tools/v4/clarify/clarifyTool.ts
+++ b/tools/v4/clarify/clarifyTool.ts
@@ -97,18 +97,32 @@ export function makeClarifyTool(): ToolHandler {
         };
       }
 
+      p2aDiag('clarify.tool.await_callback', { question, hasOptions: !!options?.length });
       const answer = await ctx.clarify(question, options);
+      p2aDiag('clarify.tool.callback_resolved', { answer });
       if (answer === null || answer.trim().length === 0) {
         return {
           ok:     false,
           status: 'cancelled',
           answer: null,
           note:
-            'The user did not answer. Proceed with a reasonable default and ' +
-            'label the assumption explicitly.',
+            'The required clarification was cancelled. Do not invent the ' +
+            'missing value or execute the constrained task. Ask again, wait ' +
+            'for the user to provide it, or proceed only after the user ' +
+            'explicitly authorizes an assumption.',
         };
       }
-      return { ok: true, status: 'answered', answer };
+      const result = { ok: true, status: 'answered', answer };
+      p2aDiag('clarify.tool.return', { status: result.status, answer });
+      return result;
     },
   };
+}
+
+function p2aDiag(event: string, data: Record<string, unknown>): void {
+  if (process.env.AIDEN_P2A_DIAG !== '1') return;
+  try {
+    const monoMs = Number(process.hrtime.bigint() / 1_000_000n);
+    process.stderr.write(`[p2a] ${JSON.stringify({ monoMs, event, ...data })}\n`);
+  } catch { /* diagnostics must never affect clarify */ }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,17 +3,16 @@
 // legacy v3 regression scripts, which are stale dev artifacts.
 import { defineConfig } from 'vitest/config';
 
-// CI runners — especially GitHub's Windows leg — run the full ~5,300-test
-// suite on only a few cores. Under that load the Node event loop backs up
-// enough that the 5s/10s vitest defaults fire before otherwise-trivial work
-// resolves (a two-mkdir hook, an in-process CLI call), producing
-// nondeterministic timeout flakes whose victims rotate run-to-run and differ
-// by Node version on the same commit. Give the starved loop headroom on CI
-// without slowing local dev, where the tight defaults still surface real
-// slowness fast. Per-test/per-hook timeouts always override these globals, so
-// genuinely long tests keep their explicit budgets and a real hang still
-// eventually times out.
-const isCI = !!process.env.CI;
+// Full-suite workers contend for the same event loop, filesystem, and terminal
+// resources even on a local workstation. Under that load the 5s/10s defaults
+// produce rotating timeout victims in otherwise-fast tests. Keep one realistic
+// budget everywhere so a focused run and a full run use the same contract.
+// Per-test/per-hook timeouts still override these globals.
+//
+// Windows pseudo-terminal helpers also share console infrastructure outside the
+// worker process. Capping file workers prevents unrelated suites from starving
+// input delivery without serializing the entire repository.
+const windowsWorkerLimit = process.platform === 'win32' ? 4 : undefined;
 
 export default defineConfig({
   test: {
@@ -28,7 +27,8 @@ export default defineConfig({
       '.next/**',
       'dashboard-next/**',
     ],
-    testTimeout: isCI ? 20_000 : 5_000,
-    hookTimeout: isCI ? 30_000 : 10_000,
+    testTimeout: 20_000,
+    hookTimeout: 30_000,
+    maxWorkers: windowsWorkerLimit,
   },
 });


### PR DESCRIPTION
## Summary

- isolates interactive prompt input across clarification, approval, and skill-save flows;
- centralizes activity lifecycle and removes stale rows and ghost timers;
- restores immediate composer handoff after normal, tool, and interrupted turns;
- prevents wrapped activity timer frames from concatenating;
- preserves provider timeout and cancellation through full streaming completion;
- uses neutral internal provider adapter naming;
- enforces required clarification before mutation;
- stabilizes Windows PTY and runtime-dependent test coverage.

## Validation

- 593 test files passed
- 6,341 tests passed
- 47 skipped
- 0 failures
- Typecheck passed
- Production build passed
- Physical Windows Terminal smoke passed:
  - FIRST → SECOND → THIRD without extra Enter
  - immediate prompt after tool completion
  - clean Ctrl+C recovery
  - empty queue
  - no stale activity row
  - no concatenated timers