### PR TITLE
fix(skills): use lru-cache v10 named export in skillLoader

### DIFF
--- a/core/skillLoader.ts
+++ b/core/skillLoader.ts
@@ -10,10 +10,10 @@ import fs   from 'fs'
 import path from 'path'
 
 // ── LRU cache for on-demand skill content loading ─────────────
-// lru-cache v6 (CommonJS). max = maximum number of items.
+// lru-cache v10 (CommonJS). max = maximum number of items.
 // Full SKILL.md is loaded lazily on first access and evicted when
 // the 50-entry limit is reached (LRU eviction).
-const _LRUClass = require('lru-cache') as { new(opts: { max: number }): { get(k: string): string | undefined; set(k: string, v: string): void; itemCount: number } }
+const { LRUCache: _LRUClass } = require('lru-cache') as { LRUCache: { new(opts: { max: number }): { get(k: string): string | undefined; set(k: string, v: string): void; size: number } } }
 const _contentCache = new _LRUClass({ max: 50 })
 
 /**
@@ -33,7 +33,7 @@ export function getSkillContent(filePath: string): string | null {
 }
 
 export function getSkillCacheStats(): { size: number; max: number } {
-  return { size: _contentCache.itemCount, max: 50 }
+  return { size: _contentCache.size, max: 50 }
 }
 
 // ── Skill injection guard ─────────────────────────────────────


### PR DESCRIPTION
## Problem

On a fresh clone (`npm install && npm run build`), the API server crashes immediately on startup:

```
TypeError: _LRUClass is not a constructor
    at core/skillLoader.ts (dist-bundle/index.js:105310:21)
    at core/agentLoop.ts
```

`core/skillLoader.ts` uses the **lru-cache v6** API — `require('lru-cache')` returning a constructor — and the comment on line 13 says so explicitly. But `package.json` pins `"lru-cache": "^10.0.0"`, and v10 exports a **named** `LRUCache` rather than a default. So `require('lru-cache')` returns `{ LRUCache }`, an object, and `new _LRUClass(...)` throws. It looks like the dependency was bumped without updating this call site.

## Fix

Two changes, both in `core/skillLoader.ts`:

1. Destructure the named `LRUCache` export (and correct the stale `v6` comment).
2. `getSkillCacheStats()`: `.itemCount` → `.size`. v10 renamed the property, so the old name silently returned `undefined` rather than throwing.

## Verification

- `npx tsc --noEmit` — clean, zero errors.
- API server (`node dist-bundle/index.js serve`) now boots and serves `/api/health` → `{"status":"ok","version":"4.15.0"}`.
- Functional check of the cache path: read caches and returns an identical hit, `getSkillCacheStats()` correctly reports `{size: 1, max: 50}` (previously `undefined`), and an unreadable path still returns `null`.
- `npm run test:audit` per CONTRIBUTING: **38 failed / 215 passed → 14 failed / 247 passed**. I confirmed the remaining 14 are pre-existing by stashing this change and re-running on a clean tree — they're unrelated config/provider checks (`together-deepseek` entry absent, `VERSION` constant, custom-provider branch) that fail on an unconfigured environment.

Repro'd on Windows 11, Node v24.14.0, clean clone of `main` @ `ce52e719`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
