### PR TITLE
fix(providers): align registry modelIds with catalog and add drift guard

### DIFF
--- a/providers/v4/registry.ts
+++ b/providers/v4/registry.ts
@@ -276,6 +276,8 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     docsUrl: 'https://docs.together.ai/',
     supportsToolCalling: true,
     modelIds: [
+      'openai/gpt-oss-120b',
+      'openai/gpt-oss-20b',
       'meta-llama/Llama-3.3-70B-Instruct-Turbo',
       'meta-llama/Llama-3.1-8B-Instruct-Turbo',
       'deepseek-ai/DeepSeek-V3',
@@ -301,7 +303,7 @@ export const PROVIDER_REGISTRY: Record<string, ProviderRegistryEntry> = {
     // flash family per DeepSeek docs; deprecated-but-live). Removal
     // is its own deprecation slice. Per-call thinking + reasoning
     // _effort defaults for v4-pro live in providers/v4/modelDefaults.ts.
-    modelIds: ['deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'],
+    modelIds: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-reasoner'],
   },
   mistral: {
     id: 'mistral',

--- a/tests/v4/providers/registryCatalogDrift.test.ts
+++ b/tests/v4/providers/registryCatalogDrift.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+
+import { PROVIDER_REGISTRY } from '../../../providers/v4/registry';
+import { findModel, listModelsForProvider } from '../../../providers/v4/modelCatalog';
+
+/**
+ * Registry ↔ catalog drift guard.
+ *
+ * PROVIDER_REGISTRY.modelIds is the picker / setup-wizard surface;
+ * MODEL_CATALOG is the model-detail source. Drift between them causes
+ * "model not found" at runtime when the fallback chain or defaults
+ * reference a catalog entry the registry never advertises.
+ */
+describe('registry ↔ catalog drift guard', () => {
+  it('every registry.modelIds entry resolves in MODEL_CATALOG for that provider', () => {
+    const missing: string[] = [];
+
+    for (const [providerId, entry] of Object.entries(PROVIDER_REGISTRY)) {
+      for (const modelId of entry.modelIds) {
+        if (!findModel(providerId, modelId)) {
+          missing.push(`${providerId}:${modelId}`);
+        }
+      }
+    }
+
+    expect(missing, `registry modelIds missing from catalog: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every catalog isDefault model appears in registry.modelIds for that provider', () => {
+    const missing: string[] = [];
+
+    for (const providerId of Object.keys(PROVIDER_REGISTRY)) {
+      const registryIds = new Set(PROVIDER_REGISTRY[providerId].modelIds);
+      const defaults = listModelsForProvider(providerId).filter((m) => m.isDefault);
+
+      for (const model of defaults) {
+        if (!registryIds.has(model.id)) {
+          missing.push(`${providerId}:${model.id} (default)`);
+        }
+      }
+    }
+
+    expect(missing, `catalog defaults missing from registry: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('together registry includes gpt-oss defaults used by fallback chain and setup wizard', () => {
+    const ids = PROVIDER_REGISTRY.together.modelIds;
+    expect(ids).toContain('openai/gpt-oss-120b');
+    expect(ids).toContain('openai/gpt-oss-20b');
+  });
+
+  it('deepseek registry includes deepseek-v4-flash from catalog', () => {
+    const ids = PROVIDER_REGISTRY.deepseek.modelIds;
+    expect(ids).toContain('deepseek-v4-flash');
+    expect(findModel('deepseek', 'deepseek-v4-flash')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add missing Together models (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`) to `PROVIDER_REGISTRY` — these are the catalog defaults used by the fallback chain and setup wizard
- Add missing DeepSeek model (`deepseek-v4-flash`) to the registry list so `/model` and the picker stay aligned with `MODEL_CATALOG`
- Add `registryCatalogDrift.test.ts` to catch future registry ↔ catalog drift (missing catalog entries + missing default models)

## Why
Registry `modelIds` is the picker/setup surface; `MODEL_CATALOG` is the model-detail source. Drift between them causes runtime defaults (e.g. Together `gpt-oss-120b`) to be unavailable in the picker while still referenced by fallback and setup flows.

## Test plan
- [x] `npm test -- tests/v4/providers/registryCatalogDrift.test.ts tests/v4/registry.test.ts tests/v4/modelCatalog.test.ts tests/v4/providers/subscriptionModelIds.test.ts tests/v4/providerFallback.test.ts` (53 passed)
- [x] `npm run typecheck`