### PR TITLE
fix(cli): align startup trust and responsive chrome

### DIFF
--- a/cli/v4/chatSession.ts
+++ b/cli/v4/chatSession.ts
@@ -117,7 +117,6 @@ import { categorizeEvent } from '../../core/v4/daemon/eventCategories';
 import { captureArtifactFromTrace } from '../../core/v4/daemon/artifactStore';
 // v4.12.1 Pillar 4 Slice 2a — type-next-while-busy.
 import { DuringTurnInput, resolveConfiguredBusyMode, type BusyEnterMode } from './duringTurnInput';
-import { modeStatusLine } from './commands/mode';
 import { attachTurnInputListener } from './turnInputListener';
 import { InputAuthority } from './inputAuthority';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
@@ -2895,6 +2894,8 @@ export class ChatSession implements ChatSessionLike {
       display.write('\n');
     }
 
+    const startupTrust = this.opts.approvalEngine?.getAutonomyPolicy?.()?.level ?? 'Assistant';
+
     // Status pills.
     // Phase v4.1.2-version-display: append the running version as the
     // fifth pill so users see what they're on without invoking
@@ -2902,7 +2903,7 @@ export class ChatSession implements ChatSessionLike {
     display.write(
       display.statusPillsRow({
         coreOnline:   true,
-        mode:         'auto',
+        trust:        startupTrust,
         model:        this.currentModelId,
         memoryActive: true,
         providerOk:   !this.opts.unconfigured,
@@ -3078,13 +3079,6 @@ export class ChatSession implements ChatSessionLike {
         });
       }
     } catch { /* never let the greeter crash boot */ }
-
-    // v4.14 BUG 1 — show the trust level calmly at boot so the user always knows
-    // how autonomous Aiden is right now, and that /mode changes it. One dim line.
-    try {
-      const lvl = this.opts.approvalEngine?.getAutonomyPolicy()?.level;
-      if (lvl) display.dim(`  ${modeStatusLine(lvl)}  ·  /mode to change`);
-    } catch { /* never break boot */ }
 
     // v4.9.0 pre-ship UI: hint moved BEFORE the closing rule so the
     // rule sits adjacent to the active prompt (it becomes the visual

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -21,6 +21,8 @@ import { marked } from 'marked';
 // marked-terminal exports a CommonJS factory.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const TerminalRenderer: new (opts?: unknown) => unknown = require('marked-terminal').default ?? require('marked-terminal');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stringWidth: (value: string) => number = require('string-width');
 
 import { SkinEngine, getSkinEngine, type ColorKind } from './skinEngine';
 import { visibleLength, truncateVisible } from './box';
@@ -594,14 +596,14 @@ export class Display {
 
   /**
    * Status pills row — one line, four pills separated by 4 spaces.
-   * Format: `● core online    ● mode auto    ● model X    ● memory active`.
+   * Wide format: `● core online    ● trust Assistant    ● model X    ● memory active`.
    * Dot is success-green when on, muted when off. Label is muted, value
    * is rendered in `agent` (off-white) for legibility without competing
    * with the banner orange.
    */
   statusPillsRow(args: {
     coreOnline: boolean;
-    mode: string;
+    trust: string;
     model: string;
     memoryActive: boolean;
     /**
@@ -629,18 +631,51 @@ export class Display {
       `${dot(on)} ${lab(label)} ${val(value)}`;
     const providerOk = args.providerOk !== false;
     const modelValue = providerOk ? args.model : 'not configured';
-    const pills = [
-      pill(args.coreOnline, 'core', args.coreOnline ? 'online' : 'starting'),
-      pill(true, 'mode', args.mode),
-      pill(providerOk, 'model', modelValue),
-      pill(args.memoryActive, 'memory', args.memoryActive ? 'active' : 'off'),
-    ];
-    if (args.version) {
-      // Version pill: dot + value, no label (the `v` prefix is the label).
-      // Always-on dot — informational, not a health indicator.
-      pills.push(`${dot(true)} ${val(`v${args.version}`)}`);
+    const indent = '  ';
+    const separator = '    ';
+    const columns = typeof this.out.columns === 'number' && this.out.columns > 0
+      ? this.out.columns
+      : this.cols();
+    const widthOf = (value: string): number =>
+      stringWidth(value.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, ''));
+    const truncateText = (value: string, maxWidth: number): string => {
+      if (widthOf(value) <= maxWidth) return value;
+      if (maxWidth <= 1) return '…';
+      let result = '';
+      for (const character of value) {
+        if (widthOf(result + character) > maxWidth - 1) break;
+        result += character;
+      }
+      return result + '…';
+    };
+
+    const corePill = pill(args.coreOnline, 'core', args.coreOnline ? 'online' : 'starting');
+    const trustPill = pill(true, 'trust', args.trust);
+    const memoryPill = pill(args.memoryActive, 'memory', args.memoryActive ? 'active' : 'off');
+    const versionPill = args.version ? `${dot(true)} ${val(`v${args.version}`)}` : null;
+    const modelPill = (maxWidth: number): string => {
+      const prefix = `${dot(providerOk)} ${lab('model')} `;
+      return prefix + val(truncateText(modelValue, Math.max(1, maxWidth - widthOf(prefix))));
+    };
+
+    if (columns < 80) {
+      const firstRow = indent + corePill + separator + trustPill;
+      const modelRow = indent + modelPill(columns - widthOf(indent));
+      if (widthOf(firstRow) <= columns) return firstRow + '\n' + modelRow;
+      return indent + corePill + '\n' + indent + trustPill + '\n' + modelRow;
     }
-    return '  ' + pills.join('    ');
+
+    if (columns < 120) {
+      const modelWidth = columns - widthOf(indent + corePill + separator + trustPill + separator);
+      const firstRow = indent + [corePill, trustPill, modelPill(modelWidth)].join(separator);
+      const secondRow = indent + [memoryPill, versionPill].filter((value): value is string => value !== null).join(separator);
+      return secondRow === indent ? firstRow : firstRow + '\n' + secondRow;
+    }
+
+    const trailing = [memoryPill, versionPill].filter((value): value is string => value !== null);
+    const suffix = trailing.length > 0 ? separator + trailing.join(separator) : '';
+    const modelWidth = columns - widthOf(indent + corePill + separator + trustPill + separator + suffix);
+    return indent + corePill + separator + trustPill + separator + modelPill(modelWidth) + suffix;
   }
 
   /**

--- a/tests/v4/cli/startupChrome.test.ts
+++ b/tests/v4/cli/startupChrome.test.ts
@@ -1,0 +1,152 @@
+import { Writable } from 'node:stream';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ChatSession, type ChatSessionOptions } from '../../../cli/v4/chatSession';
+import { CommandRegistry } from '../../../cli/v4/commandRegistry';
+import { Display } from '../../../cli/v4/display';
+import { SkinEngine } from '../../../cli/v4/skinEngine';
+import { resolveConfiguredAutonomyLevel } from '../../../core/v4/config';
+import { ApprovalEngine } from '../../../moat/approvalEngine';
+import { resolveAutonomyPolicy, type AutonomyLevel } from '../../../moat/autonomy';
+
+const stringWidth: (value: string) => number = require('string-width');
+
+function stripAnsi(value: string): string {
+  return value.replace(
+    // eslint-disable-next-line no-control-regex
+    /\x1b\[[0-?]*[ -/]*[@-~]/g,
+    '',
+  );
+}
+
+function captureDisplay(columns: number): { display: Display; chunks: string[] } {
+  const chunks: string[] = [];
+  const out = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  }) as unknown as NodeJS.WriteStream;
+  const err = new Writable({
+    write(_chunk, _encoding, callback) { callback(); },
+  }) as unknown as NodeJS.WriteStream;
+  Object.assign(out, { isTTY: true, columns });
+  Object.assign(err, { isTTY: true, columns });
+  const display = new Display({
+    skin: new SkinEngine({ forceMono: true }),
+    stdout: out,
+    stderr: err,
+  });
+  return { display, chunks };
+}
+
+function buildSession(
+  level: AutonomyLevel,
+  columns = 100,
+): { session: ChatSession; chunks: string[] } {
+  const { display, chunks } = captureDisplay(columns);
+  const approvalEngine = new ApprovalEngine('smart', {});
+  approvalEngine.setAutonomyPolicy(resolveAutonomyPolicy(level, {
+    workspaceRoots: [process.cwd()],
+  }));
+
+  const options: ChatSessionOptions = {
+    agent: {} as never,
+    display,
+    commandRegistry: new CommandRegistry(),
+    callbacks: {} as never,
+    sessionManager: {} as never,
+    approvalEngine,
+    skin: new SkinEngine({ forceMono: true }),
+    toolRegistry: { list: () => [] } as never,
+    skillLoader: { list: async () => [] } as never,
+    resolver: {} as never,
+    config: {} as never,
+    initialProviderId: 'groq',
+    initialModelId: 'llama-3.3-70b-versatile',
+    installSignalHandler: false,
+  };
+  return { session: new ChatSession(options), chunks };
+}
+
+let priorStdoutTty: boolean | undefined;
+
+beforeAll(() => {
+  priorStdoutTty = process.stdout.isTTY;
+  (process.stdout as unknown as { isTTY: boolean }).isTTY = true;
+});
+
+afterAll(() => {
+  (process.stdout as unknown as { isTTY: boolean | undefined }).isTTY = priorStdoutTty;
+});
+
+describe('startup trust chrome', () => {
+  it.each<AutonomyLevel>(['Observer', 'Assistant', 'Partner'])(
+    'renders the active %s policy exactly once without an auto fallback',
+    async (level) => {
+      const { session, chunks } = buildSession(level);
+      await session.renderStartupCard();
+      const output = stripAnsi(chunks.join(''));
+      const declarations = output.match(/trust\s+(?:Observer|Assistant|Partner)\b/gi) ?? [];
+
+      expect(declarations).toHaveLength(1);
+      expect(declarations[0]).toContain(level);
+      expect(output).not.toMatch(/mode\s+auto/i);
+      expect(output).not.toMatch(/auto\s*[—-]\s*auto/i);
+      if (level !== 'Partner') expect(output).not.toMatch(/trust\s+Partner/i);
+    },
+  );
+
+  it('renders the policy resolved from persisted configuration', async () => {
+    const config = {
+      getValue: (key: string, fallback: unknown) =>
+        key === 'agent.autonomy' ? 'Observer' : fallback,
+    } as never;
+    const persistedLevel = resolveConfiguredAutonomyLevel(config);
+    const { session, chunks } = buildSession(persistedLevel);
+
+    await session.renderStartupCard();
+    const output = stripAnsi(chunks.join(''));
+    expect(output).toMatch(/trust\s+Observer\b/i);
+    expect(output).not.toMatch(/mode\s+auto|trust\s+Partner/i);
+  });
+});
+
+describe('responsive startup status rows', () => {
+  it.each([
+    { columns: 50, expectedLines: 2, tier: 'narrow' },
+    { columns: 79, expectedLines: 2, tier: 'narrow' },
+    { columns: 80, expectedLines: 2, tier: 'medium' },
+    { columns: 100, expectedLines: 2, tier: 'medium' },
+    { columns: 140, expectedLines: 1, tier: 'wide' },
+  ])('fits the $tier layout at $columns columns', ({ columns, expectedLines, tier }) => {
+    const { display } = captureDisplay(columns);
+    const rendered = display.statusPillsRow({
+      coreOnline: true,
+      trust: 'Partner',
+      model: 'llama-3.3-70b-versatile',
+      memoryActive: true,
+      providerOk: true,
+      version: '4.14.9',
+    });
+    const lines = rendered.split('\n');
+    const plain = stripAnsi(rendered);
+
+    expect(lines).toHaveLength(expectedLines);
+    for (const line of lines) {
+      expect(stringWidth(stripAnsi(line))).toBeLessThanOrEqual(columns);
+    }
+    expect(plain).toMatch(/core\s+online/i);
+    expect(plain).toMatch(/trust\s+Partner/i);
+    expect(plain).toMatch(/model\s+llama/i);
+
+    if (tier === 'narrow') {
+      expect(plain).not.toMatch(/memory\s+(?:active|off)/i);
+      expect(plain).not.toContain('v4.14.9');
+    } else {
+      expect(plain).toMatch(/memory\s+active/i);
+      expect(plain).toContain('v4.14.9');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- shows the active Observer, Assistant, or Partner trust level at startup;
- removes the contradictory hard-coded auto status;
- removes duplicate trust presentation;
- adds responsive startup status tiers for narrow, medium, and wide terminals;
- preserves existing approval, input, activity, provider, and renderer behavior.

## Validation

- 6,350 tests passed
- 47 skipped
- Typecheck passed
- Production build passed
- Physical Windows Terminal smoke passed at normal and narrow widths