### PR TITLE
fix(cli): report activity phases consistently

### DIFF
--- a/cli/v4/activityRegistry.ts
+++ b/cli/v4/activityRegistry.ts
@@ -1,6 +1,12 @@
 /** Central lifecycle owner for live CLI tool activity rows. */
 import type { ToolRowHandle } from './display';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
+import type {
+  ToolActivityPhase,
+  ToolActivityTiming,
+  ToolActivityUpdate,
+  ToolTerminalClassification,
+} from '../../providers/v4/types';
 
 export type ActivityState = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -8,44 +14,93 @@ interface ActivityEntry {
   id: string;
   name: string;
   state: ActivityState;
-  startedAt: number;
+  lifecycleStartedAt: number;
+  phase: ToolActivityPhase;
+  phaseStartedAt: number;
+  phasePausedAt?: number;
+  phasePausedMs: number;
+  timing?: ToolActivityTiming;
   handle: ToolRowHandle;
 }
 
-export type ActivityOutcome =
+export interface ActivitySnapshot {
+  phase: ToolActivityPhase;
+  phaseElapsedMs: number;
+  lifecycleElapsedMs: number;
+  approvalWaitMs: number;
+  executionDurationMs: number;
+  verificationDurationMs: number;
+  retryBackoffMs: number;
+  attemptCount: number;
+  terminalClassification?: ToolTerminalClassification;
+}
+
+type TimingOutcome = { timing?: ToolActivityTiming };
+export type ActivityOutcome = (
   | { state: 'completed'; retries?: number; dismiss?: boolean }
   | { state: 'failed'; retries?: number }
   | { state: 'cancelled'; dismiss?: boolean }
   | { state: 'blocked' }
-  | { state: 'degraded'; reason?: string };
+  | { state: 'degraded'; reason?: string }
+) & TimingOutcome;
 
 export class ActivityRegistry {
   private readonly entries = new Map<string, ActivityEntry>();
   private readonly terminalStates = new Map<string, ActivityState>();
+  private readonly pendingUpdates = new Map<string, ToolActivityUpdate>();
   private modalDepth = 0;
   private static readonly MAX_TERMINAL_TOMBSTONES = 2_048;
 
   constructor(
-    private readonly createRow: (name: string, args: unknown) => ToolRowHandle,
+    private readonly createRow: (
+      name: string,
+      args: unknown,
+      read: () => ActivitySnapshot,
+    ) => ToolRowHandle,
     private readonly now: () => number = Date.now,
   ) {}
 
   start(id: string, name: string, args: unknown): boolean {
     if (this.entries.has(id) || this.terminalStates.has(id)) return false;
+    const pending = this.pendingUpdates.get(id);
+    this.pendingUpdates.delete(id);
+    const startedAt = pending?.timing?.dispatchStartedAt ?? this.now();
+    const initialPhase = pending && pending.phase !== 'terminal' ? pending.phase : 'queued';
     const entry: ActivityEntry = {
       id,
       name,
       state: 'pending',
-      startedAt: this.now(),
-      handle: this.createRow(name, args),
+      lifecycleStartedAt: startedAt,
+      phase: initialPhase,
+      phaseStartedAt: pending?.at ?? startedAt,
+      phasePausedMs: 0,
+      timing: pending?.timing ? cloneTiming(pending.timing) : undefined,
+      handle: undefined as unknown as ToolRowHandle,
     };
-    entry.state = 'running';
     this.entries.set(id, entry);
+    entry.handle = this.createRow(name, args, () => this.snapshot(id));
+    entry.state = 'running';
     if (this.modalDepth > 0) entry.handle.pause();
     turnIdleDiagnostic('activity.start', {
       id, name, activeCount: this.entries.size, modalDepth: this.modalDepth,
     });
     return true;
+  }
+
+  observe(id: string, update: ToolActivityUpdate): void {
+    const entry = this.entries.get(id);
+    if (!entry) {
+      if (!this.terminalStates.has(id)) this.pendingUpdates.set(id, cloneUpdate(update));
+      return;
+    }
+    if (update.timing) entry.timing = cloneTiming(update.timing);
+    if (update.phase !== 'terminal') {
+      entry.phase = update.phase;
+      entry.phaseStartedAt = update.at;
+      entry.phasePausedAt = this.modalDepth > 0 ? update.at : undefined;
+      entry.phasePausedMs = 0;
+    }
+    entry.handle.refresh?.();
   }
 
   settle(id: string, outcome: ActivityOutcome): boolean {
@@ -56,29 +111,41 @@ export class ActivityRegistry {
       modalDepth: this.modalDepth, activeCount: this.entries.size,
     });
     this.entries.delete(id);
-    const duration = Math.max(0, this.now() - entry.startedAt);
+    if (outcome.timing) entry.timing = cloneTiming(outcome.timing);
+    entry.phase = 'terminal';
+    const summary = this.snapshotEntry(entry);
+    const duration = summary.executionDurationMs;
+    const dismiss = 'dismiss' in outcome && outcome.dismiss === true;
+    if (dismiss) {
+      entry.handle.dismiss();
+    } else if (entry.handle.finish && entry.timing) {
+      entry.handle.finish(summary);
+    } else if (outcome.state === 'completed') {
+      entry.handle.ok(duration, outcome.retries ?? 0, summary);
+    } else if (outcome.state === 'failed') {
+      entry.handle.fail(duration, outcome.retries ?? 0, summary);
+    } else if (outcome.state === 'cancelled') {
+      entry.handle.cancel(duration, summary);
+    } else if (outcome.state === 'blocked') {
+      entry.handle.blocked();
+    } else {
+      entry.handle.degraded(duration, outcome.reason, summary);
+    }
     if (outcome.state === 'completed') {
       entry.state = 'completed';
       this.rememberTerminal(id, entry.state);
-      if (outcome.dismiss) entry.handle.dismiss();
-      else entry.handle.ok(duration, outcome.retries ?? 0);
     } else if (outcome.state === 'failed') {
       entry.state = 'failed';
       this.rememberTerminal(id, entry.state);
-      entry.handle.fail(duration, outcome.retries ?? 0);
     } else if (outcome.state === 'cancelled') {
       entry.state = 'cancelled';
       this.rememberTerminal(id, entry.state);
-      if (outcome.dismiss) entry.handle.dismiss();
-      else entry.handle.cancel(duration);
     } else if (outcome.state === 'blocked') {
       entry.state = 'failed';
       this.rememberTerminal(id, entry.state);
-      entry.handle.blocked();
     } else {
       entry.state = 'completed';
       this.rememberTerminal(id, entry.state);
-      entry.handle.degraded(duration, outcome.reason);
     }
     p2aDiag('activity.settle.complete', {
       id, state: entry.state, modalDepth: this.modalDepth,
@@ -98,7 +165,11 @@ export class ActivityRegistry {
       activities: [...this.entries.values()].map((entry) => ({ id: entry.id, name: entry.name, state: entry.state })),
     });
     if (this.modalDepth !== 1) return;
-    for (const entry of this.entries.values()) entry.handle.pause();
+    const now = this.now();
+    for (const entry of this.entries.values()) {
+      entry.phasePausedAt ??= now;
+      entry.handle.pause();
+    }
   }
 
   resumeAfterModal(): void {
@@ -109,7 +180,14 @@ export class ActivityRegistry {
       activities: [...this.entries.values()].map((entry) => ({ id: entry.id, name: entry.name, state: entry.state })),
     });
     if (this.modalDepth !== 0) return;
-    for (const entry of this.entries.values()) entry.handle.resume();
+    const now = this.now();
+    for (const entry of this.entries.values()) {
+      if (entry.phasePausedAt !== undefined) {
+        entry.phasePausedMs += Math.max(0, now - entry.phasePausedAt);
+        entry.phasePausedAt = undefined;
+      }
+      entry.handle.resume();
+    }
   }
 
   async runModal<T>(run: () => Promise<T>): Promise<T> {
@@ -129,6 +207,7 @@ export class ActivityRegistry {
       this.settle(id, { state: 'cancelled', dismiss: true });
     }
     this.modalDepth = 0;
+    this.pendingUpdates.clear();
     turnIdleDiagnostic('activity.sweep.complete', {
       activeCount: this.entries.size, modalDepth: this.modalDepth,
     });
@@ -141,12 +220,63 @@ export class ActivityRegistry {
     return this.entries.get(id)?.state ?? this.terminalStates.get(id) ?? null;
   }
 
+  snapshot(id: string): ActivitySnapshot {
+    const entry = this.entries.get(id);
+    if (!entry) {
+      return {
+        phase: 'terminal', phaseElapsedMs: 0, lifecycleElapsedMs: 0,
+        approvalWaitMs: 0, executionDurationMs: 0, verificationDurationMs: 0,
+        retryBackoffMs: 0, attemptCount: 0,
+        terminalClassification: this.terminalStates.get(id) === 'cancelled' ? 'cancelled' : undefined,
+      };
+    }
+    return this.snapshotEntry(entry);
+  }
+
+  private snapshotEntry(entry: ActivityEntry): ActivitySnapshot {
+    const now = this.now();
+    const phaseEnd = entry.phasePausedAt ?? now;
+    const timing = entry.timing;
+    const executionDurationMs = timing?.executionDurationMs ?? timing?.executionAttempts.reduce(
+      (total, attempt) => total + Math.max(0, (attempt.endedAt ?? now) - attempt.startedAt), 0,
+    ) ?? (entry.phase === 'running' ? Math.max(0, phaseEnd - entry.phaseStartedAt - entry.phasePausedMs) : 0);
+    return {
+      phase: entry.phase,
+      phaseElapsedMs: Math.max(0, phaseEnd - entry.phaseStartedAt - entry.phasePausedMs),
+      lifecycleElapsedMs: Math.max(0, now - entry.lifecycleStartedAt),
+      approvalWaitMs: timing?.approvalWaitMs ?? (
+        timing?.approvalStartedAt !== undefined && timing.approvalEndedAt !== undefined
+          ? Math.max(0, timing.approvalEndedAt - timing.approvalStartedAt)
+          : 0
+      ),
+      executionDurationMs,
+      verificationDurationMs: timing?.verificationDurationMs ?? 0,
+      retryBackoffMs: timing?.retryBackoffMs ?? 0,
+      attemptCount: timing?.attemptCount ?? timing?.executionAttempts.length ?? 0,
+      terminalClassification: timing?.terminalClassification,
+    };
+  }
+
   private rememberTerminal(id: string, state: ActivityState): void {
     this.terminalStates.set(id, state);
     if (this.terminalStates.size <= ActivityRegistry.MAX_TERMINAL_TOMBSTONES) return;
     const oldest = this.terminalStates.keys().next().value as string | undefined;
     if (oldest !== undefined) this.terminalStates.delete(oldest);
   }
+}
+
+function cloneTiming(timing: ToolActivityTiming): ToolActivityTiming {
+  return {
+    ...timing,
+    executionAttempts: timing.executionAttempts.map((attempt) => ({ ...attempt })),
+  };
+}
+
+function cloneUpdate(update: ToolActivityUpdate): ToolActivityUpdate {
+  return {
+    ...update,
+    timing: update.timing ? cloneTiming(update.timing) : undefined,
+  };
 }
 
 function p2aDiag(event: string, data: Record<string, unknown>): void {

--- a/cli/v4/aidenCLI.ts
+++ b/cli/v4/aidenCLI.ts
@@ -2547,7 +2547,7 @@ export async function buildAgentRuntime(
           } else {
             const startedAt = replToolCallStartTimes.get(call.id) ?? Date.now();
             replToolCallStartTimes.delete(call.id);
-            const durationMs = Date.now() - startedAt;
+            const durationMs = result?.activityTiming?.executionDurationMs ?? (Date.now() - startedAt);
             const tags = categorizeEvent('tool_call_completed');
             replRunStore.emitEventRich({
               runId:      rid,
@@ -2573,6 +2573,7 @@ export async function buildAgentRuntime(
       }
       callbacks.onToolCall?.(call, phase, result);
     },
+    onToolActivity: callbacks.onToolActivity,
     onCompression: callbacks.onCompression,
     onBudgetWarning: callbacks.onBudgetWarning,
     onPlannerGuardDecision: callbacks.onPlannerGuardDecision,

--- a/cli/v4/callbacks.ts
+++ b/cli/v4/callbacks.ts
@@ -30,7 +30,12 @@ import type { SkillProposal } from '../../moat/skillTeacher';
 import type { PlannerGuardDecision } from '../../moat/plannerGuard';
 import type { CompressionResult } from '../../core/v4/contextCompressor';
 import type { AuxiliaryClient } from '../../core/v4/auxiliaryClient';
-import type { ToolCallRequest, ToolCallResult, CapabilityCardData } from '../../providers/v4/types';
+import type {
+  ToolActivityUpdate,
+  ToolCallRequest,
+  ToolCallResult,
+  CapabilityCardData,
+} from '../../providers/v4/types';
 // v4.3 Phase 3 — manual-blocker surface. The BlockerSurface type
 // lives in tools/v4/browser/browserBlocker.ts; we import the type
 // here for the renderer + the structural mapping helper below.
@@ -453,14 +458,19 @@ export class CliCallbacks {
     };
 
     let settled: boolean;
+    const timing = result?.activityTiming;
+    const terminal = timing?.terminalClassification;
     if (typeof err === 'string' && err.includes('URL provenance gate')) {
-      settled = this.activities.settle(call.id, { state: 'blocked' });
+      settled = this.activities.settle(call.id, { state: 'blocked', timing });
+    } else if (terminal === 'cancelled') {
+      settled = this.activities.settle(call.id, { state: 'cancelled', timing });
     } else if (err) {
-      settled = this.activities.settle(call.id, { state: 'failed' });
+      settled = this.activities.settle(call.id, { state: 'failed', timing });
     } else if (result?.degraded) {
       settled = this.activities.settle(call.id, {
         state: 'degraded',
         reason: result.degradedReason,
+        timing,
       });
     } else {
       const payload = result?.result;
@@ -469,8 +479,8 @@ export class CliCallbacks {
         : undefined;
       const dismiss = call.name === 'clarify' || call.name === 'plan_approval';
       settled = status === 'cancelled'
-        ? this.activities.settle(call.id, { state: 'cancelled', dismiss })
-        : this.activities.settle(call.id, { state: 'completed', dismiss });
+        ? this.activities.settle(call.id, { state: 'cancelled', dismiss, timing })
+        : this.activities.settle(call.id, { state: 'completed', dismiss, timing });
     }
 
     // Duplicate and stale terminal callbacks cannot repaint or re-arm rows.
@@ -483,6 +493,10 @@ export class CliCallbacks {
       }
     }
     fireAfter();
+  };
+
+  onToolActivity = (call: ToolCallRequest, update: ToolActivityUpdate): void => {
+    this.activities.observe(call.id, update);
   };
 
   /**

--- a/cli/v4/display.ts
+++ b/cli/v4/display.ts
@@ -51,6 +51,7 @@ import { buildToolPreview } from './toolPreview';
 import { renderComposerBuffer } from './composerRow';
 import { ComposerLane, composerLaneEnabled, type LaneSink } from './composerLane';
 import { turnIdleDiagnostic } from './turnIdleDiagnostics';
+import type { ActivitySnapshot } from './activityRegistry';
 // v4.1.4 reply-quality polish: shared frame math for width + indent.
 // `cols()`, `rule()`, `agentTurn`, and `tryRerenderInPlace` all route
 // through frame helpers so the visible left edge / right margin / wrap
@@ -94,8 +95,8 @@ export interface SpinnerHandle {
  */
 export interface ActivityIndicatorHandle {
   /**
-   * Stop ticking and erase the indicator line. State preserved so a
-   * later `resume(verb?)` continues from the same elapsed counter.
+   * Stop ticking and erase the indicator line. Resuming the same verb keeps
+   * its phase clock; resuming with a new verb starts a new phase clock.
    * Idempotent.
    */
   pause(): void;
@@ -1144,10 +1145,8 @@ export class Display {
    *
    * Pause/resume semantics:
    *   - `pause()` erases the line + stops the tick + sets paused=true.
-   *     Elapsed time keeps accumulating wall-clock — when a later
-   *     `resume()` re-renders, the indicator shows the TOTAL elapsed
-   *     since the original `activityIndicator()` call, not just since
-   *     the last resume.
+   *     Resuming the same phase preserves its elapsed time; supplying a new
+   *     verb resets the phase clock so hidden tool time is not provider time.
    *   - `resume(verb?)` re-renders on a fresh line below the current
    *     cursor and restarts the tick. Optional `verb` swap is the
    *     supported way to transition phases ("thinking" → "drafting").
@@ -1185,7 +1184,7 @@ export class Display {
     const sk     = this.skin;
     const out    = this.out;
     const isTty  = !!out.isTTY;
-    const startTime = Date.now();
+    let phaseStartedAt = Date.now();
 
     let verb        = initialVerb;
     let dotFrame    = 0;
@@ -1275,7 +1274,7 @@ export class Display {
 
     const buildLine = (): string => {
       const dots = '.'.repeat(dotFrame); // 0..3 dots
-      const elapsedSec = Math.floor((Date.now() - startTime) / 1000);
+      const elapsedSec = Math.floor((Date.now() - phaseStartedAt) / 1000);
       const elapsedStr = elapsedSec >= 1
         ? ` ${sk.applyColors(`(${elapsedSec}s)`, 'muted')}`
         : '';
@@ -1408,7 +1407,10 @@ export class Display {
       },
       resume: (newVerb?: string) => {
         if (stopped) return;
-        if (typeof newVerb === 'string' && newVerb.length > 0) verb = newVerb;
+        if (typeof newVerb === 'string' && newVerb.length > 0 && newVerb !== verb) {
+          verb = newVerb;
+          phaseStartedAt = Date.now();
+        }
         if (!paused) return;
         paused = false;
         if (!isTty) return;
@@ -1431,7 +1433,10 @@ export class Display {
         this.setComposerRepaint(paintComposerNow);
       },
       setVerb: (newVerb: string) => {
-        if (typeof newVerb === 'string' && newVerb.length > 0) verb = newVerb;
+        if (typeof newVerb === 'string' && newVerb.length > 0 && newVerb !== verb) {
+          verb = newVerb;
+          phaseStartedAt = Date.now();
+        }
       },
       stop: () => {
         if (stopped) return;
@@ -1470,7 +1475,7 @@ export class Display {
   // completion so each line in the log carries the final state — no
   // ANSI cursor games on a dumb sink.
 
-  toolRow(name: string, args: unknown): ToolRowHandle {
+  toolRow(name: string, args: unknown, readActivity?: () => ActivitySnapshot): ToolRowHandle {
     // v4.1.5 Phase 1d (Q-Q2-a) — TRAIL_HIDE_TOOLS suppression.
     //
     // Some tools are pure agent plumbing — the model calls them to
@@ -1516,11 +1521,9 @@ export class Display {
     const mapped = buildToolPreview(name, args);
     const detail = truncDetail(mapped ?? previewToolArgs(args));
 
-    // v4.1.3-essentials: live tool indicator. Capture wall-clock start
-    // so the running-row renderer can append an elapsed-time suffix
-    // ("running 3s…") after the first second. Sub-second tools render
-    // without the suffix — no flash of `running 0s` for fast paths.
-    const startedAt = Date.now();
+    // Semantic elapsed time comes from ActivityRegistry. A compatibility row
+    // without a source advances only on its own repaint ticks.
+    let fallbackPhaseElapsedMs = 0;
 
     // Running row — muted pipe, raw icon, tool-colored verb, muted detail.
     // The optional `running Ns…` tail appears once the tool crosses the
@@ -1533,9 +1536,15 @@ export class Display {
     // by the emoji's right cell. Two spaces guarantees one visible gap
     // regardless of how the terminal measures the glyph.
     const runningRow = (): string => {
-      const elapsed = Date.now() - startedAt;
+      const snapshot = readActivity?.();
+      const elapsed = snapshot?.phaseElapsedMs ?? fallbackPhaseElapsedMs;
+      const phaseLabel = snapshot?.phase === 'awaiting_approval' ? 'awaiting approval'
+        : snapshot?.phase === 'verifying' ? 'verifying'
+        : snapshot?.phase === 'retrying' ? 'retrying'
+        : snapshot?.phase === 'queued' ? 'queued'
+        : 'running';
       const liveSuffix = elapsed >= 1000
-        ? `  ${sk.applyColors(`running ${formatToolDuration(elapsed)}…`, 'muted')}`
+        ? `  ${sk.applyColors(`${phaseLabel} ${formatToolDuration(elapsed)}…`, 'muted')}`
         : '';
       const prefix = `${sk.applyColors(TRAIL_PIPE, 'muted')} ${glyph}  ` +
         `${sk.applyColors(padVerb(verb), 'tool')} `;
@@ -1551,9 +1560,14 @@ export class Display {
 
     // Outcome row — entire line colored by outcome kind.
     const outcomeRow = (suffix: string, kind: ColorKindForBracket): string => {
-      const content =
-        `${TRAIL_PIPE} ${glyph}  ${padVerb(verb)} ${detail}` +
-        (suffix ? `  ${suffix}` : '');
+      const prefix = `${TRAIL_PIPE} ${glyph}  ${padVerb(verb)} `;
+      const suffixText = suffix ? `  ${suffix}` : '';
+      const availableDetail = terminalRowWidth === null
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, terminalRowWidth - visibleLength(prefix) - visibleLength(suffixText));
+      const content = `${prefix}${availableDetail === Number.POSITIVE_INFINITY
+        ? detail
+        : truncateVisible(detail, availableDetail)}${suffixText}`;
       return `${sk.applyColors(content, kind)}\n`;
     };
 
@@ -1659,6 +1673,7 @@ export class Display {
       // busy hint in its lane: composer content never bleeds into tool rows.
       repaintRunning = (): void => {
         if (printed && !pausedRow && this.composerRepaintIs(repaintRunning!)) {
+          if (!readActivity) fallbackPhaseElapsedMs += 1000;
           turnIdleDiagnostic('activity.row.timer', { name });
           replaceLast(runningRow());
         }
@@ -1674,6 +1689,44 @@ export class Display {
     // with the final state; live updates would be noise in scrollback.
 
     return {
+      refresh() {
+        if (settled || pausedRow || !isTty) return;
+        replaceLast(runningRow());
+      },
+      finish(snapshot: ActivitySnapshot) {
+        if (!beginSettle()) return;
+        const waited = snapshot.approvalWaitMs >= 1_000
+          ? ` · waited ${formatToolDuration(snapshot.approvalWaitMs)}`
+          : '';
+        const attempts = snapshot.attemptCount > 1 ? ` · ${snapshot.attemptCount} attempts` : '';
+        const backoff = snapshot.retryBackoffMs >= 1_000
+          ? ` · backoff ${formatToolDuration(snapshot.retryBackoffMs)}`
+          : '';
+        const execution = formatToolDuration(snapshot.executionDurationMs);
+        switch (snapshot.terminalClassification) {
+          case 'denied':
+            writeFinal(`denied${waited}`, 'warn');
+            break;
+          case 'cancelled':
+            writeFinal(snapshot.executionDurationMs > 0 ? `cancelled after ${execution}` : `cancelled${waited}`, 'muted');
+            break;
+          case 'timed_out':
+            writeFinal(snapshot.executionDurationMs > 0 ? `timed out after ${execution}` : `timed out${waited}`, 'error');
+            break;
+          case 'blocked':
+            writeFinal('blocked', 'warn');
+            break;
+          case 'failed':
+            writeFinal(snapshot.executionDurationMs > 0 ? `fail ${execution}${attempts}${waited}${backoff}` : `failed${waited}`, 'error');
+            break;
+          case 'degraded':
+            writeFinal(`partial ${execution}${waited}`, 'degraded');
+            break;
+          default:
+            writeFinal(`done ${execution}${attempts}${waited}${backoff}`, 'muted');
+            break;
+        }
+      },
       ok(durationMs: number, retries = 0) {
         if (!beginSettle()) return;
         stopTick();
@@ -2868,6 +2921,8 @@ export const TRAIL_HIDE_TOOLS: Set<string> = new Set([
  */
 export function makeNoOpToolRowHandle(): ToolRowHandle {
   return {
+    refresh:    () => { /* no-op: hidden from trail */ },
+    finish:     () => { /* no-op: hidden from trail */ },
     ok:         () => { /* no-op: hidden from trail */ },
     fail:       () => { /* no-op: hidden from trail */ },
     degraded:   () => { /* no-op: hidden from trail */ },
@@ -2896,19 +2951,21 @@ type ColorKindForBracket = 'success' | 'warn' | 'error' | 'degraded' | 'muted';
  * would double-print.
  */
 export interface ToolRowHandle {
-  ok(durationMs: number, retries?: number): void;
-  fail(durationMs: number, retries?: number): void;
+  refresh?(): void;
+  finish?(snapshot: ActivitySnapshot): void;
+  ok(durationMs: number, retries?: number, summary?: ActivitySnapshot): void;
+  fail(durationMs: number, retries?: number, summary?: ActivitySnapshot): void;
   /**
    * v4.1.3-repl-polish — tool completed but with a degraded / best-effort
    * result (e.g. recall_session returned cached data, app_launch fell back
    * to CLI). Row persists in degraded yellow.
    */
-  degraded(durationMs: number, reason?: string): void;
+  degraded(durationMs: number, reason?: string, summary?: ActivitySnapshot): void;
   retry(n: number, m: number): void;
   blocked(): void;
   emptyRetry(): void;
   emptyFail(): void;
-  cancel(durationMs: number): void;
+  cancel(durationMs: number, summary?: ActivitySnapshot): void;
   dismiss(): void;
   pause(): void;
   resume(): void;

--- a/core/v4/aidenAgent.ts
+++ b/core/v4/aidenAgent.ts
@@ -45,6 +45,8 @@ import type {
   ToolSchema,
   ToolCallRequest,
   ToolCallResult,
+  ToolActivityTiming,
+  ToolActivityUpdate,
   ProviderAdapter,
   ProviderCallOutput,
 } from '../../providers/v4/types';
@@ -157,7 +159,87 @@ import { preArmIntent } from './agent/intentPreArm';
  * The loop catches throws defensively so a buggy executor still keeps
  * the conversation alive.
  */
-export type ToolExecutor = (call: ToolCallRequest, signal?: AbortSignal) => Promise<ToolCallResult>;
+export type ToolExecutor = (
+  call: ToolCallRequest,
+  signal?: AbortSignal,
+  onActivity?: (update: ToolActivityUpdate) => void,
+) => Promise<ToolCallResult>;
+
+async function invokeToolWithTiming(
+  executor: ToolExecutor,
+  call: ToolCallRequest,
+  signal: AbortSignal | undefined,
+  onActivity: ((update: ToolActivityUpdate) => void) | undefined,
+): Promise<ToolCallResult> {
+  const startedAt = Date.now();
+  let result: ToolCallResult;
+  try {
+    result = await executor(call, signal, onActivity);
+  } catch (error) {
+    result = {
+      id: call.id,
+      name: call.name,
+      result: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (result.activityTiming) return result;
+  const endedAt = Date.now();
+  const terminalClassification = signal?.aborted
+    ? 'cancelled'
+    : result.error
+      ? (/timed?\s*out|timeout/i.test(result.error) ? 'timed_out' : 'failed')
+      : result.degraded ? 'degraded' : 'completed';
+  return {
+    ...result,
+    activityTiming: {
+      dispatchStartedAt: startedAt,
+      dispatchEndedAt: endedAt,
+      executionAttempts: [{
+        attempt: 1,
+        startedAt,
+        endedAt,
+        terminalResult: terminalClassification,
+      }],
+      executionDurationMs: Math.max(0, endedAt - startedAt),
+      approvalWaitMs: 0,
+      attemptCount: 1,
+      terminalClassification,
+    },
+  };
+}
+
+function mergeActivityTiming(
+  target: ToolActivityTiming | undefined,
+  source: ToolActivityTiming | undefined,
+): ToolActivityTiming | undefined {
+  if (!source) return target;
+  if (!target) {
+    return {
+      ...source,
+      executionAttempts: source.executionAttempts.map((attempt, index) => ({ ...attempt, attempt: index + 1 })),
+    };
+  }
+  const offset = target.executionAttempts.length;
+  const executionAttempts = [
+    ...target.executionAttempts,
+    ...source.executionAttempts.map((attempt, index) => ({ ...attempt, attempt: offset + index + 1 })),
+  ];
+  return {
+    ...target,
+    dispatchStartedAt: Math.min(target.dispatchStartedAt, source.dispatchStartedAt),
+    dispatchEndedAt: source.dispatchEndedAt ?? target.dispatchEndedAt,
+    approvalStartedAt: target.approvalStartedAt ?? source.approvalStartedAt,
+    approvalEndedAt: source.approvalEndedAt ?? target.approvalEndedAt,
+    approvalWaitMs: (target.approvalWaitMs ?? 0) + (source.approvalWaitMs ?? 0),
+    executionAttempts,
+    executionDurationMs: (target.executionDurationMs ?? 0) + (source.executionDurationMs ?? 0),
+    verificationDurationMs: (target.verificationDurationMs ?? 0) + (source.verificationDurationMs ?? 0),
+    retryBackoffMs: (target.retryBackoffMs ?? 0) + (source.retryBackoffMs ?? 0),
+    attemptCount: executionAttempts.length,
+    terminalClassification: source.terminalClassification ?? target.terminalClassification,
+  };
+}
 
 /**
  * Phase v4.1.2 alive-core: identity / memory files that can flip the
@@ -235,6 +317,8 @@ export interface AidenAgentOptions {
     phase:   'before' | 'after',
     result?: ToolCallResult,
   ) => void;
+  /** Optional live phase observer. It is observational and may be omitted. */
+  onToolActivity?: (call: ToolCallRequest, update: ToolActivityUpdate) => void;
   /**
    * Fires once at caution and once at warning. `kind` distinguishes the
    * iteration budget (turn/maxTurns) from the v4.12 BE.1 token budget
@@ -514,6 +598,7 @@ export class AidenAgent {
   private readonly modelMetadata = new ModelMetadata();
   private readonly fallback?:                   FallbackStrategy;
   private readonly onToolCall?:                 AidenAgentOptions['onToolCall'];
+  private readonly onToolActivity?:             AidenAgentOptions['onToolActivity'];
   private readonly onBudgetWarning?:            AidenAgentOptions['onBudgetWarning'];
   private readonly plannerGuard?:               PlannerGuard;
   private readonly onPlannerGuardDecision?:     AidenAgentOptions['onPlannerGuardDecision'];
@@ -615,6 +700,7 @@ export class AidenAgent {
     this.sessionTokenCap          = opts.sessionTokenCap;
     this.fallback                 = opts.fallback;
     this.onToolCall               = opts.onToolCall;
+    this.onToolActivity           = opts.onToolActivity;
     this.onBudgetWarning          = opts.onBudgetWarning;
     this.plannerGuard             = opts.plannerGuard;
     this.onPlannerGuardDecision   = opts.onPlannerGuardDecision;
@@ -1602,14 +1688,14 @@ export class AidenAgent {
           // its existing timing instrumentation can still observe it.
           if (batch.length > 1) {
             const batchResults = await Promise.all(
-              batch.map((c) =>
-                this.toolExecutor(c, this._currentSignal).catch((err: unknown): ToolCallResult => ({
-                  id:     c.id,
-                  name:   c.name,
-                  result: null,
-                  error:  err instanceof Error ? err.message : String(err),
-                })),
-              ),
+              batch.map((c) => invokeToolWithTiming(
+                this.toolExecutor,
+                c,
+                this._currentSignal,
+                (update) => {
+                  try { this.onToolActivity?.(c, update); } catch { /* observational */ }
+                },
+              )),
             );
             for (let k = 0; k < batch.length; k += 1) {
               preComputedResults.set(batch[k].id, batchResults[k]);
@@ -1718,6 +1804,7 @@ export class AidenAgent {
         let finalPolicyDecision: RecoveryActionDecision | null = null;
         let preRecordedRecovery: RecoveryDecision | null = null;
         let attemptNo = 0;
+        let aggregateTiming: ToolActivityTiming | undefined;
         let afterFired = false;
         try {
           for (;;) {
@@ -1736,27 +1823,27 @@ export class AidenAgent {
             } else if (attemptNo === 1 && _preComputed) {
               result = _preComputed;
             } else {
-              try {
-                p2aDiag('tool.executor.start', {
-                  iteration: turnCount, callId: call.id, tool: call.name,
-                  attempt: attemptNo, aborted: this._currentSignal?.aborted === true,
-                  pendingPromise: 'toolExecutor',
-                });
-                result = await this.toolExecutor(call, this._currentSignal);
-                p2aDiag('tool.executor.complete', {
-                  iteration: turnCount, callId: call.id, tool: call.name,
-                  attempt: attemptNo, hasError: result.error != null,
-                  aborted: this._currentSignal?.aborted === true,
-                });
-              } catch (err) {
-                result = {
-                  id:     call.id,
-                  name:   call.name,
-                  result: null,
-                  error:  err instanceof Error ? err.message : String(err),
-                };
-              }
+              p2aDiag('tool.executor.start', {
+                iteration: turnCount, callId: call.id, tool: call.name,
+                attempt: attemptNo, aborted: this._currentSignal?.aborted === true,
+                pendingPromise: 'toolExecutor',
+              });
+              result = await invokeToolWithTiming(
+                this.toolExecutor,
+                call,
+                this._currentSignal,
+                (update) => {
+                  try { this.onToolActivity?.(call, update); } catch { /* observational */ }
+                },
+              );
+              p2aDiag('tool.executor.complete', {
+                iteration: turnCount, callId: call.id, tool: call.name,
+                attempt: attemptNo, hasError: result.error != null,
+                aborted: this._currentSignal?.aborted === true,
+              });
             }
+            aggregateTiming = mergeActivityTiming(aggregateTiming, result.activityTiming);
+            if (aggregateTiming) result.activityTiming = aggregateTiming;
             if (_perfDiag) {
               const toolMs = Date.now() - _toolStartedAt;
               const ok = result.error == null;
@@ -1769,6 +1856,15 @@ export class AidenAgent {
             // per-tool verification ALWAYS (pure/synchronous) so the
             // post-loop honesty footer reflects real outcomes independent
             // of whether TCE/recovery is active.
+            const verificationStartedAt = Date.now();
+            if (aggregateTiming) {
+              aggregateTiming.verificationStartedAt = verificationStartedAt;
+              try {
+                this.onToolActivity?.(call, {
+                  phase: 'verifying', at: verificationStartedAt, attempt: attemptNo, timing: aggregateTiming,
+                });
+              } catch { /* observational */ }
+            }
             try {
               verification = verifierRegistry.resolve(call.name)(
                 call.name, call.arguments, result,
@@ -1776,6 +1872,14 @@ export class AidenAgent {
             } catch {
               // Defensive — a buggy verifier never breaks the agent loop.
               verification = undefined;
+            }
+            const verificationEndedAt = Date.now();
+            if (aggregateTiming) {
+              aggregateTiming.verificationEndedAt = verificationEndedAt;
+              aggregateTiming.verificationDurationMs =
+                (aggregateTiming.verificationDurationMs ?? 0) +
+                Math.max(0, verificationEndedAt - verificationStartedAt);
+              result.activityTiming = aggregateTiming;
             }
             classification = null;
             if (turnState.isEnabled() && verification && !verification.ok) {
@@ -1828,7 +1932,16 @@ export class AidenAgent {
               reason:    classification.reason,
               backoffMs: decision.backoffMs ?? 0,
             });
-            await sleepWithSignal(decision.backoffMs ?? 0, this._currentSignal);
+            const backoffMs = decision.backoffMs ?? 0;
+            if (aggregateTiming) {
+              aggregateTiming.retryBackoffMs = (aggregateTiming.retryBackoffMs ?? 0) + backoffMs;
+              try {
+                this.onToolActivity?.(call, {
+                  phase: 'retrying', at: Date.now(), attempt: attemptNo, timing: aggregateTiming,
+                });
+              } catch { /* observational */ }
+            }
+            await sleepWithSignal(backoffMs, this._currentSignal);
             if (this._currentSignal?.aborted) break;
           }
           toolCallCount += 1;
@@ -1969,6 +2082,34 @@ export class AidenAgent {
           const skillView = extractSkillViewRequiredTools(call.name, result.result);
           if (skillView) {
             trackers.skill.recordSkillView(skillView.skillName, skillView.requiredTools);
+          }
+          if (aggregateTiming) {
+            aggregateTiming.attemptCount = aggregateTiming.executionAttempts.length;
+            aggregateTiming.executionDurationMs = aggregateTiming.executionAttempts.reduce(
+              (total, attemptTiming) => total + Math.max(
+                0,
+                (attemptTiming.endedAt ?? Date.now()) - attemptTiming.startedAt,
+              ),
+              0,
+            );
+            if (this._currentSignal?.aborted) {
+              aggregateTiming.terminalClassification = 'cancelled';
+            } else if (classification?.category === 'timeout' || /timed?\s*out|timeout/i.test(result.error ?? '')) {
+              aggregateTiming.terminalClassification = 'timed_out';
+            } else if (result.error?.includes('denied by approval engine')) {
+              aggregateTiming.terminalClassification = 'denied';
+            } else if (result.degraded) {
+              aggregateTiming.terminalClassification = 'degraded';
+            } else if (verification && !verification.ok) {
+              aggregateTiming.terminalClassification = 'failed';
+            } else if (result.error) {
+              aggregateTiming.terminalClassification = aggregateTiming.terminalClassification === 'blocked'
+                ? 'blocked'
+                : 'failed';
+            } else {
+              aggregateTiming.terminalClassification = 'completed';
+            }
+            result.activityTiming = aggregateTiming;
           }
           this.onToolCall?.(call, 'after', result);
           afterFired = true;

--- a/core/v4/toolRegistry.ts
+++ b/core/v4/toolRegistry.ts
@@ -32,6 +32,9 @@ import type {
   ToolSchema,
   ToolCallRequest,
   ToolCallResult,
+  ToolActivityTiming,
+  ToolActivityUpdate,
+  ToolTerminalClassification,
 } from '../../providers/v4/types';
 // v4.11 perf — wire the legacy v3 responseCache into the v4 hot path.
 // Cache is keyed by (tool name, arguments hash); has its own per-tool
@@ -403,16 +406,54 @@ export class ToolRegistry {
    */
   buildExecutor(
     context: ToolContext,
-  ): (call: ToolCallRequest, signal?: AbortSignal) => Promise<ToolCallResult> {
-    return async (call: ToolCallRequest, signal?: AbortSignal): Promise<ToolCallResult> => {
+  ): (
+    call: ToolCallRequest,
+    signal?: AbortSignal,
+    onActivity?: (update: ToolActivityUpdate) => void,
+  ) => Promise<ToolCallResult> {
+    return async (
+      call: ToolCallRequest,
+      signal?: AbortSignal,
+      onActivity?: (update: ToolActivityUpdate) => void,
+    ): Promise<ToolCallResult> => {
+      const timing: ToolActivityTiming = {
+        dispatchStartedAt: Date.now(),
+        executionAttempts: [],
+      };
+      const emit = (phase: ToolActivityUpdate['phase'], attempt?: number): void => {
+        try { onActivity?.({ phase, at: Date.now(), attempt, timing }); } catch { /* observational */ }
+      };
+      const finish = (
+        result: ToolCallResult,
+        terminalClassification: ToolTerminalClassification,
+      ): ToolCallResult => {
+        timing.dispatchEndedAt = Date.now();
+        timing.attemptCount = timing.executionAttempts.length;
+        timing.approvalWaitMs = timing.approvalStartedAt !== undefined && timing.approvalEndedAt !== undefined
+          ? Math.max(0, timing.approvalEndedAt - timing.approvalStartedAt)
+          : 0;
+        timing.executionDurationMs = timing.executionAttempts.reduce(
+          (total, attemptTiming) => total + Math.max(0, (attemptTiming.endedAt ?? timing.dispatchEndedAt!) - attemptTiming.startedAt),
+          0,
+        );
+        timing.terminalClassification = terminalClassification;
+        emit('terminal');
+        Object.defineProperty(result, 'activityTiming', {
+          value: timing,
+          writable: true,
+          configurable: true,
+          enumerable: false,
+        });
+        return result;
+      };
       const handler = this.handlers.get(call.name);
       if (!handler) {
-        return {
+        return finish({
           id: call.id,
           name: call.name,
           result: null,
           error: `Tool "${call.name}" is not registered`,
-        };
+        }, 'failed');
       }
 
       const args = call.arguments ?? {};
@@ -425,12 +466,12 @@ export class ToolRegistry {
       // it. Never guesses a repair.
       const argShapeError = validateToolArgs(handler.schema.inputSchema, args);
       if (argShapeError) {
-        return {
+        return finish({
           id: call.id,
           name: call.name,
           result: null,
           error: `Invalid arguments for ${call.name}: ${argShapeError}`,
-        };
+        }, 'failed');
       }
 
       // ── Gate 1 — approval engine for mutating tools (runs FIRST) ───
@@ -522,19 +563,32 @@ export class ToolRegistry {
           // no extra line (graceful degradation).
           effects:  handler.effects,
         };
-        const allowed = await context.approvalEngine.checkApproval(approvalReq);
+        timing.approvalStartedAt = Date.now();
+        emit('awaiting_approval');
+        let allowed: boolean;
+        try {
+          allowed = await context.approvalEngine.checkApproval(approvalReq);
+        } catch (error) {
+          timing.approvalEndedAt = Date.now();
+          const message = error instanceof Error ? error.message : String(error);
+          const terminal = signal?.aborted
+            ? 'cancelled'
+            : /timed?\s*out|timeout/i.test(message) ? 'timed_out' : 'failed';
+          return finish({ id: call.id, name: call.name, result: null, error: message }, terminal);
+        }
+        timing.approvalEndedAt = Date.now();
         if (!allowed) {
           // Phase 6 — keep the "denied by approval engine" phrase (downstream
           // detectors match it) AND append the honest why + how-to-allow:
           // which gate fired (hard-block / autonomy-floor / manual-deny) and
           // the safe way forward.
           const why = context.approvalEngine.explainDenial(approvalReq);
-          return {
+          return finish({
             id: call.id,
             name: call.name,
             result: null,
             error: `Tool execution denied by approval engine — ${why}`,
-          };
+          }, signal?.aborted ? 'cancelled' : 'denied');
         }
       }
 
@@ -551,12 +605,12 @@ export class ToolRegistry {
         if (url && /^https?:/i.test(url)) {
           const ssrf = await context.ssrfProtection.check(url);
           if (ssrf.blocked) {
-            return {
+            return finish({
               id: call.id,
               name: call.name,
               result: null,
               error: `URL blocked: ${ssrf.reason}`,
-            };
+            }, 'blocked');
           }
         }
       }
@@ -569,12 +623,12 @@ export class ToolRegistry {
           const findings = context.tirithScanner.scanCommand(command);
           const dangerous = findings.find((f) => f.severity === 'dangerous');
           if (dangerous) {
-            return {
+            return finish({
               id: call.id,
               name: call.name,
               result: null,
               error: `Tirith blocked: ${dangerous.description}`,
-            };
+            }, 'blocked');
           }
         }
       }
@@ -592,7 +646,7 @@ export class ToolRegistry {
         // below; we keep the cached envelope shape (no JSON.parse) so
         // the consumer (aidenAgent dispatch) sees the same
         // ToolCallResult shape it would on a fresh run.
-        return { id: call.id, name: call.name, result: _cached };
+        return finish({ id: call.id, name: call.name, result: _cached }, 'completed');
       }
       // v4.9.0 Slice 6 — wrap the handler call in a tool span when the
       // daemon foundation is up AND an ExecutionContext is active. NOOP
@@ -629,6 +683,12 @@ export class ToolRegistry {
       }
 
       let result: unknown;
+      const executionAttempt = {
+        attempt: context.attempt ?? 1,
+        startedAt: Date.now(),
+      } as ToolActivityTiming['executionAttempts'][number];
+      timing.executionAttempts.push(executionAttempt);
+      emit('running', executionAttempt.attempt);
       try {
         const sliced = sliceSpanShim();
         if (sliced && sliced.db && sliced.hasContext()) {
@@ -656,6 +716,8 @@ export class ToolRegistry {
         } else {
           result = await dispatch(args);
         }
+        executionAttempt.endedAt = Date.now();
+        executionAttempt.terminalResult = 'completed';
         const inner = result as
           | { degraded?: unknown; degradedReason?: unknown }
           | null
@@ -707,21 +769,27 @@ export class ToolRegistry {
               .catch(() => { /* post-capture fault → no pair */ });
           } catch { /* synchronous capture fault → no pair; `out` is untouched */ }
         }
-        return out;
+        return finish(out, out.degraded ? 'degraded' : 'completed');
       } catch (err) {
+        executionAttempt.endedAt ??= Date.now();
+        executionAttempt.terminalResult = signal?.aborted ? 'cancelled' : 'failed';
         // v4.9.0 Slice 12a — hook blocks surface as a structured
         // rejection so the model gets the hook's `reason` / `model_message`
         // verbatim instead of a bare exception string.
         if (err instanceof HookBlockedError) {
-          return {
+          return finish({
             id: call.id,
             name: call.name,
             result: null,
             error: err.modelMessage ?? err.message,
-          };
+          }, 'blocked');
         }
         const message = err instanceof Error ? err.message : String(err);
-        return { id: call.id, name: call.name, result: null, error: message };
+        const terminal = signal?.aborted
+          ? 'cancelled'
+          : /timed?\s*out|timeout/i.test(message) ? 'timed_out' : 'failed';
+        executionAttempt.terminalResult = terminal;
+        return finish({ id: call.id, name: call.name, result: null, error: message }, terminal);
       }
     };
   }

--- a/providers/v4/types.ts
+++ b/providers/v4/types.ts
@@ -186,6 +186,61 @@ export interface ToolCallResult {
    * failure paths. Pure data — render is the REPL's concern.
    */
   capabilityCard?: CapabilityCardData;
+  /** Optional observational timing. It never affects execution or policy. */
+  activityTiming?: ToolActivityTiming;
+}
+
+export type ToolActivityPhase =
+  | 'queued'
+  | 'awaiting_approval'
+  | 'running'
+  | 'verifying'
+  | 'retrying'
+  | 'terminal';
+
+export type ToolTerminalClassification =
+  | 'completed'
+  | 'failed'
+  | 'degraded'
+  | 'blocked'
+  | 'denied'
+  | 'cancelled'
+  | 'timed_out';
+
+export interface ToolExecutionAttemptTiming {
+  attempt: number;
+  startedAt: number;
+  endedAt?: number;
+  terminalResult?: ToolTerminalClassification;
+}
+
+/**
+ * Observational timing carried beside a tool result. All fields are optional
+ * except the dispatch boundary and attempt list so compatibility executors can
+ * progressively populate only the boundaries they own.
+ */
+export interface ToolActivityTiming {
+  dispatchStartedAt: number;
+  dispatchEndedAt?: number;
+  approvalStartedAt?: number;
+  approvalEndedAt?: number;
+  approvalWaitMs?: number;
+  executionAttempts: ToolExecutionAttemptTiming[];
+  verificationStartedAt?: number;
+  verificationEndedAt?: number;
+  verificationDurationMs?: number;
+  executionDurationMs?: number;
+  retryBackoffMs?: number;
+  attemptCount?: number;
+  terminalClassification?: ToolTerminalClassification;
+}
+
+/** A phase notification for live presentation; observational only. */
+export interface ToolActivityUpdate {
+  phase: ToolActivityPhase;
+  at: number;
+  attempt?: number;
+  timing?: ToolActivityTiming;
 }
 
 /**

--- a/tests/v4/cli/activityIndicator.test.ts
+++ b/tests/v4/cli/activityIndicator.test.ts
@@ -16,7 +16,7 @@
  *   - Non-TTY: completely silent — no paint, no ticks, no erases.
  *   - pause(): erases line, stops tick; resume() re-paints + restarts.
  *   - stop(): terminal — refuses further pause/resume.
- *   - Elapsed time is wall-clock cumulative; preserved across pauses.
+ *   - Elapsed time belongs to the current provider phase and resets on a new verb.
  *   - "▸▸ Ctrl+C cancel" hint folded into the line.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -195,7 +195,7 @@ describe('Display.activityIndicator (v4.1.4 Part 1.6)', () => {
     expect(chunks.length).toBe(0);
   });
 
-  it('pause() then resume() preserves cumulative elapsed time', () => {
+  it('pause() then resume() with a new provider phase resets elapsed time', () => {
     let now = 1_000_000_000_000;
     nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
     const { d, chunks } = makeDisplay({ tty: true });
@@ -206,12 +206,13 @@ describe('Display.activityIndicator (v4.1.4 Part 1.6)', () => {
     now += 5000; // 5s pass while paused (would not count toward "running")
     handle.resume('drafting');
     expect(handle.isPaused()).toBe(false);
-    // Tick once to repaint with elapsed time.
+    // Tick once to repaint. The new phase has not reached one second yet.
+    vi.advanceTimersByTime(400);
+    expect(stripAnsi(chunks.join(''))).not.toMatch(/\(7s\)/);
+    now += 1_000;
     vi.advanceTimersByTime(400);
     const full = stripAnsi(chunks.join(''));
-    // Wall-clock since start = 7s. Test asserts the indicator surfaces
-    // total wall-clock, not paused-time-subtracted.
-    expect(full).toMatch(/\(7s\)/);
+    expect(full).toMatch(/\(1s\)/);
     expect(full).toContain('drafting');
     handle.stop();
     nowSpy.mockRestore();

--- a/tests/v4/cli/activityRegistry.test.ts
+++ b/tests/v4/cli/activityRegistry.test.ts
@@ -61,4 +61,48 @@ describe('ActivityRegistry', () => {
     expect(clarify.dismiss).toHaveBeenCalledTimes(1);
     expect(file.ok).toHaveBeenCalledTimes(1);
   });
+
+  it('uses execution attempts instead of lifecycle time for a completed row', () => {
+    let now = 0;
+    const row = handle();
+    const registry = new ActivityRegistry(() => row, () => now);
+    registry.start('timed', 'shell_exec', {});
+    now = 8_000;
+    (registry as unknown as { observe(id: string, update: unknown): void }).observe('timed', {
+      phase: 'awaiting_approval', at: 0,
+    });
+    now = 14_000;
+    registry.settle('timed', {
+      state: 'completed',
+      timing: {
+        dispatchStartedAt: 0,
+        dispatchEndedAt: 14_000,
+        approvalStartedAt: 0,
+        approvalEndedAt: 8_000,
+        executionAttempts: [{ attempt: 1, startedAt: 8_000, endedAt: 14_000, terminalResult: 'completed' }],
+        terminalClassification: 'completed',
+      },
+    } as never);
+
+    expect(row.ok).toHaveBeenCalledWith(6_000, 0, expect.objectContaining({ approvalWaitMs: 8_000 }));
+  });
+
+  it('does not let modal wait advance the running phase clock', async () => {
+    let now = 0;
+    let snapshot: (() => { phase: string; phaseElapsedMs: number }) | undefined;
+    const row = handle();
+    const registry = new ActivityRegistry(((_name, _args, read) => {
+      snapshot = read;
+      return row;
+    }) as never, () => now);
+    registry.start('modal', 'shell_exec', {});
+    (registry as unknown as { observe(id: string, update: unknown): void }).observe('modal', {
+      phase: 'running', at: now, attempt: 1,
+    });
+    now = 1_000;
+    await registry.runModal(async () => { now = 9_000; });
+
+    expect(snapshot?.().phase).toBe('running');
+    expect(snapshot?.().phaseElapsedMs).toBe(1_000);
+  });
 });

--- a/tests/v4/cli/display.test.ts
+++ b/tests/v4/cli/display.test.ts
@@ -12,6 +12,7 @@ import {
   makeNoOpToolRowHandle,
 } from '../../../cli/v4/display';
 import { SkinEngine } from '../../../cli/v4/skinEngine';
+import type { ActivitySnapshot } from '../../../cli/v4/activityRegistry';
 
 // Strip ANSI escape sequences so assertions stay terminal-agnostic.
 function stripAnsi(s: string): string {
@@ -250,7 +251,7 @@ describe('Display Phase 14b helpers', () => {
 //
 // All tests force AIDEN_UI_ICONS=0 so emoji don't sneak into assertions.
 describe('Display v4.1.3-repl-polish toolRow', () => {
-  function captureDisplay(opts: { tty: boolean }) {
+  function captureDisplay(opts: { tty: boolean; columns?: number }) {
     const chunks: string[] = [];
     const out = new Writable({
       write(chunk, _enc, cb) {
@@ -259,6 +260,7 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
       },
     }) as unknown as NodeJS.WriteStream;
     (out as unknown as { isTTY: boolean }).isTTY = opts.tty;
+    if (opts.columns !== undefined) (out as unknown as { columns: number }).columns = opts.columns;
     const skin = new SkinEngine({ forceMono: true });
     const d = new Display({ skin, stdout: out });
     return { d, chunks };
@@ -485,6 +487,59 @@ describe('Display v4.1.3-repl-polish toolRow', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('renders active phases from the registry-owned snapshot', () => {
+    const { d, chunks } = captureDisplay({ tty: true });
+    let snapshot: ActivitySnapshot = {
+      phase: 'awaiting_approval', phaseElapsedMs: 8_000, lifecycleElapsedMs: 8_000,
+      approvalWaitMs: 8_000, executionDurationMs: 0, verificationDurationMs: 0,
+      retryBackoffMs: 0, attemptCount: 0,
+    };
+    const row = d.toolRow('shell_exec', { command: 'echo ok' }, () => snapshot);
+    expect(stripAnsi(chunks.join(''))).toContain('awaiting approval 8.0s');
+    snapshot = { ...snapshot, phase: 'running', phaseElapsedMs: 6_100, executionDurationMs: 6_100, attemptCount: 1 };
+    row.refresh?.();
+    expect(stripAnsi(chunks.at(-1) ?? '')).toContain('running 6.1s');
+    snapshot = { ...snapshot, phase: 'verifying', phaseElapsedMs: 180, verificationDurationMs: 180 };
+    row.refresh?.();
+    expect(stripAnsi(chunks.at(-1) ?? '')).not.toContain('running 6.1s');
+    row.dismiss();
+  });
+
+  it.each([
+    ['completed', 'done 6.1s · waited 8.0s'],
+    ['denied', 'denied · waited 8.0s'],
+    ['cancelled', 'cancelled after 6.1s'],
+    ['timed_out', 'timed out after 6.1s'],
+  ] as const)('renders truthful %s terminal wording', (terminalClassification, expected) => {
+    const { d, chunks } = captureDisplay({ tty: true });
+    const snapshot: ActivitySnapshot = {
+      phase: 'terminal', phaseElapsedMs: 0, lifecycleElapsedMs: 14_100,
+      approvalWaitMs: 8_000,
+      executionDurationMs: terminalClassification === 'denied' ? 0 : 6_100,
+      verificationDurationMs: 100, retryBackoffMs: 0, attemptCount: terminalClassification === 'denied' ? 0 : 1,
+      terminalClassification,
+    };
+    const row = d.toolRow('shell_exec', { command: 'echo ok' }, () => snapshot);
+    chunks.length = 0;
+    row.finish?.(snapshot);
+    expect(stripAnsi(chunks.join(''))).toContain(expected);
+  });
+
+  it('keeps the primary outcome and execution duration at narrow width', () => {
+    const { d, chunks } = captureDisplay({ tty: true, columns: 50 });
+    const snapshot: ActivitySnapshot = {
+      phase: 'terminal', phaseElapsedMs: 0, lifecycleElapsedMs: 14_100,
+      approvalWaitMs: 8_000, executionDurationMs: 6_100, verificationDurationMs: 100,
+      retryBackoffMs: 2_000, attemptCount: 2, terminalClassification: 'completed',
+    };
+    const row = d.toolRow('shell_exec', { command: 'a very long command that cannot fit beside timing' }, () => snapshot);
+    chunks.length = 0;
+    row.finish?.(snapshot);
+    const rendered = stripAnsi(chunks.join(''));
+    expect(rendered).toContain('done 6.1s');
+    expect(rendered.split(/\r?\n/).filter(Boolean).every((line) => line.replace(/\r/g, '').length <= 48)).toBe(true);
   });
 
   it('non-TTY: no live indicator scheduled (no "running …" ever appears)', () => {

--- a/tests/v4/core/aidenAgent.parallel.test.ts
+++ b/tests/v4/core/aidenAgent.parallel.test.ts
@@ -25,6 +25,7 @@ import {
   type ProviderCallInput,
   type ProviderCallOutput,
   type ToolCallRequest,
+  type ToolCallResult,
   type ToolSchema,
 } from '../../../providers/v4/types';
 
@@ -225,6 +226,37 @@ describe('AidenAgent — parallel pure-read tool dispatch (v4.11 perf)', () => {
       (m): m is Extract<Message, { role: 'tool' }> => m.role === 'tool',
     );
     expect(toolMsgs.map((m) => m.toolCallId)).toEqual(['a1', 'a2', 'a3']);
+  });
+
+  it('preserves real precomputed execution timing through ordered callbacks', async () => {
+    const adapter = new ScriptedAdapter([{
+      content: '',
+      toolCalls: [tc('slow', 'web_search'), tc('fast', 'web_search')],
+      usage: { inputTokens: 1, outputTokens: 1 }, finishReason: 'tool_calls',
+    }]);
+    const callbackResults: ToolCallResult[] = [];
+    const exec: ToolExecutor = async (call) => {
+      await new Promise((resolve) => setTimeout(resolve, call.id === 'slow' ? 80 : 25));
+      return { id: call.id, name: call.name, result: 'ok' };
+    };
+    const agent = new AidenAgent({
+      provider: adapter,
+      tools: NO_TOOLS,
+      toolExecutor: exec,
+      onToolCall: (_call, phase, result) => {
+        if (phase === 'after' && result) callbackResults.push(result);
+      },
+    });
+
+    await agent.runConversation([userMsg('time both')]);
+
+    expect(callbackResults.map((result) => result.id)).toEqual(['slow', 'fast']);
+    const durations = callbackResults.map((result) => {
+      const attempt = result.activityTiming?.executionAttempts[0];
+      return attempt && attempt.endedAt !== undefined ? attempt.endedAt - attempt.startedAt : 0;
+    });
+    expect(durations[0]).toBeGreaterThanOrEqual(60);
+    expect(durations[1]).toBeGreaterThanOrEqual(15);
   });
 
   it('solo read-only call does NOT enter parallel batch (live-execution path)', async () => {

--- a/tests/v4/retryPolicy.test.ts
+++ b/tests/v4/retryPolicy.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../core/v4/retryPolicy';
 import { AidenAgent, type ToolExecutor } from '../../core/v4/aidenAgent';
 import { MockProviderAdapter } from '../../core/v4/__mocks__/mockProvider';
-import type { Message, ToolCallRequest, ToolSchema } from '../../providers/v4/types';
+import type { Message, ToolCallRequest, ToolCallResult, ToolSchema } from '../../providers/v4/types';
 import { decideTaskVerdict } from '../../core/v4/taskVerification';
 
 // ── Part 1 — the policy table (pure) ────────────────────────────────────
@@ -160,11 +160,25 @@ describe('agent-loop retry integration', () => {
       MockProviderAdapter.toolUse([tc('1', 'fetch_url', { url: 'http://x' })]),
       MockProviderAdapter.stop('done'),
     ]);
-    const agent = new AidenAgent({ provider, toolExecutor: flakyExecutor, tools: NO_TOOLS });
+    let finalToolResult: ToolCallResult | undefined;
+    const agent = new AidenAgent({
+      provider,
+      toolExecutor: flakyExecutor,
+      tools: NO_TOOLS,
+      onToolCall: (_call, phase, toolResult) => {
+        if (phase === 'after') finalToolResult = toolResult;
+      },
+    });
     const result = await agent.runConversation([userMsg('get it')]);
 
     // ONE model tool call, TWO executor attempts (the retry).
     expect(calls).toBe(2);
+    expect(finalToolResult?.activityTiming?.executionAttempts).toHaveLength(2);
+    expect(finalToolResult?.activityTiming?.attemptCount).toBe(2);
+    expect(finalToolResult?.activityTiming?.retryBackoffMs).toBeGreaterThan(0);
+    expect(finalToolResult?.activityTiming?.executionDurationMs).toBeLessThan(
+      finalToolResult?.activityTiming?.retryBackoffMs ?? 0,
+    );
     const entry = result.toolCallTrace.find((t) => t.name === 'fetch_url')!;
     expect(entry.retries).toBeDefined();
     expect(entry.retries![0].category).toBe('network');

--- a/tests/v4/toolRegistry.test.ts
+++ b/tests/v4/toolRegistry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ApprovalEngine } from '../../moat/approvalEngine';
 
 import {
   ToolRegistry,
@@ -50,6 +51,133 @@ describe('ToolRegistry', () => {
 
   beforeEach(() => {
     registry = new ToolRegistry();
+  });
+
+  it('records approval wait separately from actual handler execution', async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      registry.register(makeHandler('timed-write', {
+        category: 'write',
+        mutates: true,
+        async execute() {
+          now += 6_000;
+          return { ok: true };
+        },
+      }));
+      const approvalEngine = new ApprovalEngine('manual', {
+        promptUser: async () => {
+          now += 8_000;
+          return 'allow';
+        },
+      });
+      const exec = registry.buildExecutor({ ...makeContext(), approvalEngine });
+
+      const result = await exec(call('timed-write'));
+
+      expect(result.activityTiming?.approvalStartedAt).toBe(1_000);
+      expect(result.activityTiming?.approvalEndedAt).toBe(9_000);
+      expect(result.activityTiming?.executionAttempts).toEqual([{
+        attempt: 1,
+        startedAt: 9_000,
+        endedAt: 15_000,
+        terminalResult: 'completed',
+      }]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('records a delayed denial without fabricating handler execution', async () => {
+    let now = 5_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const execute = vi.fn(async () => ({ ok: true }));
+    try {
+      registry.register(makeHandler('denied-write', { category: 'write', mutates: true, execute }));
+      const approvalEngine = new ApprovalEngine('manual', {
+        promptUser: async () => {
+          now += 8_000;
+          return 'deny';
+        },
+      });
+      const exec = registry.buildExecutor({ ...makeContext(), approvalEngine });
+
+      const result = await exec(call('denied-write'));
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(result.activityTiming?.approvalEndedAt! - result.activityTiming?.approvalStartedAt!).toBe(8_000);
+      expect(result.activityTiming?.executionAttempts).toEqual([]);
+      expect(result.activityTiming?.terminalClassification).toBe('denied');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('cancellation during approval records no execution attempt', async () => {
+    const controller = new AbortController();
+    registry.register(makeHandler('cancelled-approval', { category: 'write', mutates: true }));
+    const approvalEngine = new ApprovalEngine('manual', {
+      promptUser: async () => {
+        controller.abort();
+        return 'interrupted';
+      },
+    });
+    const result = await registry.buildExecutor({ ...makeContext(), approvalEngine })(
+      call('cancelled-approval'), controller.signal,
+    );
+    expect(result.activityTiming?.executionAttempts).toEqual([]);
+    expect(result.activityTiming?.terminalClassification).toBe('cancelled');
+  });
+
+  it('cancellation during handler retains elapsed execution once', async () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const controller = new AbortController();
+    try {
+      registry.register(makeHandler('cancelled-run', {
+        async execute() {
+          now = 2_500;
+          controller.abort();
+          throw new Error('interrupted');
+        },
+      }));
+      const result = await registry.buildExecutor(makeContext())(call('cancelled-run'), controller.signal);
+      expect(result.activityTiming?.executionDurationMs).toBe(2_500);
+      expect(result.activityTiming?.executionAttempts).toHaveLength(1);
+      expect(result.activityTiming?.terminalClassification).toBe('cancelled');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('timeout before handler records no execution duration', async () => {
+    registry.register(makeHandler('approval-timeout', { category: 'write', mutates: true }));
+    const approvalEngine = new ApprovalEngine('manual', {
+      promptUser: async () => { throw new Error('approval timed out'); },
+    });
+    const result = await registry.buildExecutor({ ...makeContext(), approvalEngine })(call('approval-timeout'));
+    expect(result.activityTiming?.executionAttempts).toEqual([]);
+    expect(result.activityTiming?.executionDurationMs).toBe(0);
+    expect(result.activityTiming?.terminalClassification).toBe('timed_out');
+  });
+
+  it('timeout during handler retains execution duration and one settlement', async () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      registry.register(makeHandler('handler-timeout', {
+        async execute() {
+          now = 3_000;
+          throw new Error('handler timeout');
+        },
+      }));
+      const result = await registry.buildExecutor(makeContext())(call('handler-timeout'));
+      expect(result.activityTiming?.executionDurationMs).toBe(3_000);
+      expect(result.activityTiming?.executionAttempts).toHaveLength(1);
+      expect(result.activityTiming?.terminalClassification).toBe('timed_out');
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('1. register/get round-trip returns the same handler', () => {


### PR DESCRIPTION
## Summary

- separates approval wait from actual tool execution time;
- reports real handler execution across retries;
- preserves real timing for parallel read-only tools;
- distinguishes denied, cancelled, timed-out, running, verifying, and retrying states;
- makes ActivityRegistry the authoritative activity clock;
- preserves concurrency, provider result order, approval policy, retry behavior,
  input ownership, modal behavior, provider transport, and verifier semantics.

## Validation

- 6,365 tests passed
- 47 skipped
- Typecheck passed
- Production build passed
- Activity timer ConPTY passed
- Built CLI acceptance passed
- Full-runtime input PTY passed
- Physical Windows Terminal smoke passed
